### PR TITLE
Remove DISABLE_REGISTRATION env variable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,6 @@ APP_DATABASE_PATH       # SQLite database path
 APP_FILES_DIR           # File storage directory
 SMTP_HOST/PORT/USER/PASS # Email configuration
 PAGESPEED_API_KEY       # Google PageSpeed API
-DISABLE_REGISTRATION    # Disable new signups
 FRONTEND_URL            # Frontend URL for emails
 SENTRY_DSN              # Error tracking
 ```
@@ -127,7 +126,6 @@ SENTRY_DSN              # Error tracking
 ### Frontend Environment
 ```bash
 SHOPMON_API_URL         # API URL (defaults to production)
-VITE_DISABLE_REGISTRATION # Hide registration UI
 ```
 
 ## Deployment

--- a/README.md
+++ b/README.md
@@ -79,7 +79,6 @@ PAGESPEED_API_KEY=your-google-pagespeed-api-key
 
 # Application
 FRONTEND_URL=http://localhost:5173
-DISABLE_REGISTRATION=false
 APP_FILES_DIR=./files
 
 # Monitoring (optional)
@@ -124,20 +123,6 @@ PAGESPEED_API_KEY=your-api-key-here
 ```
 
 ## Configuration
-
-### Disable registration
-
-To disable user registrations:
-
-1. In your `api/.env` file:
-```env
-DISABLE_REGISTRATION=true
-```
-
-2. For the frontend, create a `frontend/.env` file:
-```env
-VITE_DISABLE_REGISTRATION=1
-```
 
 ### Production Deployment
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -14,7 +14,6 @@ PAGESPEED_API_KEY=
 
 # Application
 FRONTEND_URL=http://localhost:5173
-DISABLE_REGISTRATION=false
 APP_FILES_DIR=./files
 
 # Monitoring (optional)

--- a/api/src/types/env.d.ts
+++ b/api/src/types/env.d.ts
@@ -20,7 +20,6 @@ declare global {
 
             // Application
             FRONTEND_URL?: string;
-            DISABLE_REGISTRATION?: string;
             APP_FILES_DIR?: string;
 
             // Monitoring (optional)

--- a/frontend/src/env.d.ts
+++ b/frontend/src/env.d.ts
@@ -2,5 +2,4 @@
 
 interface ImportMetaEnv {
     readonly VITE_API_URL: string;
-    readonly VITE_DISABLE_REGISTRATION: boolean;
 }

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -149,13 +149,6 @@ router.beforeEach(async (to: RouteLocationNormalized) => {
     const authRequired = !publicPages.includes(to.name as string);
     const { setReturnUrl } = useReturnUrl();
 
-    if (
-        import.meta.env.VITE_DISABLE_REGISTRATION &&
-        (to.name as string) === 'account.register'
-    ) {
-        return { name: 'home' };
-    }
-
     if (authRequired && !session.value.data) {
         setReturnUrl(to.fullPath);
         return { name: 'account.login' };

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="login-header">
         <h2>Sign in to your account</h2>
-        <p v-if="!disableRegistration">
+        <p>
             New to Shopmon?
             {{ ' ' }}
             <router-link :to="{ name: 'account.register' }">
@@ -101,8 +101,6 @@ const schema = Yup.object().shape({
     email: Yup.string().required('Email is required').email(),
     password: Yup.string().required('Password is required'),
 });
-
-const disableRegistration = import.meta.env.VITE_DISABLE_REGISTRATION;
 
 async function onSubmit(values: Record<string, unknown>) {
     const email = values.email as string;


### PR DESCRIPTION
## Summary
- remove optional registration toggle from docs and env
- always allow registration in router and login view
- clean up unused env types

## Testing
- `bun run biome:check`


------
https://chatgpt.com/codex/tasks/task_b_683c5e1fae1c8320894f285be2f5ce75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to remove references to disabling user registration via environment variables.

- **Bug Fixes**
  - The registration page and registration link are now always accessible; restrictions based on environment variables have been removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->