### PR TITLE
clarify email message when updating shop data fails

### DIFF
--- a/api/src/cron/jobs/shopScrape.ts
+++ b/api/src/cron/jobs/shopScrape.ts
@@ -271,12 +271,12 @@ async function updateShop(shop: SQLShop, con: Drizzle) {
             await Shops.alert(con, {
                 key: `shop.update-auth-error.${shop.id}`,
                 shopId: shop.id.toString(),
-                subject: 'Shop Update Error',
-                message: `The Shop could not be updated. Please check your credentials and try again.${error}`,
+                subject: 'Refresh shop data error',
+                message: `The shop data could not be refreshed. Please check your credentials and try again. ${error}`,
             });
 
             logger.info(
-                `Shop ${shop.name} could not be updated, error is ${error}`,
+                `Shop ${shop.name} could not be refreshed, error is ${error}`,
             );
 
             await con


### PR DESCRIPTION
The following email incorrectly suggests that Shopmon is unable to update or upgrade Shopware. The email should make clear that Shopmon is unable to synchronise the shop data.

![image](https://github.com/user-attachments/assets/90f9c281-d55a-4d29-8cc8-0f701e6ff8df)
