### PR TITLE
Fix internal server error when deleting the default environment

### DIFF
--- a/api/internal/api/server.gen.go
+++ b/api/internal/api/server.gen.go
@@ -150,7 +150,7 @@ type AccountOrganization struct {
 
 // AccountShop defines model for AccountShop.
 type AccountShop struct {
-	DefaultEnvironmentId int     `json:"defaultEnvironmentId"`
+	DefaultEnvironmentId *int    `json:"defaultEnvironmentId"`
 	Description          *string `json:"description"`
 	GitUrl               *string `json:"gitUrl"`
 	Id                   int     `json:"id"`
@@ -486,7 +486,7 @@ type ScheduledTask struct {
 
 // Shop defines model for Shop.
 type Shop struct {
-	DefaultEnvironmentId int     `json:"defaultEnvironmentId"`
+	DefaultEnvironmentId *int    `json:"defaultEnvironmentId"`
 	Description          *string `json:"description"`
 	GitUrl               *string `json:"gitUrl"`
 	Id                   int     `json:"id"`

--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -752,6 +752,23 @@ func (q *Queries) ListEnvironmentsByOrganization(ctx context.Context, organizati
 	return items, nil
 }
 
+const reassignShopDefaultEnvironment = `-- name: ReassignShopDefaultEnvironment :exec
+UPDATE shop SET default_environment_id = (
+    SELECT e.id FROM environment e
+    WHERE e.shop_id = shop.id AND e.id != $1
+    ORDER BY e.id LIMIT 1
+), updated_at = NOW()
+WHERE default_environment_id = $1
+`
+
+// Before deleting an environment, move any shop that uses it as its default to
+// another environment of the same shop (lowest id), or NULL if none remain. This
+// avoids violating the RESTRICT foreign key shop.default_environment_id -> environment.
+func (q *Queries) ReassignShopDefaultEnvironment(ctx context.Context, id int32) error {
+	_, err := q.db.Exec(ctx, reassignShopDefaultEnvironment, id)
+	return err
+}
+
 const updateEnvironment = `-- name: UpdateEnvironment :exec
 UPDATE environment SET name = $1, url = $2, client_id = $3, client_secret = $4, ignores = $5, shop_id = $6 WHERE id = $7
 `

--- a/api/internal/handler/account.go
+++ b/api/internal/handler/account.go
@@ -242,7 +242,7 @@ func (h *Handler) GetAccountShops(w http.ResponseWriter, r *http.Request) {
 		result = append(result, api.AccountShop{
 			Id: int(row.ID), Name: row.Name, Description: row.Description,
 			GitUrl: row.GitUrl, OrganizationId: row.OrganizationID, OrganizationName: row.OrganizationName,
-			DefaultEnvironmentId: derefInt32(row.DefaultEnvironmentID),
+			DefaultEnvironmentId: int32PtrToIntPtr(row.DefaultEnvironmentID),
 		})
 	}
 

--- a/api/internal/handler/environment.go
+++ b/api/internal/handler/environment.go
@@ -168,7 +168,15 @@ func (h *Handler) DeleteEnvironment(w http.ResponseWriter, r *http.Request, envi
 		}
 	}
 
-	if err := h.queries.DeleteEnvironment(r.Context(), int32(environmentId)); err != nil {
+	// Reassigning the shop's default environment and deleting the environment must
+	// be atomic: the shop.default_environment_id foreign key uses ON DELETE RESTRICT,
+	// so the environment cannot be removed while any shop still points at it.
+	if err := h.withTx(r.Context(), func(txq *queries.Queries) error {
+		if err := txq.ReassignShopDefaultEnvironment(r.Context(), int32(environmentId)); err != nil {
+			return err
+		}
+		return txq.DeleteEnvironment(r.Context(), int32(environmentId))
+	}); err != nil {
 		httputil.WriteErrorAuto(w, err)
 		return
 	}

--- a/api/internal/handler/environment_test.go
+++ b/api/internal/handler/environment_test.go
@@ -126,6 +126,62 @@ func TestDeleteEnvironment(t *testing.T) {
 	assert.True(t, resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusForbidden)
 }
 
+// TestDeleteDefaultEnvironment_Reassigns covers the case from issue #702: deleting an
+// environment that is its shop's default must not fail on the RESTRICT foreign key. The
+// shop's default is moved to another environment of the same shop.
+func TestDeleteDefaultEnvironment_Reassigns(t *testing.T) {
+	env := testutil.Setup(t)
+	token := env.SeedUser(t, "user-1", "Test User", "test@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Test Org", "test-org", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Test Shop")
+	// First environment becomes the shop default.
+	defaultEnvID := env.SeedEnvironment(t, "org-1", shopID, "Default", "https://default.example.com")
+	otherEnvID := env.SeedEnvironment(t, "org-1", shopID, "Other", "https://other.example.com")
+
+	var currentDefault int
+	require.NoError(t, env.Pool.QueryRow(t.Context(),
+		`SELECT default_environment_id FROM shop WHERE id = $1`, shopID).Scan(&currentDefault))
+	require.Equal(t, defaultEnvID, currentDefault)
+
+	req := testutil.NewRequest(t, "DELETE", fmt.Sprintf("%s/api/environments/%d", env.Server.URL, defaultEnvID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	// The shop default is reassigned to the remaining environment.
+	require.NoError(t, env.Pool.QueryRow(t.Context(),
+		`SELECT default_environment_id FROM shop WHERE id = $1`, shopID).Scan(&currentDefault))
+	assert.Equal(t, otherEnvID, currentDefault)
+}
+
+// TestDeleteLastEnvironment_ClearsDefault covers deleting the only environment of a shop:
+// the shop's default is cleared to NULL instead of violating the RESTRICT foreign key.
+func TestDeleteLastEnvironment_ClearsDefault(t *testing.T) {
+	env := testutil.Setup(t)
+	token := env.SeedUser(t, "user-1", "Test User", "test@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Test Org", "test-org", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Test Shop")
+	environmentID := env.SeedEnvironment(t, "org-1", shopID, "Only", "https://only.example.com")
+
+	req := testutil.NewRequest(t, "DELETE", fmt.Sprintf("%s/api/environments/%d", env.Server.URL, environmentID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	var defaultEnvID *int
+	require.NoError(t, env.Pool.QueryRow(t.Context(),
+		`SELECT default_environment_id FROM shop WHERE id = $1`, shopID).Scan(&defaultEnvID))
+	assert.Nil(t, defaultEnvID)
+}
+
 func TestGetEnvironmentSubscription(t *testing.T) {
 	env := testutil.Setup(t)
 	token := env.SeedUser(t, "user-1", "Test User", "test@example.com", "user")

--- a/api/internal/handler/environment_test.go
+++ b/api/internal/handler/environment_test.go
@@ -180,6 +180,19 @@ func TestDeleteLastEnvironment_ClearsDefault(t *testing.T) {
 	require.NoError(t, env.Pool.QueryRow(t.Context(),
 		`SELECT default_environment_id FROM shop WHERE id = $1`, shopID).Scan(&defaultEnvID))
 	assert.Nil(t, defaultEnvID)
+
+	// The API must expose the missing default as null rather than coercing it to a
+	// bogus environment id of 0, which would render broken links in the shop lists.
+	shopsReq := testutil.NewRequest(t, "GET", env.Server.URL+"/api/account/shops", nil)
+	shopsReq.Header.Set("Authorization", "Bearer "+token)
+	shopsResp, err := http.DefaultClient.Do(shopsReq)
+	require.NoError(t, err)
+	defer func() { _ = shopsResp.Body.Close() }()
+
+	var shops []api.AccountShop
+	require.NoError(t, json.NewDecoder(shopsResp.Body).Decode(&shops))
+	require.Len(t, shops, 1)
+	assert.Nil(t, shops[0].DefaultEnvironmentId)
 }
 
 func TestGetEnvironmentSubscription(t *testing.T) {

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -163,11 +163,15 @@ func (h *Handler) loadAuthorizedEnvironmentCredentials(w http.ResponseWriter, r 
 	return &creds, true
 }
 
-func derefInt32(v *int32) int {
+// int32PtrToIntPtr converts a nullable database int32 into a nullable int,
+// preserving nil so a shop without a default environment serializes as JSON null
+// instead of a misleading environment id of 0.
+func int32PtrToIntPtr(v *int32) *int {
 	if v == nil {
-		return 0
+		return nil
 	}
-	return int(*v)
+	i := int(*v)
+	return &i
 }
 
 func (h *Handler) requireShopInOrganization(w http.ResponseWriter, r *http.Request, shopID int32, orgID string) bool {

--- a/api/internal/handler/shop.go
+++ b/api/internal/handler/shop.go
@@ -35,7 +35,7 @@ func (h *Handler) GetOrganizationShops(w http.ResponseWriter, r *http.Request, o
 			Description:          row.Description,
 			GitUrl:               row.GitUrl,
 			OrganizationId:       row.OrganizationID,
-			DefaultEnvironmentId: derefInt32(row.DefaultEnvironmentID),
+			DefaultEnvironmentId: int32PtrToIntPtr(row.DefaultEnvironmentID),
 		})
 	}
 
@@ -124,7 +124,7 @@ func (h *Handler) CreateShop(w http.ResponseWriter, r *http.Request, orgId api.O
 		Description:          req.Description,
 		GitUrl:               req.GitUrl,
 		OrganizationId:       orgId,
-		DefaultEnvironmentId: int(environmentID),
+		DefaultEnvironmentId: int32PtrToIntPtr(&environmentID),
 	})
 }
 

--- a/api/openapi/spec.yaml
+++ b/api/openapi/spec.yaml
@@ -2693,6 +2693,7 @@ components:
           type: string
         defaultEnvironmentId:
           type: integer
+          nullable: true
 
     AccountChangelog:
       type: object
@@ -3190,6 +3191,7 @@ components:
           type: string
         defaultEnvironmentId:
           type: integer
+          nullable: true
 
     CreateShopRequest:
       type: object

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -27,6 +27,17 @@ UPDATE environment SET name = $1, url = $2, client_id = $3, client_secret = $4, 
 -- name: UpdateEnvironmentName :exec
 UPDATE environment SET name = $1 WHERE id = $2;
 
+-- name: ReassignShopDefaultEnvironment :exec
+-- Before deleting an environment, move any shop that uses it as its default to
+-- another environment of the same shop (lowest id), or NULL if none remain. This
+-- avoids violating the RESTRICT foreign key shop.default_environment_id -> environment.
+UPDATE shop SET default_environment_id = (
+    SELECT e.id FROM environment e
+    WHERE e.shop_id = shop.id AND e.id != $1
+    ORDER BY e.id LIMIT 1
+), updated_at = NOW()
+WHERE default_environment_id = $1;
+
 -- name: DeleteEnvironment :exec
 DELETE FROM environment WHERE id = $1;
 

--- a/api/sql/schema.sql
+++ b/api/sql/schema.sql
@@ -170,6 +170,13 @@ CREATE TABLE "environment" (
 ALTER TABLE "deployment" ADD CONSTRAINT fk_deployment_environment
   FOREIGN KEY ("environment_id") REFERENCES "environment"("id") ON DELETE cascade;
 
+-- shop.default_environment_id references environment with ON DELETE RESTRICT, so an
+-- environment that is still a shop's default cannot be deleted. The application moves
+-- the default to another environment of the shop (or NULL) before deleting. Defined
+-- here via ALTER because shop is created before environment to resolve the cycle.
+ALTER TABLE "shop" ADD CONSTRAINT shop_default_environment_id_fkey
+  FOREIGN KEY ("default_environment_id") REFERENCES "environment"("id") ON DELETE RESTRICT;
+
 CREATE TABLE "environment_sitespeed" (
   "id" serial PRIMARY KEY NOT NULL,
   "environment_id" integer REFERENCES "environment"("id") ON DELETE cascade,

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -55,12 +55,7 @@
             <SidebarMenu>
               <SidebarMenuItem v-for="shop in shops" :key="shop.id">
                 <SidebarMenuButton as-child>
-                  <RouterLink
-                    :to="{
-                      name: 'account.environments.detail',
-                      params: { environmentId: shop.defaultEnvironmentId },
-                    }"
-                  >
+                  <RouterLink :to="shopLink(shop)">
                     <img
                       v-if="defaultEnvFavicon(shop)"
                       :src="defaultEnvFavicon(shop)!"
@@ -323,6 +318,18 @@ function loadShops() {
 }
 loadShops();
 watch(activeOrganizationId, () => loadShops());
+
+function shopLink(shop: AccountShop) {
+  // A shop without a default environment (e.g. its last environment was deleted)
+  // has nowhere to point an environment link, so send the user to the shop itself.
+  if (shop.defaultEnvironmentId == null) {
+    return { name: "account.shops.edit", params: { shopId: shop.id } };
+  }
+  return {
+    name: "account.environments.detail",
+    params: { environmentId: shop.defaultEnvironmentId },
+  };
+}
 
 function defaultEnvFavicon(shop: AccountShop): string | null {
   return environments.value.find((e) => e.id === shop.defaultEnvironmentId)?.favicon ?? null;

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1641,7 +1641,7 @@ export interface components {
       gitUrl: string | null;
       organizationId: string;
       organizationName: string;
-      defaultEnvironmentId: number;
+      defaultEnvironmentId: number | null;
     };
     AccountChangelog: {
       id: number;
@@ -1806,7 +1806,7 @@ export interface components {
       description: string | null;
       gitUrl: string | null;
       organizationId: string;
-      defaultEnvironmentId: number;
+      defaultEnvironmentId: number | null;
     };
     CreateShopRequest: {
       name: string;

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -296,6 +296,11 @@ function envCount(shop: AccountShop): number {
 }
 
 function shopLink(shop: AccountShop) {
+  // A shop without a default environment (e.g. its last environment was deleted)
+  // has nowhere to point an environment link, so send the user to the shop itself.
+  if (shop.defaultEnvironmentId == null) {
+    return { name: "account.shops.edit", params: { shopId: shop.id } };
+  }
   return {
     name: "account.environments.detail",
     params: { environmentId: shop.defaultEnvironmentId },

--- a/frontend/src/views/shop/ListShops.vue
+++ b/frontend/src/views/shop/ListShops.vue
@@ -112,6 +112,11 @@ function envCount(shop: AccountShop): number {
 }
 
 function shopLink(shop: AccountShop) {
+  // A shop without a default environment (e.g. its last environment was deleted)
+  // has nowhere to point an environment link, so send the user to the shop itself.
+  if (shop.defaultEnvironmentId == null) {
+    return { name: "account.shops.edit", params: { shopId: shop.id } };
+  }
   return {
     name: "account.environments.detail",
     params: { environmentId: shop.defaultEnvironmentId },


### PR DESCRIPTION
Deleting an environment that was a shop's default failed with a 500 because
shop.default_environment_id references environment with ON DELETE RESTRICT.

DeleteEnvironment now reassigns the shop's default to another environment of
the same shop (or NULL when none remain) in the same transaction as the
delete, so the RESTRICT constraint is never violated.

The RESTRICT foreign key existed only in migration 000006 and was missing
from sql/schema.sql, so tests (which build from schema.sql) never exercised
it. Add the constraint to schema.sql and cover both reassignment and
last-environment cases.

Fixes #702

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014kjZmqmzSY2WSx5LqzShwr