### PR TITLE
fix: deeplink extension environments to extensions tab

### DIFF
--- a/frontend/src/views/account/ListExtensions.vue
+++ b/frontend/src/views/account/ListExtensions.vue
@@ -134,7 +134,7 @@
                 v-for="env in ext.environments"
                 :key="env.environmentId"
                 :to="{
-                  name: 'account.environments.detail',
+                  name: 'account.environments.detail.extensions',
                   params: {
                     organizationId: env.environmentOrganizationId,
                     environmentId: env.environmentId,


### PR DESCRIPTION
## Summary

Fixes #661.

In the **My Extensions** list, expanding an extension shows the environments where it's installed. Each environment linked to the shop detail **overview** page; this changes the deeplink to the shop detail's **Extensions tab** for better UX.

## Change

`frontend/src/views/account/ListExtensions.vue` — the environment `RouterLink` now targets the existing `account.environments.detail.extensions` route (same params) instead of `account.environments.detail`.

## Verification

Tested locally (logged in via seeded `owner@fos.gg`):
- Expanded panel links now render as `/app/environments/{id}/extensions`.
- Clicking one lands directly on the shop's **Extensions** tab (breadcrumb `… › Production › Extensions`, Extensions tab active).