### PR TITLE
Fix dashboard redirect loop when refocusing login

### DIFF
--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -131,13 +131,20 @@ const schema = Yup.object().shape({
 function goToDashboard() {
   const sess = authClient.useSession();
 
-  watch(sess, (user) => {
-    if (user.data?.user) {
+  const stop = watch(
+    sess,
+    async (user) => {
+      if (!user.data?.user) {
+        return;
+      }
+
+      stop();
       const redirectUrl = returnUrl.value ?? "/app/dashboard";
       clearReturnUrl();
-      router.push(redirectUrl);
-    }
-  });
+      await router.push(redirectUrl);
+    },
+    { immediate: true },
+  );
 }
 
 async function onSubmit(values: Record<string, unknown>) {


### PR DESCRIPTION
Summary
- stop watching the session once a user is detected so repeated focus changes do not re-trigger navigation
- ensure we await the router push and respect the return URL before clearing it

Testing
- Not run (not requested)