### PR TITLE
fix: ignore inactive scheduled tasks in overdue checks

### DIFF
--- a/api/src/modules/shop/checker/checks/task.ts
+++ b/api/src/modules/shop/checker/checks/task.ts
@@ -4,7 +4,7 @@ import type { Checker, CheckerInput, CheckerOutput } from "../registery.ts";
 export default class implements Checker {
   async check(input: CheckerInput, result: CheckerOutput): Promise<void> {
     for (const task of input.scheduledTasks) {
-      if (isTaskOverdue(task) && task.interval > 3600) {
+      if (isTaskOverdue(task) && task.interval > 3600 && task.status !== "inactive") {
         result.warning(`task.${task.name}`, `Task ${task.name} is overdue`);
       }
     }

--- a/frontend/src/views/shop/detail/DetailShop.vue
+++ b/frontend/src/views/shop/detail/DetailShop.vue
@@ -393,7 +393,12 @@ const overdueTasks = computed(() => {
   const fifteenMinutesAgo = new Date(Date.now() - 15 * 60 * 1000);
 
   return shop.value.scheduledTask
-    .filter((task) => task.overdue && new Date(task.nextExecutionTime) < fifteenMinutesAgo)
+    .filter(
+      (task) =>
+        task.overdue &&
+        task.status !== "inactive" &&
+        new Date(task.nextExecutionTime) < fifteenMinutesAgo,
+    )
     .slice(0, 5);
 });
 


### PR DESCRIPTION
## Summary
- Skip scheduled tasks with `status === 'inactive'` when checking for overdue tasks
- Fixes false positives in the **Security & Health Checks** panel (backend checker) and the **Scheduled Tasks** overview (frontend)

## Test plan
- [ ] Verify inactive tasks no longer appear as overdue warnings in health checks
- [ ] Verify inactive tasks no longer show in the overdue tasks list on the shop detail page
- [ ] Verify active overdue tasks still surface correctly