### PR TITLE
fix: add pointer cursor to overview extension version link

### DIFF
--- a/frontend/src/views/environment/detail/DetailEnvironment.vue
+++ b/frontend/src/views/environment/detail/DetailEnvironment.vue
@@ -155,7 +155,7 @@
             <div class="min-w-0 flex-1 text-sm">
               <span class="font-medium">{{ ext.label }}</span>
               <button
-                class="ml-1 text-primary hover:underline"
+                class="ml-1 cursor-pointer text-primary hover:underline"
                 @click="openExtensionChangelog(ext)"
               >
                 {{ ext.version }} → {{ ext.latestVersion }}


### PR DESCRIPTION
## Summary

Fixes #663.

The "update version" link (`current → latest`) in the shop detail **overview** extension card showed no pointer cursor on hover.

## Root cause

Tailwind v4's Preflight resets `<button>` to `cursor: default` (a change from v3). The version `<button>` in `DetailEnvironment.vue` was missing `cursor-pointer`. Same recurring class as #662 / #660 / #664 / #665.

## Change

Added `cursor-pointer` to the version button.

## Verification

`oxlint` and `oxfmt --check` pass. Not verified in a live browser this session (Chrome DevTools MCP was unavailable), but the fix is identical in shape to #662/#664/#665, which were each verified live to flip the computed cursor from `default` to `pointer`.