### PR TITLE
fix: Sitespeed hast some rows with null values

### DIFF
--- a/api/src/trpc/organization/shop.ts
+++ b/api/src/trpc/organization/shop.ts
@@ -6,7 +6,7 @@ import {
     SimpleShop,
 } from '@shopware-ag/app-server-sdk';
 import { TRPCError } from '@trpc/server';
-import { desc, eq, sql } from 'drizzle-orm';
+import { desc, eq, isNotNull, and, or, sql } from 'drizzle-orm';
 import { z } from 'zod';
 import { scrapeSingleShop } from '../../cron/jobs/shopScrape.ts';
 import { scrapeSingleSitespeedShop } from '../../cron/jobs/sitespeedScrape.ts';
@@ -115,7 +115,17 @@ export const shopRouter = router({
                 .get();
 
             const sitespeedQuery = ctx.drizzle.query.shopSitespeed.findMany({
-                where: eq(schema.shopSitespeed.shopId, input.shopId),
+                where: and(
+                    eq(schema.shopSitespeed.shopId, input.shopId),
+                    or(
+                        isNotNull(schema.shopSitespeed.ttfb),
+                        isNotNull(schema.shopSitespeed.fullyLoaded),
+                        isNotNull(schema.shopSitespeed.largestContentfulPaint),
+                        isNotNull(schema.shopSitespeed.firstContentfulPaint),
+                        isNotNull(schema.shopSitespeed.cumulativeLayoutShift),
+                        isNotNull(schema.shopSitespeed.transferSize)
+                    )
+                ),
                 orderBy: [desc(schema.shopSitespeed.createdAt)],
             });
 


### PR DESCRIPTION
Fixes the problem with null entries in the site speed database

<img width="1118" height="461" alt="Bildschirmfoto 2025-09-07 um 18 48 01" src="https://github.com/user-attachments/assets/6481d9ee-c4fa-404c-bbd0-5a5738afb244" />
