### PR TITLE
refactor: handling & display of extension changelogs

### DIFF
--- a/api/internal/api/server.gen.go
+++ b/api/internal/api/server.gen.go
@@ -375,7 +375,6 @@ type ErrorResponse struct {
 // ExtensionChangelogEntry defines model for ExtensionChangelogEntry.
 type ExtensionChangelogEntry struct {
 	CreationDate time.Time `json:"creationDate"`
-	IsCompatible bool      `json:"isCompatible"`
 	Text         string    `json:"text"`
 	Version      string    `json:"version"`
 }

--- a/api/internal/jobs/environment_scrape_changelog_test.go
+++ b/api/internal/jobs/environment_scrape_changelog_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +34,6 @@ func TestExtensionDiffRoundTrip(t *testing.T) {
 					Version:      "5.1.0",
 					Text:         "<p>Fixed a checkout bug</p>",
 					CreationDate: created,
-					IsCompatible: true,
 				},
 			},
 		},
@@ -62,8 +62,85 @@ func TestExtensionDiffRoundTrip(t *testing.T) {
 	entry := (*got.Changelog)[0]
 	assert.Equal(t, "5.1.0", entry.Version)
 	assert.Equal(t, "<p>Fixed a checkout bug</p>", entry.Text)
-	assert.True(t, entry.IsCompatible)
 	assert.True(t, created.Equal(entry.CreationDate))
+}
+
+func TestBuildCompatibleChangelogs(t *testing.T) {
+	mkEntry := func(v string) storeChangelog {
+		cl := storeChangelog{Version: v, Text: "notes " + v}
+		cl.CreationDate.Date = "2024-01-15 08:30:00"
+		return cl
+	}
+
+	sp := &storePlugin{
+		Name:    "AcmeExt",
+		Version: "2.1.0", // latest version compatible with shop's Shopware version
+		Changelogs: []storeChangelog{
+			mkEntry("1.9.0"), // older than installed -> excluded
+			mkEntry("2.0.0"), // == installed       -> excluded
+			mkEntry("2.0.5"), // in range            -> included
+			mkEntry("2.1.0"), // == cap              -> included
+			mkEntry("2.2.0"), // requires newer SW   -> excluded
+			mkEntry("3.0.0"), // requires newer SW   -> excluded
+		},
+	}
+
+	got := buildCompatibleChangelogs(sp, "2.0.0")
+
+	require.Len(t, got, 2)
+	assert.Equal(t, "2.0.5", got[0].Version)
+	assert.Equal(t, "2.1.0", got[1].Version)
+
+	// When installed == sp.Version there's nothing newer compatible.
+	assert.Nil(t, buildCompatibleChangelogs(sp, "2.1.0"))
+}
+
+func TestCalculateExtensionDiffCapsChangelogToNewVersion(t *testing.T) {
+	// Stored changelog at scrape time was capped at the latest compatible
+	// version (2.2.4). Shop actually updates 2.1.0 -> 2.2.1, so the diff
+	// must drop entries above 2.2.1.
+	stored := []extensionChangelog{
+		{Version: "2.1.1", Text: "patch 1"},
+		{Version: "2.2.0", Text: "minor"},
+		{Version: "2.2.1", Text: "target"},
+		{Version: "2.2.2", Text: "above target"},
+		{Version: "2.2.4", Text: "latest compatible"},
+	}
+	raw, err := json.Marshal(stored)
+	require.NoError(t, err)
+
+	old := []queries.EnvironmentExtension{
+		{
+			Name:      "AcmeExt",
+			Label:     "Acme",
+			Active:    true,
+			Version:   "2.1.0",
+			Installed: true,
+			Changelog: raw,
+		},
+	}
+	newExts := []extensionEntry{
+		{
+			Name:      "AcmeExt",
+			Label:     "Acme",
+			Active:    true,
+			Version:   "2.2.1",
+			Installed: true,
+		},
+	}
+
+	diffs := calculateExtensionDiff(old, newExts)
+	require.Len(t, diffs, 1)
+	d := diffs[0]
+	assert.Equal(t, "updated", d.State)
+	require.NotNil(t, d.OldVersion)
+	require.NotNil(t, d.NewVersion)
+	assert.Equal(t, "2.1.0", *d.OldVersion)
+	assert.Equal(t, "2.2.1", *d.NewVersion)
+
+	require.Len(t, d.Changelog, 3)
+	got := []string{d.Changelog[0].Version, d.Changelog[1].Version, d.Changelog[2].Version}
+	assert.Equal(t, []string{"2.1.1", "2.2.0", "2.2.1"}, got)
 }
 
 func TestParseStoreDate(t *testing.T) {

--- a/api/internal/jobs/environment_scrape_types.go
+++ b/api/internal/jobs/environment_scrape_types.go
@@ -93,7 +93,6 @@ type extensionChangelog struct {
 	Version      string    `json:"version"`
 	Text         string    `json:"text"`
 	CreationDate time.Time `json:"creationDate"`
-	IsCompatible bool      `json:"isCompatible"`
 }
 
 type extensionDiff struct {

--- a/api/internal/jobs/environment_scrape_util.go
+++ b/api/internal/jobs/environment_scrape_util.go
@@ -67,35 +67,36 @@ func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extens
 			continue
 		}
 
-		upgradeVersion := extensions[i].LatestVersion
-
 		extensions[i].LatestVersion = strPtr(sp.Version)
 		extensions[i].RatingAverage = &sp.RatingAverage
 
 		storeLink := strings.ReplaceAll(sp.StoreLink, "http://store.shopware.com:80", "https://store.shopware.com")
 		extensions[i].StoreLink = &storeLink
 
-		// Generate changelog for versions newer than installed but within upgrade path
-		if sp.Version != extensions[i].Version {
-			var changelogs []extensionChangelog
-			for _, cl := range sp.Changelogs {
-				if versionCompare(cl.Version, extensions[i].Version) > 0 {
-					if upgradeVersion == nil || versionCompare(cl.Version, *upgradeVersion) <= 0 {
-						isCompatible := versionCompare(cl.Version, *extensions[i].LatestVersion) <= 0
-						changelogs = append(changelogs, extensionChangelog{
-							Version:      cl.Version,
-							Text:         cl.Text,
-							CreationDate: parseStoreDate(cl.CreationDate.Date),
-							IsCompatible: isCompatible,
-						})
-					}
-				}
-			}
-			if len(changelogs) > 0 {
-				extensions[i].Changelog = changelogs
-			}
+		if changelogs := buildCompatibleChangelogs(sp, extensions[i].Version); len(changelogs) > 0 {
+			extensions[i].Changelog = changelogs
 		}
 	}
+}
+
+// buildCompatibleChangelogs returns store changelog entries strictly newer than
+// the installed version and not exceeding sp.Version. sp.Version is the latest
+// extension version the store reports as compatible with the shop's Shopware
+// version (controlled by the shopwareVersion query param to the store API),
+// so capping at it excludes entries that require a newer Shopware.
+func buildCompatibleChangelogs(sp *storePlugin, installedVersion string) []extensionChangelog {
+	var changelogs []extensionChangelog
+	for _, cl := range sp.Changelogs {
+		if versionCompare(cl.Version, installedVersion) > 0 &&
+			versionCompare(cl.Version, sp.Version) <= 0 {
+			changelogs = append(changelogs, extensionChangelog{
+				Version:      cl.Version,
+				Text:         cl.Text,
+				CreationDate: parseStoreDate(cl.CreationDate.Date),
+			})
+		}
+	}
+	return changelogs
 }
 
 // calculateExtensionDiff compares old (from DB) and new (from scrape) extensions.
