### PR TITLE
fix version overflow

### DIFF
--- a/frontend/src/views/account/ListExtensions.vue
+++ b/frontend/src/views/account/ListExtensions.vue
@@ -67,7 +67,7 @@
                             :key="rowIndex"
                             class="shops-row"
                         >
-                            {{ shop.version }}
+                            <span class="extension-version" :data-tooltip="shop.version">{{ shop.version }}</span>
                             <span
                                 v-if="row.latestVersion && shop.version < row.latestVersion"
                                 data-tooltip="Update available"
@@ -138,6 +138,12 @@ function getExtensionState(
         font-weight: normal;
         opacity: .6;
     }
+}
+
+.extension-version {
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .shops-row {


### PR DESCRIPTION
The SwagInsiderPreviews plugin uses a long version number `6.6.0.0-7edb8d52c50e5048540019f06fd35190ba9a6b0e8e375858b2bcf3db38e3037b`. This causes some overflow issues on the extension list. The right side of the table is cut off.

<img width="1306" alt="Shopware Monitoring 2025-06-04 22-11-35" src="https://github.com/user-attachments/assets/d1334d27-8627-4058-b43e-efedbf0880fb" />

This PR add an ellipsis for long version numbers and a tooltip when the version number is too long.