### PR TITLE
feat: add shop token for authentication bypass

### DIFF
--- a/api/apply-fixtures.ts
+++ b/api/apply-fixtures.ts
@@ -1,9 +1,9 @@
-import { HttpClient, type HttpClientResponse, SimpleShop } from "@shopware-ag/app-server-sdk";
+import { HttpClient, type HttpClientResponse } from "#src/modules/shop/http-client.ts";
 import { auth } from "#src/auth.ts";
 import { scrapeSingleShop } from "#src/modules/shop/jobs/shop-scrape.job.ts";
 import { encrypt } from "#src/modules/shop/crypto.ts";
 import { closeConnection, getConnection, schema } from "#src/db.ts";
-import shops from "#src/modules/shop/shop.repository.ts";
+import shops, { generateShopToken } from "#src/modules/shop/shop.repository.ts";
 import { eq } from "drizzle-orm";
 
 const user1 = await auth.api.signUpEmail({
@@ -78,13 +78,17 @@ await getConnection().insert(schema.project).values({
   updatedAt: new Date(),
 });
 
-const shop = new SimpleShop("", "http://localhost:3889", "");
-shop.setShopCredentials(
-  "SWIAUZL4OXRKEG1RR3PMCEVNMG",
-  "aXhNQ3NoRHZONmxPYktHT0c2c09rNkR0UHI0elZHOFIycjBzWks",
-);
+const shopUrl = "http://localhost:3889";
+const shopClientId = "SWIAUZL4OXRKEG1RR3PMCEVNMG";
+const shopClientSecret = "aXhNQ3NoRHZONmxPYktHT0c2c09rNkR0UHI0elZHOFIycjBzWks";
+const shopToken = generateShopToken();
 
-const client = new HttpClient(shop);
+const client = new HttpClient({
+  url: shopUrl,
+  clientId: shopClientId,
+  clientSecret: shopClientSecret,
+  shopToken,
+});
 
 const resp: HttpClientResponse<{ version: string }> = await client.get("/_info/config");
 
@@ -92,10 +96,11 @@ const shopId = await shops.createShop(getConnection(), {
   name: "Local",
   organizationId: org.id,
   projectId: 1,
-  shopUrl: shop.getShopUrl(),
-  clientId: shop.getShopClientId(),
-  clientSecret: await encrypt(process.env.APP_SECRET, shop.getShopClientSecret()),
+  shopUrl,
+  clientId: shopClientId,
+  clientSecret: await encrypt(process.env.APP_SECRET, shopClientSecret),
   version: resp.body.version,
+  shopToken,
 });
 
 await scrapeSingleShop(shopId);
@@ -106,7 +111,7 @@ console.log("User 2 (org admin):", user2.user.email);
 console.log("User 3 (org member):", user3.user.email);
 console.log("User 4 (regular user without organization):", user4.user.email);
 console.log("Organization:", org.name);
-console.log("Shop:", shop.getShopUrl());
+console.log("Shop:", shopUrl);
 
 console.log('All users have the password "password".');
 

--- a/api/drizzle/0010_shop_token.sql
+++ b/api/drizzle/0010_shop_token.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "shop" ADD COLUMN "shop_token" text;--> statement-breakpoint
+UPDATE "shop" SET "shop_token" = md5(random()::text || clock_timestamp()::text) || md5(random()::text || clock_timestamp()::text) WHERE "shop_token" IS NULL;--> statement-breakpoint
+ALTER TABLE "shop" ALTER COLUMN "shop_token" SET NOT NULL;

--- a/api/drizzle/meta/0010_snapshot.json
+++ b/api/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1891 @@
+{
+  "id": "29114d53-d53a-4195-9985-979a761fddb2",
+  "prevId": "1c0651a2-e748-4cff-ac06-154c54f62e59",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.deployment": {
+      "name": "deployment",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "return_code": {
+          "name": "return_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "execution_time": {
+          "name": "execution_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "composer": {
+          "name": "composer",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "reference": {
+          "name": "reference",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "deployment_shop_id_shop_id_fk": {
+          "name": "deployment_shop_id_shop_id_fk",
+          "tableFrom": "deployment",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitation": {
+      "name": "invitation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "invitation_organizationId_idx": {
+          "name": "invitation_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invitation_email_idx": {
+          "name": "invitation_email_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": ["inviter_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lock": {
+      "name": "lock",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires": {
+          "name": "expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member": {
+      "name": "member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_organizationId_idx": {
+          "name": "member_organizationId_idx",
+          "columns": [
+            {
+              "expression": "organization_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_userId_idx": {
+          "name": "member_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization": {
+      "name": "organization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": ["slug"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backed_up": {
+          "name": "backed_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_userId_idx": {
+          "name": "passkey_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_credentialID_idx": {
+          "name": "passkey_credentialID_idx",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project": {
+      "name": "project",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_organization_id_organization_id_fk": {
+          "name": "project_organization_id_organization_id_fk",
+          "tableFrom": "project",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_api_key": {
+      "name": "project_api_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_api_key_project_id_project_id_fk": {
+          "name": "project_api_key_project_id_project_id_fk",
+          "tableFrom": "project_api_key",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "project_api_key_token_unique": {
+          "name": "project_api_key_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_organization_id": {
+          "name": "active_organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop": {
+      "name": "shop",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'green'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "favicon": {
+          "name": "favicon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_secret": {
+          "name": "client_secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "shopware_version": {
+          "name": "shopware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_scraped_at": {
+          "name": "last_scraped_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_scraped_error": {
+          "name": "last_scraped_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignores": {
+          "name": "ignores",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "shop_image": {
+          "name": "shop_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_changelog": {
+          "name": "last_changelog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "active_deployment_id": {
+          "name": "active_deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "connection_issue_count": {
+          "name": "connection_issue_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sitespeed_enabled": {
+          "name": "sitespeed_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sitespeed_urls": {
+          "name": "sitespeed_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "shop_token": {
+          "name": "shop_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_organization_id_organization_id_fk": {
+          "name": "shop_organization_id_organization_id_fk",
+          "tableFrom": "shop",
+          "tableTo": "organization",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shop_project_id_project_id_fk": {
+          "name": "shop_project_id_project_id_fk",
+          "tableFrom": "shop",
+          "tableTo": "project",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shop_active_deployment_id_deployment_id_fk": {
+          "name": "shop_active_deployment_id_deployment_id_fk",
+          "tableFrom": "shop",
+          "tableTo": "deployment",
+          "columnsFrom": ["active_deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_cache": {
+      "name": "shop_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "environment": {
+          "name": "environment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "http_cache": {
+          "name": "http_cache",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_adapter": {
+          "name": "cache_adapter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_cache_shop_id_shop_id_fk": {
+          "name": "shop_cache_shop_id_shop_id_fk",
+          "tableFrom": "shop_cache",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shop_cache_shop_id_unique": {
+          "name": "shop_cache_shop_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shop_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_changelog": {
+      "name": "shop_changelog",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extensions": {
+          "name": "extensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "old_shopware_version": {
+          "name": "old_shopware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_shopware_version": {
+          "name": "new_shopware_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_changelog_shop_id_shop_id_fk": {
+          "name": "shop_changelog_shop_id_shop_id_fk",
+          "tableFrom": "shop_changelog",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_check": {
+      "name": "shop_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_check_shop_id_shop_id_fk": {
+          "name": "shop_check_shop_id_shop_id_fk",
+          "tableFrom": "shop_check",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shop_check_shop_id_check_id_unique": {
+          "name": "shop_check_shop_id_check_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shop_id", "check_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_extension": {
+      "name": "shop_extension",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "latest_version": {
+          "name": "latest_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed": {
+          "name": "installed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rating_average": {
+          "name": "rating_average",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_link": {
+          "name": "store_link",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "changelog": {
+          "name": "changelog",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_extension_shop_id_shop_id_fk": {
+          "name": "shop_extension_shop_id_shop_id_fk",
+          "tableFrom": "shop_extension",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shop_extension_shop_id_name_unique": {
+          "name": "shop_extension_shop_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shop_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_queue": {
+      "name": "shop_queue",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_queue_shop_id_shop_id_fk": {
+          "name": "shop_queue_shop_id_shop_id_fk",
+          "tableFrom": "shop_queue",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shop_queue_shop_id_name_unique": {
+          "name": "shop_queue_shop_id_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shop_id", "name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_scheduled_task": {
+      "name": "shop_scheduled_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overdue": {
+          "name": "overdue",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_execution_time": {
+          "name": "last_execution_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_execution_time": {
+          "name": "next_execution_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_scheduled_task_shop_id_shop_id_fk": {
+          "name": "shop_scheduled_task_shop_id_shop_id_fk",
+          "tableFrom": "shop_scheduled_task",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "shop_scheduled_task_shop_id_task_id_unique": {
+          "name": "shop_scheduled_task_shop_id_task_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["shop_id", "task_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.shop_sitespeed": {
+      "name": "shop_sitespeed",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "shop_id": {
+          "name": "shop_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deployment_id": {
+          "name": "deployment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ttfb": {
+          "name": "ttfb",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fully_loaded": {
+          "name": "fully_loaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "largest_contentful_paint": {
+          "name": "largest_contentful_paint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_contentful_paint": {
+          "name": "first_contentful_paint",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cumulative_layout_shift": {
+          "name": "cumulative_layout_shift",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transfer_size": {
+          "name": "transfer_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "shop_sitespeed_shop_id_shop_id_fk": {
+          "name": "shop_sitespeed_shop_id_shop_id_fk",
+          "tableFrom": "shop_sitespeed",
+          "tableTo": "shop",
+          "columnsFrom": ["shop_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "shop_sitespeed_deployment_id_deployment_id_fk": {
+          "name": "shop_sitespeed_deployment_id_deployment_id_fk",
+          "tableFrom": "shop_sitespeed",
+          "tableTo": "deployment",
+          "columnsFrom": ["deployment_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sso_provider": {
+      "name": "sso_provider",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "issuer": {
+          "name": "issuer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oidc_config": {
+          "name": "oidc_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saml_config": {
+          "name": "saml_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sso_provider_user_id_user_id_fk": {
+          "name": "sso_provider_user_id_user_id_fk",
+          "tableFrom": "sso_provider",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sso_provider_provider_id_unique": {
+          "name": "sso_provider_provider_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["provider_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notifications": {
+          "name": "notifications",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification": {
+      "name": "user_notification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "link": {
+          "name": "link",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_user_id_user_id_fk": {
+          "name": "user_notification_user_id_user_id_fk",
+          "tableFrom": "user_notification",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_notification_user_id_key_unique": {
+          "name": "user_notification_user_id_key_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "key"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1772479209040,
       "tag": "0009_sitespeed_deployment_reference",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1773386019706,
+      "tag": "0010_shop_token",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -13,7 +13,6 @@
     "@better-auth/passkey": "catalog:",
     "@better-auth/sso": "catalog:",
     "@sentry/bun": "^10.27.0",
-    "@shopware-ag/app-server-sdk": "^2.0.0",
     "@trpc/server": "^11.7.2",
     "better-auth": "catalog:",
     "drizzle-orm": "^0.45.0",

--- a/api/src/db.ts
+++ b/api/src/db.ts
@@ -68,6 +68,7 @@ export const shop = pgTable("shop", {
   connectionIssueCount: integer("connection_issue_count").default(0).notNull(),
   sitespeedEnabled: boolean("sitespeed_enabled").default(false).notNull(),
   sitespeedUrls: jsonb("sitespeed_urls").default([]).$type<string[]>().notNull(),
+  shopToken: text("shop_token").notNull(),
   createdAt: timestamp("created_at").notNull(),
 });
 

--- a/api/src/modules/shop/checker/registery.ts
+++ b/api/src/modules/shop/checker/registery.ts
@@ -1,4 +1,4 @@
-import type { HttpClient } from "@shopware-ag/app-server-sdk";
+import type { HttpClient } from "#src/modules/shop/http-client.ts";
 import type { CacheInfo, Extension, QueueInfo, ScheduledTask } from "#src/types/index.ts";
 import env from "./checks/env.ts";
 import frosh_tools from "./checks/frosh_tools.ts";

--- a/api/src/modules/shop/http-client.ts
+++ b/api/src/modules/shop/http-client.ts
@@ -1,0 +1,221 @@
+const HEADER_NAME = "shopmon-shop-token";
+
+export class HttpClientResponse<ResponseType> {
+  statusCode: number;
+  body: ResponseType;
+  headers: Headers;
+  constructor(statusCode: number, body: ResponseType, headers: Headers) {
+    this.statusCode = statusCode;
+    this.body = body;
+    this.headers = headers;
+  }
+}
+
+export class ApiClientAuthenticationFailed extends Error {
+  response: HttpClientResponse<string>;
+  constructor(response: HttpClientResponse<string>) {
+    super(
+      `Authentication failed with status ${response.statusCode}: ${JSON.stringify(response.body)}`,
+    );
+    this.response = response;
+  }
+}
+
+export class ApiClientRequestFailed extends Error {
+  response: HttpClientResponse<ShopwareErrorResponse>;
+  constructor(response: HttpClientResponse<ShopwareErrorResponse>) {
+    const message = response.body.errors?.map((e) => e.detail).join(", ") ?? "Unknown error";
+    super(`Request failed: ${message}`);
+    this.response = response;
+  }
+}
+
+type ShopwareErrorResponse = {
+  errors: {
+    code: string;
+    status: string;
+    title: string;
+    detail: string;
+  }[];
+};
+
+interface TokenCacheItem {
+  token: string;
+  expiresIn: Date;
+}
+
+interface ShopCredentials {
+  url: string;
+  clientId: string;
+  clientSecret: string;
+  shopToken: string;
+}
+
+export class HttpClient {
+  private shop: ShopCredentials;
+  private cachedToken: TokenCacheItem | null = null;
+
+  constructor(shop: ShopCredentials) {
+    this.shop = shop;
+  }
+
+  async get<R>(url: string, headers: Record<string, string> = {}): Promise<HttpClientResponse<R>> {
+    return this.request("GET", url, null, headers);
+  }
+
+  async post<R>(
+    url: string,
+    json: object = {},
+    headers: Record<string, string> = {},
+  ): Promise<HttpClientResponse<R>> {
+    headers["content-type"] = "application/json";
+    headers.accept = "application/json";
+    return this.request("POST", url, JSON.stringify(json), headers);
+  }
+
+  async put<R>(
+    url: string,
+    json: object = {},
+    headers: Record<string, string> = {},
+  ): Promise<HttpClientResponse<R>> {
+    headers["content-type"] = "application/json";
+    headers.accept = "application/json";
+    return this.request("PUT", url, JSON.stringify(json), headers);
+  }
+
+  async patch<R>(
+    url: string,
+    json: object = {},
+    headers: Record<string, string> = {},
+  ): Promise<HttpClientResponse<R>> {
+    headers["content-type"] = "application/json";
+    headers.accept = "application/json";
+    return this.request("PATCH", url, JSON.stringify(json), headers);
+  }
+
+  async delete<R>(
+    url: string,
+    json: object = {},
+    headers: Record<string, string> = {},
+  ): Promise<HttpClientResponse<R>> {
+    headers["content-type"] = "application/json";
+    headers.accept = "application/json";
+    return this.request("DELETE", url, JSON.stringify(json), headers);
+  }
+
+  async getToken(): Promise<string> {
+    if (this.cachedToken && this.cachedToken.expiresIn.getTime() > Date.now()) {
+      return this.cachedToken.token;
+    }
+
+    this.cachedToken = null;
+
+    const resp = await globalThis.fetch(this.buildUrl(this.shop.url, "/api/oauth/token"), {
+      method: "POST",
+      redirect: "manual",
+      headers: {
+        "content-type": "application/json",
+        [HEADER_NAME]: this.shop.shopToken,
+      },
+      body: JSON.stringify({
+        grant_type: "client_credentials",
+        client_id: this.shop.clientId,
+        client_secret: this.shop.clientSecret,
+      }),
+    });
+
+    if (resp.status === 301 || resp.status === 302) {
+      throw new ApiClientRequestFailed(
+        new HttpClientResponse(
+          resp.status,
+          {
+            errors: [
+              {
+                code: "301",
+                status: "301",
+                title: "Redirect",
+                detail:
+                  "Got a redirect response, the URL should point to the Shop without redirect",
+              },
+            ],
+          },
+          resp.headers,
+        ),
+      );
+    }
+
+    if (!resp.ok) {
+      const contentType = resp.headers.get("content-type") ?? "text/plain";
+      const body = contentType.includes("application/json") ? await resp.json() : await resp.text();
+      throw new ApiClientAuthenticationFailed(
+        new HttpClientResponse(resp.status, body as string, resp.headers),
+      );
+    }
+
+    const authBody = (await resp.json()) as { access_token: string; expires_in: number };
+    const expireDate = new Date();
+    expireDate.setSeconds(expireDate.getSeconds() + authBody.expires_in);
+
+    this.cachedToken = { token: authBody.access_token, expiresIn: expireDate };
+    return this.cachedToken.token;
+  }
+
+  private buildUrl(...parts: string[]): string {
+    return parts.map((part) => part.replace(/^\/+|\/+$/g, "")).join("/");
+  }
+
+  private async request<R>(
+    method: string,
+    url: string,
+    body: string | null,
+    headers: Record<string, string>,
+  ): Promise<HttpClientResponse<R>> {
+    const f = await globalThis.fetch(this.buildUrl(this.shop.url, "/api", url), {
+      redirect: "manual",
+      body,
+      headers: {
+        Authorization: `Bearer ${await this.getToken()}`,
+        [HEADER_NAME]: this.shop.shopToken,
+        ...headers,
+      },
+      method,
+    });
+
+    if (f.status === 301 || f.status === 302) {
+      throw new ApiClientRequestFailed(
+        new HttpClientResponse(
+          f.status,
+          {
+            errors: [
+              {
+                code: "301",
+                status: "301",
+                title: "Redirect",
+                detail:
+                  "Got a redirect response, the URL should point to the Shop without redirect",
+              },
+            ],
+          },
+          f.headers,
+        ),
+      );
+    }
+
+    if (!f.ok && f.status === 401) {
+      this.cachedToken = null;
+      return this.request(method, url, body, headers);
+    }
+
+    if (!f.ok) {
+      throw new ApiClientRequestFailed(
+        new HttpClientResponse(f.status, (await f.json()) as ShopwareErrorResponse, f.headers),
+      );
+    }
+
+    if (f.status === 204) {
+      return new HttpClientResponse(f.status, {} as R, f.headers);
+    }
+
+    return new HttpClientResponse(f.status, (await f.json()) as R, f.headers);
+  }
+}

--- a/api/src/modules/shop/jobs/shop-scrape.job.ts
+++ b/api/src/modules/shop/jobs/shop-scrape.job.ts
@@ -4,8 +4,7 @@ import {
   ApiClientRequestFailed,
   HttpClient,
   type HttpClientResponse,
-  SimpleShop,
-} from "@shopware-ag/app-server-sdk";
+} from "#src/modules/shop/http-client.ts";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import {
   type Drizzle,
@@ -39,6 +38,7 @@ interface SQLShop {
   url: string;
   clientId: string;
   clientSecret: string;
+  shopToken: string;
   shopwareVersion: string;
   ignores: string[];
   connectionIssueCount: number;
@@ -116,6 +116,7 @@ export async function shopScrapeJob() {
       url: schema.shop.url,
       clientId: schema.shop.clientId,
       clientSecret: schema.shop.clientSecret,
+      shopToken: schema.shop.shopToken,
       shopwareVersion: schema.shop.shopwareVersion,
       organizationId: schema.shop.organizationId,
       organizationSlug: schema.organization.slug,
@@ -147,6 +148,7 @@ export async function scrapeSingleShop(shopId: number) {
       url: schema.shop.url,
       clientId: schema.shop.clientId,
       clientSecret: schema.shop.clientSecret,
+      shopToken: schema.shop.shopToken,
       shopwareVersion: schema.shop.shopwareVersion,
       organizationId: schema.shop.organizationId,
       organizationSlug: schema.organization.slug,
@@ -213,9 +215,12 @@ async function updateShop(shop: SQLShop, con: Drizzle) {
 
     const clientSecret = await decrypt(process.env.APP_SECRET, shop.clientSecret);
 
-    const apiShop = new SimpleShop("", shop.url, "");
-    apiShop.setShopCredentials(shop.clientId, clientSecret);
-    const client = new HttpClient(apiShop);
+    const client = new HttpClient({
+      url: shop.url,
+      clientId: shop.clientId,
+      clientSecret,
+      shopToken: shop.shopToken,
+    });
 
     try {
       await client.getToken();

--- a/api/src/modules/shop/jobs/sitespeed-scrape.job.ts
+++ b/api/src/modules/shop/jobs/sitespeed-scrape.job.ts
@@ -35,6 +35,7 @@ export async function scrapeSingleSitespeedShop(shopId: number) {
       sitespeedEnabled: true,
       sitespeedUrls: true,
       connectionIssueCount: true,
+      shopToken: true,
     },
     where: eq(schema.shop.id, shopId),
   });
@@ -65,7 +66,9 @@ export async function scrapeSingleSitespeedShop(shopId: number) {
   );
 
   try {
-    const result = await runSitespeedReport(shop.id, shop.sitespeedUrls);
+    const result = await runSitespeedReport(shop.id, shop.sitespeedUrls, {
+      "shopmon-shop-token": shop.shopToken,
+    });
 
     // Store the metrics in the database
     await drizzle

--- a/api/src/modules/shop/shop.repository.ts
+++ b/api/src/modules/shop/shop.repository.ts
@@ -9,6 +9,7 @@ interface CreateShopRequest {
   clientId: string;
   clientSecret: string;
   projectId: number;
+  shopToken: string;
 }
 
 export interface Shop {
@@ -20,6 +21,13 @@ export interface User {
   displayName: string;
   email: string;
   notifications?: string[];
+}
+
+export function generateShopToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
 }
 
 async function createShop(con: Drizzle, params: CreateShopRequest): Promise<number> {
@@ -34,6 +42,7 @@ async function createShop(con: Drizzle, params: CreateShopRequest): Promise<numb
       createdAt: new Date(),
       shopwareVersion: params.version,
       projectId: params.projectId,
+      shopToken: params.shopToken,
     })
     .returning({ id: schema.shop.id });
 

--- a/api/src/modules/shop/shop.router.ts
+++ b/api/src/modules/shop/shop.router.ts
@@ -38,6 +38,7 @@ export const shopRouter = router({
         clientId: z.string(),
         clientSecret: z.string(),
         projectId: z.number(),
+        shopToken: z.string().min(1),
       }),
     )
     .use(loggedInUserMiddleware)

--- a/api/src/modules/shop/shop.service.ts
+++ b/api/src/modules/shop/shop.service.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { HttpClient, type HttpClientResponse, SimpleShop } from "@shopware-ag/app-server-sdk";
+import { HttpClient, type HttpClientResponse } from "#src/modules/shop/http-client.ts";
 import { TRPCError } from "@trpc/server";
 import { and, desc, eq, sql } from "drizzle-orm";
 import {
@@ -29,6 +29,7 @@ export interface CreateShopInput {
   clientId: string;
   clientSecret: string;
   projectId: number;
+  shopToken: string;
 }
 
 export interface UpdateShopInput {
@@ -99,6 +100,7 @@ export const getShopDetails = async (db: Drizzle, shopId: number) => {
       projectDescription: schema.project.description,
       sitespeedEnabled: schema.shop.sitespeedEnabled,
       sitespeedUrls: schema.shop.sitespeedUrls,
+      shopToken: schema.shop.shopToken,
       activeDeploymentId: schema.shop.activeDeploymentId,
       activeDeploymentName: schema.deployment.name,
       activeDeploymentCreatedAt: schema.deployment.createdAt,
@@ -291,10 +293,12 @@ export const create = async (db: Drizzle, userId: string, input: CreateShopInput
     });
   }
 
-  const shop = new SimpleShop("", input.shopUrl, "");
-  shop.setShopCredentials(input.clientId, input.clientSecret);
-
-  const client = new HttpClient(shop);
+  const client = new HttpClient({
+    url: input.shopUrl,
+    clientId: input.clientId,
+    clientSecret: input.clientSecret,
+    shopToken: input.shopToken,
+  });
 
   let resp: HttpClientResponse<{ version: string }>;
   try {
@@ -316,6 +320,7 @@ export const create = async (db: Drizzle, userId: string, input: CreateShopInput
     shopUrl: input.shopUrl,
     version: resp.body.version,
     projectId: input.projectId,
+    shopToken: input.shopToken,
   });
 
   await scrapeSingleShop(id);
@@ -380,11 +385,18 @@ export const update = async (db: Drizzle, userId: string, input: UpdateShopInput
   }
 
   if (input.shopUrl && input.clientId && input.clientSecret) {
-    // Try out the new credentials
-    const shop = new SimpleShop("", input.shopUrl, "");
-    shop.setShopCredentials(input.clientId, input.clientSecret);
+    const existingShop = await db.query.shop.findFirst({
+      columns: { shopToken: true },
+      where: eq(schema.shop.id, input.shopId),
+    });
 
-    const client = new HttpClient(shop);
+    // Try out the new credentials
+    const client = new HttpClient({
+      url: input.shopUrl,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret,
+      shopToken: existingShop?.shopToken ?? "",
+    });
 
     try {
       await client.get("/_info/config");
@@ -424,6 +436,7 @@ export const clearCache = async (db: Drizzle, shopId: number) => {
       url: true,
       clientId: true,
       clientSecret: true,
+      shopToken: true,
     },
     where: eq(schema.shop.id, shopId),
   });
@@ -436,9 +449,12 @@ export const clearCache = async (db: Drizzle, shopId: number) => {
   }
 
   const clientSecret = await decrypt(process.env.APP_SECRET, shopData.clientSecret);
-  const shop = new SimpleShop("", shopData.url, "");
-  shop.setShopCredentials(shopData.clientId, clientSecret);
-  const client = new HttpClient(shop);
+  const client = new HttpClient({
+    url: shopData.url,
+    clientId: shopData.clientId,
+    clientSecret,
+    shopToken: shopData.shopToken,
+  });
 
   await client.delete("/_action/cache");
 };
@@ -449,6 +465,7 @@ export const rescheduleTask = async (db: Drizzle, shopId: number, taskId: string
       url: true,
       clientId: true,
       clientSecret: true,
+      shopToken: true,
     },
     where: eq(schema.shop.id, shopId),
   });
@@ -461,9 +478,12 @@ export const rescheduleTask = async (db: Drizzle, shopId: number, taskId: string
   }
 
   const clientSecret = await decrypt(process.env.APP_SECRET, shopData.clientSecret);
-  const shop = new SimpleShop("", shopData.url, "");
-  shop.setShopCredentials(shopData.clientId, clientSecret);
-  const client = new HttpClient(shop);
+  const client = new HttpClient({
+    url: shopData.url,
+    clientId: shopData.clientId,
+    clientSecret,
+    shopToken: shopData.shopToken,
+  });
 
   const nextExecutionTime: string = new Date().toISOString();
   await client.patch(`/scheduled-task/${taskId}`, {

--- a/api/src/modules/shop/sitespeed.service.ts
+++ b/api/src/modules/shop/sitespeed.service.ts
@@ -15,8 +15,17 @@ export function getReportUrl(shopId: number) {
   return `${sitespeedServiceUrl}/result/${recordId}/index.html`;
 }
 
-export async function runSitespeedReport(shopId: number, urls: string[]) {
+export async function runSitespeedReport(
+  shopId: number,
+  urls: string[],
+  headers?: Record<string, string>,
+) {
   const recordId = getReportName(shopId);
+
+  const body: { urls: string[]; headers?: Record<string, string> } = { urls };
+  if (headers && Object.keys(headers).length > 0) {
+    body.headers = headers;
+  }
 
   const response = await fetch(`${sitespeedServiceUrl}/api/result/${recordId}`, {
     method: "POST",
@@ -24,9 +33,7 @@ export async function runSitespeedReport(shopId: number, urls: string[]) {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.APP_SITESPEED_API_KEY || "secret"}`,
     },
-    body: JSON.stringify({
-      urls: urls,
-    }),
+    body: JSON.stringify(body),
   });
 
   return (await response.json()) as {

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "@better-auth/passkey": "catalog:",
         "@better-auth/sso": "catalog:",
         "@sentry/bun": "^10.27.0",
-        "@shopware-ag/app-server-sdk": "^2.0.0",
         "@trpc/server": "^11.7.2",
         "better-auth": "catalog:",
         "drizzle-orm": "^0.45.0",
@@ -611,8 +610,6 @@
     "@sentry/node-core": ["@sentry/node-core@10.38.0", "", { "dependencies": { "@apm-js-collab/tracing-hooks": "^0.3.1", "@sentry/core": "10.38.0", "@sentry/opentelemetry": "10.38.0", "import-in-the-middle": "^2.0.6" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/resources": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-ErXtpedrY1HghgwM6AliilZPcUCoNNP1NThdO4YpeMq04wMX9/GMmFCu46TnCcg6b7IFIOSr2S4yD086PxLlHQ=="],
 
     "@sentry/opentelemetry": ["@sentry/opentelemetry@10.38.0", "", { "dependencies": { "@sentry/core": "10.38.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-YPVhWfYmC7nD3EJqEHGtjp4fp5LwtAbE5rt9egQ4hqJlYFvr8YEz9sdoqSZxO0cZzgs2v97HFl/nmWAXe52G2Q=="],
-
-    "@shopware-ag/app-server-sdk": ["@shopware-ag/app-server-sdk@2.0.0", "", { "peerDependencies": { "@aws-sdk/client-dynamodb": "^3", "@aws-sdk/lib-dynamodb": "^3", "better-sqlite3": "^11 || ^12", "hono": "^4" }, "optionalPeers": ["@aws-sdk/client-dynamodb", "@aws-sdk/lib-dynamodb", "better-sqlite3", "hono"] }, "sha512-vj5Sj00SxWYovNtMsfE0Y4Iu2lgRAWlSRoFKaH3/17gZqk4tCd8Od+kH3nSBIXLEXKG+QaqlEnxwjVzm1odJ7g=="],
 
     "@simplewebauthn/browser": ["@simplewebauthn/browser@13.2.2", "", {}, "sha512-FNW1oLQpTJyqG5kkDg5ZsotvWgmBaC6jCHR7Ej0qUNep36Wl9tj2eZu7J5rP+uhXgHaLk+QQ3lqcw2vS5MX1IA=="],
 

--- a/frontend/src/composables/useWhatsNew.spec.ts
+++ b/frontend/src/composables/useWhatsNew.spec.ts
@@ -22,7 +22,7 @@ describe("useWhatsNew", () => {
   });
 
   it("keeps the modal closed when the current release was already seen", async () => {
-    const { WHATS_NEW_VERSION, useWhatsNew } = await import("./useWhatsNew");
+    const { WHATS_NEW_VERSION } = await import("./useWhatsNew");
 
     localStorage.setItem("shopmon-whats-new", WHATS_NEW_VERSION);
 

--- a/frontend/src/views/shop/AddShop.vue
+++ b/frontend/src/views/shop/AddShop.vue
@@ -60,6 +60,22 @@
         </div>
       </form-group>
 
+      <form-group title="Bypass Authentication Header">
+        <template #info>
+          If your website is protected by authentication, please configure the header
+          <code>shopmon-shop-token</code> with the value below to be excluded, so Shopmon can
+          function normally.
+        </template>
+
+        <div class="shop-token-display">
+          <code>{{ shopToken }}</code>
+
+          <button type="button" class="btn btn-sm btn-icon" @click="copyToken">
+            <icon-fa6-solid:copy />
+          </button>
+        </div>
+      </form-group>
+
       <form-group title="Integration">
         <template #info>
           The easiest way to get started is to install the
@@ -141,9 +157,23 @@ import { ref } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import * as Yup from "yup";
 
-const { error } = useAlert();
+const { error, success } = useAlert();
 const router = useRouter();
 const route = useRoute();
+
+function generateShopToken(): string {
+  const bytes = crypto.getRandomValues(new Uint8Array(32));
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+const shopToken = generateShopToken();
+
+async function copyToken() {
+  await navigator.clipboard.writeText(shopToken);
+  success("Token copied to clipboard");
+}
 
 const projects = ref<RouterOutput["account"]["currentUserProjects"]>([]);
 const selectedProjectId = ref<number>(route.query.projectId ? Number(route.query.projectId) : 0);
@@ -193,6 +223,7 @@ const onSubmit = async (values: Record<string, unknown>) => {
       clientId: typedValues.clientId,
       clientSecret: typedValues.clientSecret,
       projectId: selectedProjectId.value,
+      shopToken,
     };
     await trpcClient.organization.shop.create.mutate(input);
 
@@ -241,3 +272,16 @@ function processPluginData() {
   }
 }
 </script>
+
+<style scoped>
+.shop-token-display {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  code {
+    font-size: 0.8rem;
+    word-break: break-all;
+  }
+}
+</style>

--- a/frontend/src/views/shop/detail/DetailShop.vue
+++ b/frontend/src/views/shop/detail/DetailShop.vue
@@ -120,6 +120,31 @@
             {{ shop.projectName }}
           </dd>
         </div>
+
+        <div class="shop-info-item shop-token-item">
+          <dt>
+            Bypass Authentication Header
+            <span
+              data-tooltip="If your website is protected by authentication, configure the header 'shopmon-shop-token' with this value to be excluded"
+              class="tooltip-top-center"
+            >
+              <icon-fa6-solid:circle-info class="icon" />
+            </span>
+          </dt>
+
+          <dd class="shop-token-value">
+            <code>{{ shop.shopToken }}</code>
+
+            <button
+              type="button"
+              class="btn btn-sm btn-icon tooltip-top-center"
+              data-tooltip="Copy token"
+              @click="copyToken"
+            >
+              <icon-fa6-solid:copy />
+            </button>
+          </dd>
+        </div>
       </dl>
     </div>
   </div>
@@ -348,8 +373,15 @@ type ExtensionWithCompatibility = Extension & {
   } | null;
 };
 
-const { error } = useAlert();
+const { error, success } = useAlert();
 const { shop, shopwareVersions, latestShopwareVersion } = useShopDetail();
+
+async function copyToken() {
+  if (shop.value?.shopToken) {
+    await navigator.clipboard.writeText(shop.value.shopToken);
+    success("Token copied to clipboard");
+  }
+}
 
 const {
   viewExtensionChangelogDialog,
@@ -529,6 +561,21 @@ async function loadUpdateWizard(version: string) {
 
   dd {
     color: var(--text-color-muted);
+  }
+}
+
+.shop-token-item {
+  grid-column: 1 / -1;
+}
+
+.shop-token-value {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  code {
+    font-size: 0.8rem;
+    word-break: break-all;
   }
 }
 


### PR DESCRIPTION
## Summary

<img width="2364" height="452" alt="image" src="https://github.com/user-attachments/assets/4ea8676b-8619-4c34-a2d7-133394a456e2" />


- Add `shop_token` column to shops table for authentication bypass
- Replace `@shopware-ag/app-server-sdk` with custom `http-client.ts` implementation
- Add UI to display and copy shop token in AddShop and DetailShop views
- Pass `shopmon-shop-token` header to sitespeed for authenticated sites
- Generate cryptographically secure token for each new shop

## Test plan

- [ ] Create a new shop and verify token is generated
- [ ] Copy token from AddShop and DetailShop views
- [ ] Verify sitespeed can access shops behind authentication using the token
- [ ] Verify shop scraping works with the new http-client