@@ -134,7 +135,16 @@ func calculateExtensionDiff(oldExtensions []queries.EnvironmentExtension, newExt
 					if state == "updated" && old.Changelog != nil {
 						var cl []extensionChangelog
 						if json.Unmarshal(old.Changelog, &cl) == nil {
-							diff.Changelog = cl
+							// Stored changelog was capped at the latest compatible version
+							// at scrape time, which may be ahead of the version the shop
+							// actually updated to. Keep only entries up to newExt.Version.
+							filtered := cl[:0]
+							for _, entry := range cl {
+								if versionCompare(entry.Version, newExt.Version) <= 0 {
+									filtered = append(filtered, entry)
+								}
+							}
+							diff.Changelog = filtered
 						}
 					}
 					diffs = append(diffs, diff)

--- a/api/openapi/spec.yaml
+++ b/api/openapi/spec.yaml
@@ -2769,7 +2769,6 @@ components:
         - version
         - text
         - creationDate
-        - isCompatible
       properties:
         version:
           type: string
@@ -2778,8 +2777,6 @@ components:
         creationDate:
           type: string
           format: date-time
-        isCompatible:
-          type: boolean
 
     SubscribedEnvironment:
       type: object

--- a/frontend/src/components/modal/ExtensionChangelog.vue
+++ b/frontend/src/components/modal/ExtensionChangelog.vue
@@ -11,10 +11,6 @@
       <ul v-if="changelogEntries.length > 0" class="list-none space-y-6 p-0">
         <li v-for="changeLog in changelogEntries" :key="changeLog.version">
           <div class="mb-2 flex items-center gap-2 font-semibold">
-            <span v-if="!changeLog.isCompatible" :title="$t('extensionChangelog.notCompatible')">
-              <icon-fa6-solid:circle-info class="size-4 text-warning" />
-            </span>
-
             {{ changeLog.version }} -
             <span class="font-normal text-muted-foreground">
               {{ formatDate(changeLog.creationDate) }}

--- a/frontend/src/composables/useExtensionChangelogModal.ts
+++ b/frontend/src/composables/useExtensionChangelogModal.ts
@@ -4,7 +4,6 @@ interface ExtensionChangelog {
   version: string;
   text: string;
   creationDate: string;
-  isCompatible: boolean;
 }
 
 export interface ExtensionWithChangelog {

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -748,8 +748,7 @@
   },
   "extensionChangelog": {
     "title": "Änderungsprotokoll",
-    "noData": "Keine Änderungsprotokolldaten vorhanden",
-    "notCompatible": "nicht kompatibel mit Ihrer Version"
+    "noData": "Keine Änderungsprotokolldaten vorhanden"
   },
   "updateWizard": {
     "title": "Shopware Erweiterungs-Kompatibilitätsprüfung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -748,8 +748,7 @@
   },
   "extensionChangelog": {
     "title": "Changelog",
-    "noData": "No Changelog data provided",
-    "notCompatible": "not compatible with your version"
+    "noData": "No Changelog data provided"
   },
   "updateWizard": {
     "title": "Shopware Extension Compatibility Check",

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1651,7 +1651,6 @@ export interface components {
       text: string;
       /** Format: date-time */
       creationDate: string;
-      isCompatible: boolean;
     };
     SubscribedEnvironment: {
       id: number;

--- a/frontend/src/types/shop.ts
+++ b/frontend/src/types/shop.ts
@@ -12,7 +12,6 @@ export interface ExtensionChangelog {
   version: string;
   text: string;
   creationDate: string;
-  isCompatible: boolean;
 }
 
 export interface ShopChangelog {


### PR DESCRIPTION
### Backend / API

- Drop isCompatible from ExtensionChangelogEntry in server.gen.go, from extensionChangelog in environment_scrape_types.go, and from the OpenAPI spec in spec.yaml.
- Rewrite the changelog builder in environment_scrape_util.go so it returns only entries that are strictly newer than the installed version and no higher than the latest compatible version. No flag needed once the      
filter is the source of truth.
- Fix calculateExtensionDiff to cap the stored changelog at the new version when an update is detected, so the diff doesn't include entries for versions the shop never installed.

### Frontend

- Drop the isCompatible property from the TypeScript types, the changelog Vue components, and the translation files. No more dead warning row.

### Tests

- Added tests in environment_scrape_changelog_test.go covering the new filter and the diff-cap behavior.