### PR TITLE
fix: close mobile sidebar on navigation

### DIFF
--- a/frontend/src/components/layout/MobileSidebarAutoClose.vue
+++ b/frontend/src/components/layout/MobileSidebarAutoClose.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { watch } from "vue";
+import { useRoute } from "vue-router";
+import { useSidebar } from "@/components/ui/sidebar";
+
+const route = useRoute();
+const { isMobile, openMobile, setOpenMobile } = useSidebar();
+
+// Close the mobile sidebar sheet whenever the route changes, otherwise it
+// stays open over the freshly navigated page. See #659.
+watch(
+  () => route.fullPath,
+  () => {
+    if (isMobile.value && openMobile.value) {
+      setOpenMobile(false);
+    }
+  },
+);
+</script>
+
+<template>
+  <span class="hidden" aria-hidden="true" />
+</template>

--- a/frontend/src/components/layout/MobileSidebarAutoClose.vue
+++ b/frontend/src/components/layout/MobileSidebarAutoClose.vue
@@ -18,6 +18,4 @@ watch(
 );
 </script>
 
-<template>
-  <span class="hidden" aria-hidden="true" />
-</template>
+<template></template>

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -1,5 +1,6 @@
 <template>
   <SidebarProvider>
+    <MobileSidebarAutoClose />
     <Sidebar collapsible="icon">
       <!-- Logo + brand -->
       <SidebarHeader class="border-b">
@@ -261,6 +262,7 @@ import ImpersonationBanner from "@/components/ImpersonationBanner.vue";
 import Notification from "@/components/Notification.vue";
 import LayoutFooter from "@/components/layout/LayoutFooter.vue";
 import OrganizationSwitcher from "@/components/layout/OrganizationSwitcher.vue";
+import MobileSidebarAutoClose from "@/components/layout/MobileSidebarAutoClose.vue";
 import StatusIcon from "@/components/StatusIcon.vue";
 import Logo from "@/components/Logo.vue";
 


### PR DESCRIPTION
## Summary

Fixes #659.

On mobile, opening the navigation sheet and then navigating (e.g. to a shop) changed the page in the background but left the sidebar open, forcing a manual close.

## Change

- New `MobileSidebarAutoClose.vue` helper rendered inside `SidebarProvider`. It uses `useSidebar()` and watches the route, calling `setOpenMobile(false)` on change (only when mobile + open).
- Wired into `AppLayout.vue`.

A separate child component is needed because `useSidebar()` injects context provided by `SidebarProvider`, so it can't be called in `AppLayout`'s own setup (the provider's parent).

## Verification

Tested locally at 390×844 (logged in as seeded `owner@fos.gg`):
- Open mobile menu → click **My Shops**: navigates and the sheet auto-closes.
- Open mobile menu → click a shop link (`/app/environments/1`): navigates and the sheet auto-closes.

`oxlint` and `vue-tsc --noEmit` both pass.