### PR TITLE
feat: refresh shop data after a deployment with configurable delay

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -167,6 +167,12 @@ Required only if you use the deployment tracking feature.
 | `APP_S3_BUCKET` | `shopmon` | Bucket name |
 | `APP_S3_REGION` | `auto` | Region |
 
+### Deployments
+
+| Variable | Default | Description |
+|---|---|---|
+| `DEPLOYMENT_SCRAPE_DELAY` | `5m` | How long to wait after a deployment is recorded before re-scraping the environment. Accepts a Go duration (e.g. `30s`, `5m`, `2m30s`). Gives post-deploy tasks (theme compile, indexing, cache warming) time to settle. Set to `0` to scrape immediately. |
+
 ### Observability (OpenTelemetry)
 
 | Variable | Default | Description |

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/joho/godotenv"
 )
@@ -40,6 +41,11 @@ type Config struct {
 	PackagesAPIToken string
 
 	DisableRegistration bool
+
+	// DeploymentScrapeDelay is how long to wait after a CLI deployment is
+	// recorded before re-scraping the environment, giving post-deploy tasks
+	// (theme compile, indexing, cache warming) time to settle.
+	DeploymentScrapeDelay time.Duration
 
 	ShopwareAPIURL      string
 	ShopwareVersionsURL string
@@ -106,6 +112,17 @@ func Load() *Config {
 
 		ListenAddr:     getEnv("LISTEN_ADDR", ":8080"),
 		TrustedProxies: parseCommaList(getEnv("TRUSTED_PROXIES", "")),
+	}
+
+	// Parse the post-deployment scrape delay, falling back to 5m on an
+	// empty or invalid value.
+	cfg.DeploymentScrapeDelay = 5 * time.Minute
+	if raw := getEnv("DEPLOYMENT_SCRAPE_DELAY", ""); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d >= 0 {
+			cfg.DeploymentScrapeDelay = d
+		} else {
+			slog.Warn("invalid DEPLOYMENT_SCRAPE_DELAY, using default", "value", raw, "default", cfg.DeploymentScrapeDelay)
+		}
 	}
 
 	// Derive WebAuthn config from FrontendURL

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentScrapeDelay(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want time.Duration
+	}{
+		{name: "default when unset", env: "", want: 5 * time.Minute},
+		{name: "custom duration", env: "2m", want: 2 * time.Minute},
+		{name: "zero disables delay", env: "0s", want: 0},
+		{name: "invalid falls back to default", env: "not-a-duration", want: 5 * time.Minute},
+		{name: "negative falls back to default", env: "-1m", want: 5 * time.Minute},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.env == "" {
+				t.Setenv("DEPLOYMENT_SCRAPE_DELAY", "")
+			} else {
+				t.Setenv("DEPLOYMENT_SCRAPE_DELAY", tt.env)
+			}
+
+			cfg := Load()
+			assert.Equal(t, tt.want, cfg.DeploymentScrapeDelay)
+		})
+	}
+}

--- a/api/internal/handler/deployment.go
+++ b/api/internal/handler/deployment.go
@@ -13,7 +13,9 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+	"github.com/friendsofshopware/shopmon/api/internal/jobs"
 	"github.com/jackc/pgx/v5/pgtype"
+	goqueue "github.com/shyim/go-queue"
 )
 
 // isS3NotFound reports whether err indicates the requested S3 object does not
@@ -273,6 +275,14 @@ func (h *Handler) CreateCliDeployment(w http.ResponseWriter, r *http.Request) {
 		ActiveDeploymentID: &deployID,
 		ID:                 int32(req.EnvironmentId),
 	})
+
+	// Refresh the shop data after the deployment so Shopmon reflects the new
+	// state. The scrape is delayed to give post-deploy tasks (theme compile,
+	// indexing, cache warming) time to settle; the delay is configurable via
+	// DEPLOYMENT_SCRAPE_DELAY.
+	if err := goqueue.Dispatch(r.Context(), h.bus, jobs.EnvironmentScrape{EnvironmentID: int32(req.EnvironmentId)}, goqueue.WithDelay(h.cfg.DeploymentScrapeDelay)); err != nil {
+		slog.Error("failed to enqueue post-deployment scrape", "environmentId", req.EnvironmentId, "error", err)
+	}
 
 	// Get presigned upload URL from S3
 	var uploadURL string


### PR DESCRIPTION
## Summary

Closes #611.

After a deployment is recorded via the CLI endpoint (`POST /cli/deployments`), Shopmon now automatically re-scrapes the environment so the shop information reflects the new state. The scrape is **delayed** to give post-deploy tasks (theme compilation, indexing, cache warming) time to settle.

## Implementation

- **`CreateCliDeployment`** (`api/internal/handler/deployment.go`): after the deployment row + active-deployment pointer are persisted, dispatches `jobs.EnvironmentScrape` via the existing queue with `goqueue.WithDelay(cfg.DeploymentScrapeDelay)`. Dispatch failures are logged, not surfaced — the deployment record still succeeds.
- **Config** (`api/internal/config/config.go`): new `DeploymentScrapeDelay time.Duration`, parsed from `DEPLOYMENT_SCRAPE_DELAY` (Go duration string, e.g. `5m`, `30s`, `2m30s`). Defaults to **5m**; invalid or negative values fall back to the default with a warning. Set to `0` to scrape immediately.
- **Docs** (`SELF_HOSTING.md`): documents the new env var.

No API schema / payload change — the trigger is implicit, so shopmon-cli needs no changes. The delay is operator-configurable server-side.

## Tests

- `config_test.go`: covers default, custom, zero, invalid, and negative `DEPLOYMENT_SCRAPE_DELAY` values.
- Existing `TestCreateCliDeployment` passes with the new dispatch path (test harness's noop transport accepts the enqueue).

`go build ./...`, `gofmt`, `go vet`, and `go test ./internal/{config,handler,jobs}/` all pass.