### PR TITLE
feat: add SSG support for public pages

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -74,12 +74,15 @@
         "@iconify-json/octicon": "^1.2.19",
         "@iconify-json/ri": "^1.2.6",
         "@trpc/server": "^11.7.2",
+        "@unhead/vue": "^2.1.12",
         "@vitejs/plugin-vue": "6.0.5",
         "@vitest/ui": "^4.0.18",
         "@vue/test-utils": "^2.4.6",
+        "beasties": "^0.3.5",
         "jsdom": "^29.0.0",
         "typescript": "catalog:",
         "vite": "8.0.1",
+        "vite-ssg": "^28.3.0",
         "vitest": "^4.0.18",
       },
     },
@@ -97,6 +100,8 @@
     "typescript": "5.9.3",
   },
   "packages": {
+    "@acemir/cssom": ["@acemir/cssom@0.9.31", "", {}, "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="],
+
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
     "@apm-js-collab/code-transformer": ["@apm-js-collab/code-transformer@0.8.2", "", {}, "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA=="],
@@ -325,13 +330,13 @@
 
     "@iconify/utils": ["@iconify/utils@3.1.0", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/types": "^2.0.0", "mlly": "^1.8.0" } }, "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw=="],
 
-    "@ioredis/commands": ["@ioredis/commands@1.5.0", "", {}, "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="],
-
     "@intlify/core-base": ["@intlify/core-base@10.0.8", "", { "dependencies": { "@intlify/message-compiler": "10.0.8", "@intlify/shared": "10.0.8" } }, "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ=="],
 
     "@intlify/message-compiler": ["@intlify/message-compiler@10.0.8", "", { "dependencies": { "@intlify/shared": "10.0.8", "source-map-js": "^1.0.2" } }, "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg=="],
 
     "@intlify/shared": ["@intlify/shared@10.0.8", "", {}, "sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.5.0", "", {}, "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -679,6 +684,10 @@
 
     "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
 
+    "@unhead/dom": ["@unhead/dom@2.1.12", "", { "peerDependencies": { "unhead": "2.1.12" } }, "sha512-PpBWWgS3t32qSl60v3UDIhZreuFOAl/Wj2T+bDnlhW/mMGFeVJrHoeJB5pa9UHWJwC1nLyBDn+6XqfCxOftQ2g=="],
+
+    "@unhead/vue": ["@unhead/vue@2.1.12", "", { "dependencies": { "hookable": "^6.0.1", "unhead": "2.1.12" }, "peerDependencies": { "vue": ">=3.5.18" } }, "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g=="],
+
     "@vitejs/plugin-vue": ["@vitejs/plugin-vue@6.0.5", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.2" }, "peerDependencies": { "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0", "vue": "^3.2.25" } }, "sha512-bL3AxKuQySfk1iGcBsQnoRVexTPJq0Z/ixFVM8OhVJAP6ZXXXLtM7NFKWhLl30Kg7uTBqIaPXbh+nuQCuBDedg=="],
 
     "@vitest/expect": ["@vitest/expect@4.0.18", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "chai": "^6.2.1", "tinyrainbow": "^3.0.3" } }, "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ=="],
@@ -735,11 +744,15 @@
 
     "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
@@ -758,6 +771,8 @@
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.9.19", "", { "bin": { "baseline-browser-mapping": "dist/cli.js" } }, "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg=="],
+
+    "beasties": ["beasties@0.3.5", "", { "dependencies": { "css-select": "^6.0.0", "css-what": "^7.0.0", "dom-serializer": "^2.0.0", "domhandler": "^5.0.3", "htmlparser2": "^10.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.49", "postcss-media-query-parser": "^0.2.3" } }, "sha512-NaWu+f4YrJxEttJSm16AzMIFtVldCvaJ68b1L098KpqXmxt9xOLtKoLkKxb8ekhOrLqEJAbvT6n6SEvB/sac7A=="],
 
     "better-auth": ["better-auth@1.4.1", "", { "dependencies": { "@better-auth/core": "1.4.1", "@better-auth/telemetry": "1.4.1", "@better-auth/utils": "0.3.0", "@better-fetch/fetch": "1.1.18", "@noble/ciphers": "^2.0.0", "@noble/hashes": "^2.0.0", "@standard-schema/spec": "^1.0.0", "better-call": "1.1.0", "defu": "^6.1.4", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1", "zod": "^4.1.12" } }, "sha512-HDVE69Nw6Y1FPTcmFEmPolfsjMfVB5U823Ij9yWBoM8MdHZ2lA3JVus4xQJ2oRE1riJTlcSLFcgJKWGD7V7hmw=="],
 
@@ -788,6 +803,8 @@
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "c12": ["c12@3.3.3", "", { "dependencies": { "chokidar": "^5.0.0", "confbox": "^0.2.2", "defu": "^6.1.4", "dotenv": "^17.2.3", "exsolve": "^1.0.8", "giget": "^2.0.0", "jiti": "^2.6.1", "ohash": "^2.0.11", "pathe": "^2.0.3", "perfect-debounce": "^2.0.0", "pkg-types": "^2.3.0", "rc9": "^2.1.2" }, "peerDependencies": { "magicast": "*" }, "optionalPeers": ["magicast"] }, "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
     "camel-case": ["camel-case@4.1.2", "", { "dependencies": { "pascal-case": "^3.1.2", "tslib": "^2.0.3" } }, "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw=="],
 
@@ -845,11 +862,13 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
-    "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+    "css-select": ["css-select@6.0.0", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^7.0.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "nth-check": "^2.1.1" } }, "sha512-rZZVSLle8v0+EY8QAkDWrKhpgt6SA5OtHsgBnsj6ZaLb5dmDVOWUDtQitd9ydxxvEjhewNudS6eTVU7uOyzvXw=="],
 
     "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
-    "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+    "css-what": ["css-what@7.0.0", "", {}, "sha512-wD5oz5xibMOPHzy13CyGmogB3phdvcDaB5t0W/Nr5Z2O/agcB8YwOz6e2Lsp10pNDzBoDO9nVa3RGs/2BttpHQ=="],
+
+    "cssstyle": ["cssstyle@6.2.0", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@csstools/css-syntax-patches-for-csstree": "^1.0.28", "css-tree": "^3.1.0", "lru-cache": "^11.2.6" } }, "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -903,7 +922,7 @@
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
@@ -959,13 +978,21 @@
 
     "hono": ["hono@4.12.7", "", {}, "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw=="],
 
-    "hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+    "hookable": ["hookable@6.1.0", "", {}, "sha512-ZoKZSJgu8voGK2geJS+6YtYjvIzu9AOM/KZXsBxr83uhLL++e9pEv/dlgwgy3dvHg06kTz6JOh1hk3C8Ceiymw=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-minifier": ["html-minifier-terser@7.2.0", "", { "dependencies": { "camel-case": "^4.1.2", "clean-css": "~5.3.2", "commander": "^10.0.0", "entities": "^4.4.0", "param-case": "^3.0.4", "relateurl": "^0.2.7", "terser": "^5.15.1" }, "bin": { "html-minifier-terser": "cli.js" } }, "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA=="],
 
-    "htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
+    "html-minifier-terser": ["html-minifier-terser@7.2.0", "", { "dependencies": { "camel-case": "^4.1.2", "clean-css": "~5.3.2", "commander": "^10.0.0", "entities": "^4.4.0", "param-case": "^3.0.4", "relateurl": "^0.2.7", "terser": "^5.15.1" }, "bin": { "html-minifier-terser": "cli.js" } }, "sha512-tXgn3QfqPIpGl9o+K5tpcj3/MN4SfLtsx2GWwBC3SSd0tXQGyF3gsSqad8loJgKZGM3ZxbYDd5yhiBIdWpmvLA=="],
+
+    "html5parser": ["html5parser@2.0.2", "", { "dependencies": { "tslib": "^2.2.0" } }, "sha512-L0y+IdTVxHsovmye8MBtFgBvWZnq1C9WnI/SmJszxoQjmUH1psX2uzDk21O5k5et6udxdGjwxkbmT9eVRoG05w=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
@@ -1241,6 +1268,8 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
+    "postcss-media-query-parser": ["postcss-media-query-parser@0.2.3", "", {}, "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig=="],
+
     "postgres": ["postgres@3.4.8", "", {}, "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg=="],
 
     "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
@@ -1403,6 +1432,8 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
+    "unhead": ["unhead@2.1.12", "", { "dependencies": { "hookable": "^6.0.1" } }, "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA=="],
+
     "unplugin": ["unplugin@2.3.11", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "acorn": "^8.15.0", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww=="],
 
     "unplugin-icons": ["unplugin-icons@23.0.1", "", { "dependencies": { "@antfu/install-pkg": "^1.1.0", "@iconify/utils": "^3.1.0", "local-pkg": "^1.1.2", "obug": "^2.1.1", "unplugin": "^2.3.11" }, "peerDependencies": { "@svgr/core": ">=7.0.0", "@svgx/core": "^1.0.1", "@vue/compiler-sfc": "^3.0.2", "svelte": "^3.0.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["@svgr/core", "@svgx/core", "@vue/compiler-sfc", "svelte"] }, "sha512-rv0XEJepajKzDLvRUWASM8K+8+/CCfZn2jtogXqg6RIp7kpatRc/aFrVJn8ANQA09e++lPEEv9yX8cC9enc+QQ=="],
@@ -1420,6 +1451,8 @@
     "vee-validate": ["vee-validate@4.15.1", "", { "dependencies": { "@vue/devtools-api": "^7.5.2", "type-fest": "^4.8.3" }, "peerDependencies": { "vue": "^3.4.26" } }, "sha512-DkFsiTwEKau8VIxyZBGdO6tOudD+QoUBPuHj3e6QFqmbfCRj1ArmYWue9lEp6jLSWBIw4XPlDLjFIZNLdRAMSg=="],
 
     "vite": ["vite@8.0.1", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.3", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.10", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw=="],
+
+    "vite-ssg": ["vite-ssg@28.3.0", "", { "dependencies": { "@unhead/dom": "^2.1.2", "@unhead/vue": "^2.1.2", "ansis": "^4.2.0", "cac": "^6.7.14", "html-minifier-terser": "^7.2.0", "html5parser": "^2.0.2", "jsdom": "^28.0.0" }, "peerDependencies": { "beasties": "^0.3.5", "prettier": "^3.3.0", "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0 || ^7.0.0-0 || ^8.0.0-0", "vue": "^3.2.10", "vue-router": "^4.0.1 || ^5.0.0-0" }, "optionalPeers": ["beasties", "prettier", "vue-router"], "bin": { "vite-ssg": "bin/vite-ssg.js" } }, "sha512-dIUjv+scfhJTfYGwf83R0KGAmr/duIo9oln5ZsQOIZZACm3voAON//7oKhtEwaOTtD4QTTab+nhvyn0QiIaFMA=="],
 
     "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
 
@@ -1545,6 +1578,8 @@
 
     "@vue/compiler-ssr/@vue/shared": ["@vue/shared@3.5.27", "", {}, "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ=="],
 
+    "@vue/devtools-kit/hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
+
     "@vue/devtools-kit/perfect-debounce": ["perfect-debounce@1.0.0", "", {}, "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA=="],
 
     "@vue/server-renderer/@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.30", "", { "dependencies": { "@vue/compiler-dom": "3.5.30", "@vue/shared": "3.5.30" } }, "sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA=="],
@@ -1559,11 +1594,13 @@
 
     "cheerio/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
+    "cheerio-select/css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
+
+    "cheerio-select/css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
     "chevrotain/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "data-urls/whatwg-url": ["whatwg-url@16.0.0", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ=="],
-
-    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "editorconfig/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
@@ -1575,15 +1612,17 @@
 
     "html-minifier/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
-    "html-minifier/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "html-minifier-terser/commander": ["commander@10.0.1", "", {}, "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="],
 
-    "htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "juice/commander": ["commander@6.2.1", "", {}, "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="],
 
     "local-pkg/mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
     "mjml-cli/chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "mjml-parser-xml/htmlparser2": ["htmlparser2@9.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.1.0", "entities": "^4.5.0" } }, "sha512-5zfg6mHUoaer/97TxnGpxmbR7zJtPwIYFMZ/H5ucTlPZhKvtum05yiPK3Mgai3a0DyVxv7qYqoweaEd2nrYQzQ=="],
 
     "mlly/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -1592,6 +1631,8 @@
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "nypm/citty": ["citty@0.2.1", "", {}, "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg=="],
+
+    "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "parse5-htmlparser2-tree-adapter/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -1606,6 +1647,8 @@
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
     "unplugin-vue-components/unplugin": ["unplugin@3.0.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.3", "webpack-virtual-modules": "^0.6.2" } }, "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg=="],
+
+    "vite-ssg/jsdom": ["jsdom@28.1.0", "", { "dependencies": { "@acemir/cssom": "^0.9.31", "@asamuzakjp/dom-selector": "^6.8.1", "@bramus/specificity": "^2.4.2", "@exodus/bytes": "^1.11.0", "cssstyle": "^6.0.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.0", "undici": "^7.21.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug=="],
 
     "vitest/vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
@@ -1647,7 +1690,7 @@
 
     "@vue/compiler-dom/@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
-    "cheerio/htmlparser2/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "cheerio/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "data-urls/whatwg-url/@exodus/bytes": ["@exodus/bytes@1.14.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ=="],
 
@@ -1662,6 +1705,10 @@
     "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "parse5-htmlparser2-tree-adapter/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "vite-ssg/jsdom/@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@6.8.1", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.1.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.6" } }, "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ=="],
 
     "vitest/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
@@ -1692,6 +1739,8 @@
     "mlly/pkg-types/mlly/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "vue-router/@vue/devtools-api/@vue/devtools-kit/@vue/devtools-shared": ["@vue/devtools-shared@8.0.6", "", { "dependencies": { "rfdc": "^1.4.1" } }, "sha512-Pp1JylTqlgMJvxW6MGyfTF8vGvlBSCAvMFaDCYa82Mgw7TT5eE5kkHgDvmOGHWeJE4zIDfCpCxHapsK2LtIAJg=="],
+
+    "vue-router/@vue/devtools-api/@vue/devtools-kit/hookable": ["hookable@5.5.3", "", {}, "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ=="],
 
     "vue-router/mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "SHOPMON_API_URL=http://127.0.0.1:5789 vite --port 3000 --host",
-    "build": "vite build",
+    "build": "vite-ssg build",
     "preview": "vite preview",
     "test": "vitest",
     "test:ui": "vitest --ui",
@@ -49,12 +49,15 @@
     "@iconify-json/octicon": "^1.2.19",
     "@iconify-json/ri": "^1.2.6",
     "@trpc/server": "^11.7.2",
+    "@unhead/vue": "^2.1.12",
     "@vitejs/plugin-vue": "6.0.5",
     "@vitest/ui": "^4.0.18",
     "@vue/test-utils": "^2.4.6",
+    "beasties": "^0.3.5",
     "jsdom": "^29.0.0",
     "typescript": "catalog:",
     "vite": "8.0.1",
+    "vite-ssg": "^28.3.0",
     "vitest": "^4.0.18"
   }
 }

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,2 +1,4 @@
 User-agent: *
 Allow: /
+
+Sitemap: https://shopmon.fos.gg/sitemap.xml

--- a/frontend/src/composables/useDarkMode.ts
+++ b/frontend/src/composables/useDarkMode.ts
@@ -44,6 +44,10 @@ export function useDarkMode(): {
 }
 
 function initializeDarkMode() {
+  if (import.meta.env.SSR) {
+    return;
+  }
+
   // Get initial preference
   const stored = localStorage.getItem(DARK_MODE_STORAGE_KEY);
   if (stored !== null) {
@@ -79,6 +83,9 @@ function initializeDarkMode() {
 }
 
 function updateDarkModeClass(isDark: boolean): void {
+  if (import.meta.env.SSR) {
+    return;
+  }
   if (isDark) {
     document.documentElement.classList.add("dark");
   } else {

--- a/frontend/src/composables/useLocale.ts
+++ b/frontend/src/composables/useLocale.ts
@@ -7,8 +7,10 @@ export function useLocale() {
 
   function setLocale(lang: string) {
     locale.value = lang;
-    localStorage.setItem(LOCALE_STORAGE_KEY, lang);
-    document.documentElement.lang = lang;
+    if (!import.meta.env.SSR) {
+      localStorage.setItem(LOCALE_STORAGE_KEY, lang);
+      document.documentElement.lang = lang;
+    }
   }
 
   function toggleLocale() {

--- a/frontend/src/i18n.ts
+++ b/frontend/src/i18n.ts
@@ -5,6 +5,9 @@ import de from "./locales/de.json";
 const LOCALE_STORAGE_KEY = "shopmon-locale";
 
 function getInitialLocale(): string {
+  if (import.meta.env.SSR) {
+    return "en";
+  }
   const stored = localStorage.getItem(LOCALE_STORAGE_KEY);
   if (stored && ["en", "de"].includes(stored)) {
     return stored;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -1,14 +1,22 @@
-import { createApp } from "vue";
+import { ViteSSG } from "vite-ssg";
 
 import "./style.css";
 
 import App from "./App.vue";
-import { router } from "./router";
+import { routes, setupRouterGuards } from "./router";
 import { i18n } from "./i18n";
 
-const app = createApp(App);
+export const createApp = ViteSSG(
+  App,
+  {
+    routes,
+    linkActiveClass: "active",
+  },
+  ({ app, router, isClient }) => {
+    app.use(i18n as any);
 
-app.use(i18n as any);
-app.use(router);
-
-app.mount("#app");
+    if (isClient) {
+      setupRouterGuards(router);
+    }
+  },
+);

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,351 +1,69 @@
-import { type RouteLocationNormalized, createRouter, createWebHistory } from "vue-router";
+import type { RouteLocationNormalized, Router } from "vue-router";
 
 import { useReturnUrl } from "@/composables/useReturnUrl";
 import { authClient } from "@/helpers/auth-client";
 import { i18n } from "@/i18n";
-import AppLayout from "@/layouts/AppLayout.vue";
-import LoginLayout from "@/layouts/LoginLayout.vue";
-import DefaultLayout from "@/layouts/DefaultLayout.vue";
-import ShopDetailLayout from "@/layouts/ShopDetailLayout.vue";
-import adminRoutes from "@/router/admin";
 import { nextTick } from "vue";
 
-import FaShop from "~icons/fa6-solid/shop";
-import FaCircleCheck from "~icons/fa6-solid/circle-check";
-import FaFileWaveform from "~icons/fa6-solid/file-waveform";
-import FaListCheck from "~icons/fa6-solid/list-check";
-import FaPlug from "~icons/fa6-solid/plug";
-import FaRocket from "~icons/fa6-solid/rocket";
-import FaCodeBranch from "~icons/fa6-solid/code-branch";
-import Dashboard from "~icons/ri/dashboard-fill";
-import FaFolder from "~icons/fa6-solid/folder";
-import FaBuilding from "~icons/fa6-solid/building";
-import FaBook from "~icons/fa6-solid/book";
+export { routes } from "./routes";
 
-const session = authClient.useSession();
+export function setupRouterGuards(router: Router) {
+  const session = authClient.useSession();
 
-export const router = createRouter({
-  history: createWebHistory(import.meta.env.BASE_URL),
-  linkActiveClass: "active",
-  routes: [
-    {
-      path: "/",
-      component: DefaultLayout,
-      children: [
-        {
-          path: "",
-          name: "home",
-          component: () => import("@/views/Home.vue"),
-        },
-        {
-          path: "privacy",
-          name: "privacy",
-          component: () => import("@/views/Privacy.vue"),
-        },
-        {
-          path: "imprint",
-          name: "imprint",
-          component: () => import("@/views/Imprint.vue"),
-        },
-      ],
-    },
-    {
-      path: "/account",
-      component: LoginLayout,
-      children: [
-        {
-          name: "account.login",
-          path: "login",
-          component: () => import("@/views/auth/Login.vue"),
-        },
-        {
-          name: "account.register",
-          path: "register",
-          component: () => import("@/views/auth/Register.vue"),
-        },
-        {
-          name: "account.confirm",
-          path: "confirm/:token",
-          component: () => import("@/views/auth/AccountConfirm.vue"),
-        },
-        {
-          name: "account.forgot.password",
-          path: "forgot-password",
-          component: () => import("@/views/auth/ForgotPassword.vue"),
-        },
-        {
-          name: "account.forgot.password.confirm",
-          path: "forgot-password/:token",
-          component: () => import("@/views/auth/ForgotPasswordConfirm.vue"),
-        },
-      ],
-    },
-    {
-      path: "/app",
-      component: AppLayout,
-      children: [
-        {
-          path: "dashboard",
-          name: "account.dashboard",
-          component: () => import("@/views/Dashboard.vue"),
-          meta: {
-            titleKey: "nav.dashboard",
-            icon: Dashboard,
-          },
-        },
-        {
-          name: "account.settings",
-          path: "settings",
-          component: () => import("@/views/account/Settings.vue"),
-          meta: {
-            titleKey: "nav.settings",
-            icon: FaShop,
-          },
-        },
-        {
-          name: "account.project.list",
-          path: "projects",
-          component: () => import("@/views/shop/ListProjects.vue"),
-          meta: {
-            titleKey: "nav.myProjects",
-            icon: FaFolder,
-          },
-        },
-        {
-          name: "account.shops.new",
-          path: "shops/new",
-          component: () => import("@/views/shop/AddShop.vue"),
-        },
-        {
-          name: "account.projects.new",
-          path: "projects/new",
-          component: () => import("@/views/shop/AddProject.vue"),
-        },
-        {
-          name: "account.projects.edit",
-          path: "projects/:projectId(\\d+)/edit",
-          component: () => import("@/views/shop/EditProject.vue"),
-          meta: {
-            titleKey: "nav.editProject",
-          },
-        },
-        {
-          name: "account.shops.edit",
-          path: "organizations/:slug/shops/:shopId(\\d+)/edit",
-          component: () => import("@/views/shop/EditShop.vue"),
-        },
-        {
-          path: "organizations/:slug/shops/:shopId(\\d+)",
-          component: ShopDetailLayout,
-          children: [
-            {
-              name: "account.shops.detail",
-              path: "",
-              component: () => import("@/views/shop/detail/DetailShop.vue"),
-              meta: {
-                titleKey: "nav.shopInformation",
-                icon: FaShop,
-              },
-            },
-            {
-              name: "account.shops.detail.checks",
-              path: "checks",
-              component: () => import("@/views/shop/detail/DetailChecks.vue"),
-              meta: {
-                titleKey: "nav.checks",
-                icon: FaCircleCheck,
-              },
-            },
-            {
-              name: "account.shops.detail.extensions",
-              path: "extensions",
-              component: () => import("@/views/shop/detail/DetailExtensions.vue"),
-              meta: {
-                titleKey: "nav.extensions",
-                icon: FaPlug,
-              },
-            },
-            {
-              name: "account.shops.detail.tasks",
-              path: "tasks",
-              component: () => import("@/views/shop/detail/DetailScheduledTasks.vue"),
-              meta: {
-                titleKey: "nav.scheduledTasks",
-                icon: FaListCheck,
-              },
-            },
-            {
-              name: "account.shops.detail.queue",
-              path: "queue",
-              component: () => import("@/views/shop/detail/DetailQueue.vue"),
-              meta: {
-                titleKey: "nav.queue",
-                icon: FaCircleCheck,
-              },
-            },
-            {
-              name: "account.shops.detail.sitespeed",
-              path: "sitespeed",
-              component: () => import("@/views/shop/detail/DetailSitespeed.vue"),
-              meta: {
-                titleKey: "nav.sitespeed",
-                icon: FaRocket,
-              },
-            },
-            {
-              name: "account.shops.detail.changelog",
-              path: "changelog",
-              component: () => import("@/views/shop/detail/DetailChangelog.vue"),
-              meta: {
-                titleKey: "nav.changelog",
-                icon: FaFileWaveform,
-              },
-            },
-            {
-              name: "account.shops.detail.deployments",
-              path: "deployments",
-              component: () => import("@/views/shop/detail/DetailDeployments.vue"),
-              meta: {
-                titleKey: "nav.deployments",
-                icon: FaCodeBranch,
-              },
-            },
-            {
-              name: "account.shops.detail.deployment",
-              path: "deployments/:deploymentId(\\d+)",
-              component: () => import("@/views/shop/detail/DetailDeployment.vue"),
-              meta: {
-                titleKey: "nav.deploymentDetails",
-              },
-            },
-          ],
-        },
-        {
-          name: "account.organizations.list",
-          path: "organizations",
-          component: () => import("@/views/organization/ListOrganizations.vue"),
-          meta: {
-            titleKey: "nav.myOrganizations",
-            icon: FaBuilding,
-          },
-        },
-        {
-          name: "account.organizations.new",
-          path: "organizations/new",
-          component: () => import("@/views/organization/AddOrganization.vue"),
-        },
-        {
-          name: "account.organizations.detail",
-          path: "organizations/:slug",
-          component: () => import("@/views/organization/DetailOrganization.vue"),
-        },
-        {
-          name: "account.organizations.edit",
-          path: "organizations/edit/:slug",
-          component: () => import("@/views/organization/EditOrganization.vue"),
-        },
-        {
-          name: "account.organizations.sso",
-          path: "organizations/:slug/sso",
-          component: () => import("@/views/organization/ManageSSO.vue"),
-        },
-        {
-          name: "account.extension.list",
-          path: "extensions",
-          component: () => import("@/views/account/ListExtensions.vue"),
-          meta: {
-            titleKey: "nav.myExtensions",
-            icon: FaPlug,
-          },
-        },
-        {
-          name: "account.docs",
-          path: "docs",
-          component: () => import("@/views/Docs.vue"),
-          meta: {
-            titleKey: "nav.documentation",
-            icon: FaBook,
-          },
-        },
-        {
-          name: "account.organization.accept",
-          path: "organizations/accept/:token",
-          component: () => import("@/views/organization/AcceptRejectInvitation.vue"),
-          props: {
-            action: "accept",
-          },
-        },
-        {
-          name: "account.organization.reject",
-          path: "organizations/reject/:token",
-          component: () => import("@/views/organization/AcceptRejectInvitation.vue"),
-          props: {
-            action: "reject",
-          },
-        },
-      ],
-    },
-    ...adminRoutes,
-    // catch all redirect to home page
-    {
-      path: "/:pathMatch(.*)*",
-      name: "not-found",
-      redirect: { name: "home" },
-    },
-  ],
-});
-
-router.beforeEach(async (to: RouteLocationNormalized) => {
-  if (session.value.isPending) {
-    await new Promise((resolve) => {
-      const a = setInterval(() => {
-        if (!session.value.isPending) {
-          clearInterval(a);
-          resolve(true);
-        }
-      }, 50);
-    });
-  }
-
-  // redirect to the login page if not logged in and trying to access a restricted page
-  const publicPages = [
-    "home",
-    "privacy",
-    "imprint",
-    "account.login",
-    "account.register",
-    "account.confirm",
-    "account.forgot.password",
-    "account.forgot.password.confirm",
-  ];
-  const authRequired = !publicPages.includes(to.name as string);
-  const { setReturnUrl } = useReturnUrl();
-
-  if (authRequired && !session.value.data) {
-    setReturnUrl(to.fullPath);
-    return { name: "account.login" };
-  } else if (to.name === "account.login") {
-    setReturnUrl("/app/dashboard");
-  }
-
-  // Check admin routes
-  if (to.path.startsWith("/admin") && session.value.data) {
-    const userRole = session.value.data.user.role;
-    if (userRole !== "admin") {
-      return { name: "home" };
+  router.beforeEach(async (to: RouteLocationNormalized) => {
+    if (session.value.isPending) {
+      await new Promise((resolve) => {
+        const a = setInterval(() => {
+          if (!session.value.isPending) {
+            clearInterval(a);
+            resolve(true);
+          }
+        }, 50);
+      });
     }
-  }
-});
 
-const DEFAULT_TITLE = "Shopmon";
-router.afterEach(async (to) => {
-  await nextTick();
+    // redirect to the login page if not logged in and trying to access a restricted page
+    const publicPages = [
+      "home",
+      "privacy",
+      "imprint",
+      "account.login",
+      "account.register",
+      "account.confirm",
+      "account.forgot.password",
+      "account.forgot.password.confirm",
+    ];
+    const authRequired = !publicPages.includes(to.name as string);
+    const { setReturnUrl } = useReturnUrl();
 
-  const titleKey = to.meta.titleKey;
-  if (typeof titleKey === "string") {
-    document.title = i18n.global.t(titleKey) + `| ${DEFAULT_TITLE}`;
-    return;
-  }
+    if (authRequired && !session.value.data) {
+      setReturnUrl(to.fullPath);
+      return { name: "account.login" };
+    } else if (to.name === "account.login") {
+      setReturnUrl("/app/dashboard");
+    }
 
-  document.title = DEFAULT_TITLE;
-});
+    // Check admin routes
+    if (to.path.startsWith("/admin") && session.value.data) {
+      const userRole = session.value.data.user.role;
+      if (userRole !== "admin") {
+        return { name: "home" };
+      }
+    }
+  });
+
+  const DEFAULT_TITLE = "Shopmon";
+  router.afterEach(async (to) => {
+    if (typeof document === "undefined") return;
+
+    await nextTick();
+
+    const titleKey = to.meta.titleKey;
+    if (typeof titleKey === "string") {
+      document.title = i18n.global.t(titleKey) + `| ${DEFAULT_TITLE}`;
+      return;
+    }
+
+    document.title = DEFAULT_TITLE;
+  });
+}

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -1,0 +1,286 @@
+import type { RouteRecordRaw } from "vue-router";
+
+import AppLayout from "@/layouts/AppLayout.vue";
+import LoginLayout from "@/layouts/LoginLayout.vue";
+import DefaultLayout from "@/layouts/DefaultLayout.vue";
+import ShopDetailLayout from "@/layouts/ShopDetailLayout.vue";
+import adminRoutes from "@/router/admin";
+
+import FaShop from "~icons/fa6-solid/shop";
+import FaCircleCheck from "~icons/fa6-solid/circle-check";
+import FaFileWaveform from "~icons/fa6-solid/file-waveform";
+import FaListCheck from "~icons/fa6-solid/list-check";
+import FaPlug from "~icons/fa6-solid/plug";
+import FaRocket from "~icons/fa6-solid/rocket";
+import FaCodeBranch from "~icons/fa6-solid/code-branch";
+import Dashboard from "~icons/ri/dashboard-fill";
+import FaFolder from "~icons/fa6-solid/folder";
+import FaBuilding from "~icons/fa6-solid/building";
+import FaBook from "~icons/fa6-solid/book";
+
+export const routes: RouteRecordRaw[] = [
+  {
+    path: "/",
+    component: DefaultLayout,
+    children: [
+      {
+        path: "",
+        name: "home",
+        component: () => import("@/views/Home.vue"),
+      },
+      {
+        path: "privacy",
+        name: "privacy",
+        component: () => import("@/views/Privacy.vue"),
+      },
+      {
+        path: "imprint",
+        name: "imprint",
+        component: () => import("@/views/Imprint.vue"),
+      },
+    ],
+  },
+  {
+    path: "/account",
+    component: LoginLayout,
+    children: [
+      {
+        name: "account.login",
+        path: "login",
+        component: () => import("@/views/auth/Login.vue"),
+      },
+      {
+        name: "account.register",
+        path: "register",
+        component: () => import("@/views/auth/Register.vue"),
+      },
+      {
+        name: "account.confirm",
+        path: "confirm/:token",
+        component: () => import("@/views/auth/AccountConfirm.vue"),
+      },
+      {
+        name: "account.forgot.password",
+        path: "forgot-password",
+        component: () => import("@/views/auth/ForgotPassword.vue"),
+      },
+      {
+        name: "account.forgot.password.confirm",
+        path: "forgot-password/:token",
+        component: () => import("@/views/auth/ForgotPasswordConfirm.vue"),
+      },
+    ],
+  },
+  {
+    path: "/app",
+    component: AppLayout,
+    children: [
+      {
+        path: "dashboard",
+        name: "account.dashboard",
+        component: () => import("@/views/Dashboard.vue"),
+        meta: {
+          titleKey: "nav.dashboard",
+          icon: Dashboard,
+        },
+      },
+      {
+        name: "account.settings",
+        path: "settings",
+        component: () => import("@/views/account/Settings.vue"),
+        meta: {
+          titleKey: "nav.settings",
+          icon: FaShop,
+        },
+      },
+      {
+        name: "account.project.list",
+        path: "projects",
+        component: () => import("@/views/shop/ListProjects.vue"),
+        meta: {
+          titleKey: "nav.myProjects",
+          icon: FaFolder,
+        },
+      },
+      {
+        name: "account.shops.new",
+        path: "shops/new",
+        component: () => import("@/views/shop/AddShop.vue"),
+      },
+      {
+        name: "account.projects.new",
+        path: "projects/new",
+        component: () => import("@/views/shop/AddProject.vue"),
+      },
+      {
+        name: "account.projects.edit",
+        path: "projects/:projectId(\\d+)/edit",
+        component: () => import("@/views/shop/EditProject.vue"),
+        meta: {
+          titleKey: "nav.editProject",
+        },
+      },
+      {
+        name: "account.shops.edit",
+        path: "organizations/:slug/shops/:shopId(\\d+)/edit",
+        component: () => import("@/views/shop/EditShop.vue"),
+      },
+      {
+        path: "organizations/:slug/shops/:shopId(\\d+)",
+        component: ShopDetailLayout,
+        children: [
+          {
+            name: "account.shops.detail",
+            path: "",
+            component: () => import("@/views/shop/detail/DetailShop.vue"),
+            meta: {
+              titleKey: "nav.shopInformation",
+              icon: FaShop,
+            },
+          },
+          {
+            name: "account.shops.detail.checks",
+            path: "checks",
+            component: () => import("@/views/shop/detail/DetailChecks.vue"),
+            meta: {
+              titleKey: "nav.checks",
+              icon: FaCircleCheck,
+            },
+          },
+          {
+            name: "account.shops.detail.extensions",
+            path: "extensions",
+            component: () => import("@/views/shop/detail/DetailExtensions.vue"),
+            meta: {
+              titleKey: "nav.extensions",
+              icon: FaPlug,
+            },
+          },
+          {
+            name: "account.shops.detail.tasks",
+            path: "tasks",
+            component: () => import("@/views/shop/detail/DetailScheduledTasks.vue"),
+            meta: {
+              titleKey: "nav.scheduledTasks",
+              icon: FaListCheck,
+            },
+          },
+          {
+            name: "account.shops.detail.queue",
+            path: "queue",
+            component: () => import("@/views/shop/detail/DetailQueue.vue"),
+            meta: {
+              titleKey: "nav.queue",
+              icon: FaCircleCheck,
+            },
+          },
+          {
+            name: "account.shops.detail.sitespeed",
+            path: "sitespeed",
+            component: () => import("@/views/shop/detail/DetailSitespeed.vue"),
+            meta: {
+              titleKey: "nav.sitespeed",
+              icon: FaRocket,
+            },
+          },
+          {
+            name: "account.shops.detail.changelog",
+            path: "changelog",
+            component: () => import("@/views/shop/detail/DetailChangelog.vue"),
+            meta: {
+              titleKey: "nav.changelog",
+              icon: FaFileWaveform,
+            },
+          },
+          {
+            name: "account.shops.detail.deployments",
+            path: "deployments",
+            component: () => import("@/views/shop/detail/DetailDeployments.vue"),
+            meta: {
+              titleKey: "nav.deployments",
+              icon: FaCodeBranch,
+            },
+          },
+          {
+            name: "account.shops.detail.deployment",
+            path: "deployments/:deploymentId(\\d+)",
+            component: () => import("@/views/shop/detail/DetailDeployment.vue"),
+            meta: {
+              titleKey: "nav.deploymentDetails",
+            },
+          },
+        ],
+      },
+      {
+        name: "account.organizations.list",
+        path: "organizations",
+        component: () => import("@/views/organization/ListOrganizations.vue"),
+        meta: {
+          titleKey: "nav.myOrganizations",
+          icon: FaBuilding,
+        },
+      },
+      {
+        name: "account.organizations.new",
+        path: "organizations/new",
+        component: () => import("@/views/organization/AddOrganization.vue"),
+      },
+      {
+        name: "account.organizations.detail",
+        path: "organizations/:slug",
+        component: () => import("@/views/organization/DetailOrganization.vue"),
+      },
+      {
+        name: "account.organizations.edit",
+        path: "organizations/edit/:slug",
+        component: () => import("@/views/organization/EditOrganization.vue"),
+      },
+      {
+        name: "account.organizations.sso",
+        path: "organizations/:slug/sso",
+        component: () => import("@/views/organization/ManageSSO.vue"),
+      },
+      {
+        name: "account.extension.list",
+        path: "extensions",
+        component: () => import("@/views/account/ListExtensions.vue"),
+        meta: {
+          titleKey: "nav.myExtensions",
+          icon: FaPlug,
+        },
+      },
+      {
+        name: "account.docs",
+        path: "docs",
+        component: () => import("@/views/Docs.vue"),
+        meta: {
+          titleKey: "nav.documentation",
+          icon: FaBook,
+        },
+      },
+      {
+        name: "account.organization.accept",
+        path: "organizations/accept/:token",
+        component: () => import("@/views/organization/AcceptRejectInvitation.vue"),
+        props: {
+          action: "accept",
+        },
+      },
+      {
+        name: "account.organization.reject",
+        path: "organizations/reject/:token",
+        component: () => import("@/views/organization/AcceptRejectInvitation.vue"),
+        props: {
+          action: "reject",
+        },
+      },
+    ],
+  },
+  ...adminRoutes,
+  // catch all redirect to home page
+  {
+    path: "/:pathMatch(.*)*",
+    name: "not-found",
+    redirect: { name: "home" },
+  },
+];

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -42,7 +42,11 @@
     </div>
 
     <div class="col-img">
-      <img :src="getThemeImage('/home/shopmon-dashboard.png')" :alt="$t('home.altDashboard')" />
+      <img
+        :src="getThemeImage('/home/shopmon-dashboard.png')"
+        :alt="$t('home.altDashboard')"
+        fetchpriority="high"
+      />
     </div>
   </div>
 

--- a/frontend/src/views/auth/Register.vue
+++ b/frontend/src/views/auth/Register.vue
@@ -61,12 +61,13 @@ import { Field, Form as VeeForm } from "vee-validate";
 import { useI18n } from "vue-i18n";
 import * as Yup from "yup";
 
-import { router } from "@/router";
+import { useRouter } from "vue-router";
 
 import { useAlert } from "@/composables/useAlert";
 import { authClient } from "@/helpers/auth-client";
 
 const { t } = useI18n();
+const router = useRouter();
 const alert = useAlert();
 
 const schema = Yup.object().shape({

--- a/frontend/vite.config.mjs
+++ b/frontend/vite.config.mjs
@@ -1,10 +1,21 @@
 import { URL, fileURLToPath } from "node:url";
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 import Vue from "@vitejs/plugin-vue";
 import IconsResolver from "unplugin-icons/resolver";
 import Icons from "unplugin-icons/vite";
 import Components from "unplugin-vue-components/vite";
 import { defineConfig } from "vite";
+
+const ssgRoutes = [
+  "/",
+  "/privacy",
+  "/imprint",
+  "/account/login",
+  "/account/register",
+  "/account/forgot-password",
+];
 
 const hmr = {};
 
@@ -27,6 +38,24 @@ export default defineConfig({
       scale: 1,
     }),
   ],
+  ssgOptions: {
+    includedRoutes() {
+      return ssgRoutes;
+    },
+    dirStyle: "nested",
+    onFinished() {
+      const siteUrl = "https://shopmon.fos.gg";
+      const today = new Date().toISOString().split("T")[0];
+      const sitemap = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${ssgRoutes.map((route) => `  <url>\n    <loc>${siteUrl}${route}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`).join("\n")}
+</urlset>`;
+      writeFileSync(resolve("dist", "sitemap.xml"), sitemap);
+    },
+  },
+  ssr: {
+    noExternal: [/vue-i18n/],
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
## Summary
- Pre-renders 6 public routes (home, privacy, imprint, login, register, forgot-password) as static HTML using `vite-ssg` for better SEO and faster initial load
- Generates `sitemap.xml` at build time with all public routes
- Adds SSR guards for browser-only APIs (`localStorage`, `document`, `navigator`) in composables and i18n
- Extracts route definitions into `routes.ts` and wraps router guards in `setupRouterGuards()` so they only run client-side

Backported from 526e52172ba13548865cfae5272ca62d3b304c43, adapted for current codebase (better-auth, tRPC, different route structure).

## Test plan
- [ ] Verify `bun run build` in `frontend/` succeeds and produces pre-rendered HTML in `dist/`
- [ ] Check that `dist/sitemap.xml` is generated with correct URLs
- [ ] Verify pre-rendered pages (e.g. `dist/index.html`, `dist/privacy/index.html`) contain meaningful HTML content
- [ ] Test dev server still works normally (`bun run dev`)
- [ ] Verify client-side navigation and auth flows still work after hydration