### PR TITLE
fix: add pointer cursor to changelog expand rows

### DIFF
--- a/frontend/src/views/environment/detail/DetailChangelog.vue
+++ b/frontend/src/views/environment/detail/DetailChangelog.vue
@@ -19,7 +19,7 @@
       >
         <!-- Header row — always visible -->
         <button
-          class="flex w-full items-start gap-4 px-4 py-3 text-left sm:items-center"
+          class="flex w-full cursor-pointer items-start gap-4 px-4 py-3 text-left sm:items-center"
           @click="toggle(entry.id)"
         >
           <!-- Date -->


### PR DESCRIPTION
## Summary

Fixes #665.

The expandable rows in the shop detail **Changelog** list showed no pointer cursor on hover.

## Root cause

Tailwind v4's Preflight resets `<button>` to `cursor: default` (a change from v3). The changelog entry header buttons in `DetailChangelog.vue` were missing `cursor-pointer`.

## Change

Added `cursor-pointer` to the changelog entry header button.

## Verification

Tested locally (logged in as seeded `owner@fos.gg`): all changelog entry headers now compute `cursor: pointer` (previously `default`), and expand/collapse still works.

`oxlint` and `oxfmt --check` pass.