### PR TITLE
fix: add pointer cursor to list filter buttons

### DIFF
--- a/frontend/src/components/FilterSearchBar.vue
+++ b/frontend/src/components/FilterSearchBar.vue
@@ -17,7 +17,7 @@ const search = defineModel<string>("search", { required: true });
         v-for="f in filters"
         :key="f.value"
         :class="[
-          'flex-1 rounded-md px-3 py-1 text-sm font-medium transition-colors sm:flex-none',
+          'flex-1 cursor-pointer rounded-md px-3 py-1 text-sm font-medium transition-colors sm:flex-none',
           filter === f.value
             ? 'bg-background text-foreground shadow-sm'
             : 'text-muted-foreground hover:text-foreground',


### PR DESCRIPTION
## Summary

Fixes #664.

The list filter pills (e.g. **All / Active / Inactive / Updates** in a shop's extension list) showed no pointer cursor on hover.

## Root cause

Tailwind v4's Preflight resets `<button>` to `cursor: default` (a change from v3). The filter buttons in the shared `FilterSearchBar` component were missing `cursor-pointer`.

## Change

Added `cursor-pointer` to the filter button in `FilterSearchBar.vue`. This component is shared, so the fix also covers the **Scheduled tasks** filters (`All / Healthy / Overdue / Inactive`).

## Verification

Tested locally (logged in as seeded `owner@fos.gg`):
- Extension list filters now compute `cursor: pointer` (previously `default`).
- Scheduled tasks filters likewise.

`oxlint` and `oxfmt --check` pass.