### PR TITLE
feat: add changelog to changelog

### DIFF
--- a/frontend/src/components/modal/ShopChangelog.vue
+++ b/frontend/src/components/modal/ShopChangelog.vue
@@ -35,6 +35,28 @@
                 {{ extension.old_version }}
               </template>
             </template>
+
+            <ul
+              v-if="extension.state === 'updated' && extension.changelog?.length"
+              class="extension-changelog"
+            >
+              <li
+                v-for="entry in extension.changelog"
+                :key="entry.version"
+                class="extension-changelog-item"
+              >
+                <div class="extension-changelog-title">
+                  {{ entry.version }} -
+                  <span class="extension-changelog-date">
+                    {{ formatDateTime(entry.creationDate) }}
+                  </span>
+                </div>
+
+                <!-- eslint-disable vue/no-v-html -->
+                <div class="extension-changelog-content" v-html="entry.text" />
+                <!-- eslint-enable vue/no-v-html -->
+              </li>
+            </ul>
           </li>
         </ul>
       </div>
@@ -58,6 +80,7 @@ defineEmits<{
 </script>
 
 <style scoped>
+.extension-changelog-date,
 .modal-changelog-title-date {
   font-weight: normal;
   color: var(--text-color-muted);


### PR DESCRIPTION
This pull request enhances the display of extension changelogs in the `ShopChangelog.vue` modal component. The main improvement is the addition of a detailed changelog section for updated extensions, allowing users to view version history and release notes directly in the modal.

**Changelog display improvements:**

* Added a new `<ul>` section that lists changelog entries for extensions with an `updated` state, showing version, date, and rich-text content for each entry.

**Styling enhancements:**

* Introduced the `.extension-changelog-date` CSS class to style changelog dates consistently with other date elements in the modal.

Fixes #529

<img width="1439" height="791" alt="image" src="https://github.com/user-attachments/assets/2da94ae1-cd83-4132-980a-75eea4c00b2e" />
