### PR TITLE
fix: extension list update button — pointer cursor + translation

### DIFF
--- a/frontend/src/views/account/ListExtensions.vue
+++ b/frontend/src/views/account/ListExtensions.vue
@@ -98,7 +98,7 @@
                   class="cursor-pointer text-xs text-warning hover:underline"
                   @click="openExtensionChangelog(ext)"
                 >
-                  update available
+                  {{ $t("shopDetail.updateAvailable") }}
                 </button>
               </template>
             </div>

--- a/frontend/src/views/account/ListExtensions.vue
+++ b/frontend/src/views/account/ListExtensions.vue
@@ -95,7 +95,7 @@
               }}</Badge>
               <template v-if="hasUpdate(ext)">
                 <button
-                  class="text-xs text-warning hover:underline"
+                  class="cursor-pointer text-xs text-warning hover:underline"
                   @click="openExtensionChangelog(ext)"
                 >
                   update available
@@ -110,7 +110,7 @@
 
             <!-- Expand -->
             <button
-              class="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent"
+              class="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-md text-muted-foreground hover:bg-accent"
               @click="toggle(ext.name)"
             >
               <icon-fa6-solid:chevron-down


### PR DESCRIPTION
## Summary

Fixes #662 and #660 (both touch the "update available" button in the **My Extensions** list).

## Changes

### Pointer cursor (#662, #660)
Tailwind v4's Preflight resets `<button>` to `cursor: default` (a change from v3). The shadcn `Button` component compensates with `cursor-pointer`, but the raw `<button>` elements in `ListExtensions.vue` did not. Added `cursor-pointer` to:
- the expand chevron button
- the "update available" button

### Translation (#660)
The "update available" label was a hardcoded English string, so it stayed English even in German. Now uses the existing `shopDetail.updateAvailable` i18n key (`Update verfügbar` in German).

## Verification

Tested locally (logged in as seeded `owner@fos.gg`):
- All extension-list buttons compute `cursor: pointer` (previously `default`).
- In German the update button renders **"Update verfügbar"**; in English **"Update available"**.

`oxlint` and `oxfmt --check` pass.