### PR TITLE
fix: render sitespeed charts when opening the tab

### DIFF
--- a/api/fixtures.go
+++ b/api/fixtures.go
@@ -301,6 +301,12 @@ func (s *seeder) seedShopAndEnvironments(org orgFixture) (int32, []int32, error)
 		if err != nil {
 			return 0, nil, fmt.Errorf("create environment %s: %w", ed.name, err)
 		}
+		// Enable sitespeed so the seeded sitespeed samples are actually shown in
+		// the UI; CreateEnvironment leaves sitespeed_enabled at its false default.
+		if _, err := s.pool.Exec(s.ctx, `UPDATE environment SET sitespeed_enabled = true WHERE id = $1`, envID); err != nil {
+			slog.Error("failed to enable sitespeed", "environmentId", envID, "error", err)
+		}
+
 		environmentIDs = append(environmentIDs, envID)
 		slog.Info("created environment", "name", ed.name, "id", envID, "url", envURL)
 	}

--- a/frontend/e2e/environment-detail.spec.ts
+++ b/frontend/e2e/environment-detail.spec.ts
@@ -38,4 +38,60 @@ test.describe("environment detail tabs", () => {
     await expect(page.getByRole("link", { name: "Storefront" })).toBeVisible();
     await expect(page.getByRole("link", { name: "Admin" })).toBeVisible();
   });
+
+  // Charts are drawn on a <canvas> by Chart.js, which only renders correctly once
+  // the canvas has been laid out. This regressed when switching to the tab: the
+  // canvas stayed blank until a full reload. Assert the charts actually paint
+  // when navigating in via the tab bar (the broken path).
+  test("Sitespeed tab renders charts when navigated to via the tab bar", async ({ page }) => {
+    await page.getByRole("link", { name: /^Sitespeed/ }).click();
+    await expect(page).toHaveURL(new RegExp(`${BASE}/sitespeed`));
+
+    // The "not enabled" alert must not be shown — the fixture enables sitespeed.
+    const canvases = page.locator("canvas");
+    await expect(canvases.first()).toBeVisible();
+
+    // Three charts: performance over time, transfer size, CLS.
+    await expect(canvases).toHaveCount(3);
+
+    // The bug renders the chart chrome (axes, gridlines, legend) but never draws
+    // the data series, so the canvas isn't blank — checking for "any non-blank
+    // pixel" gives a false pass. The data series are saturated colours (blue,
+    // pink, orange, yellow) while the axes/gridlines are near-grey, so assert
+    // there are coloured pixels inside the plot area. Poll because Chart.js
+    // draws on the animation frame after layout.
+    for (let i = 0; i < 3; i++) {
+      // Note: don't scrollIntoView here — that triggers a Chart.js resize which
+      // restarts the entry animation, so a read right after catches a half-drawn
+      // frame. The poll below tolerates animation; getImageData works off-screen.
+      await expect
+        .poll(
+          () =>
+            canvases.nth(i).evaluate((el) => {
+              const canvas = el as HTMLCanvasElement;
+              if (!canvas.width || !canvas.height) return 0;
+              const ctx = canvas.getContext("2d", { willReadFrequently: true });
+              if (!ctx) return 0;
+              const { data, width, height } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+              // Restrict to the plot area so the coloured legend swatches at the
+              // top don't count — they're present even when the data is missing.
+              const top = Math.floor(height * 0.25);
+              let coloured = 0;
+              for (let y = top; y < height; y++) {
+                for (let x = 0; x < width; x++) {
+                  const o = (y * width + x) * 4;
+                  const [r, g, b, a] = [data[o], data[o + 1], data[o + 2], data[o + 3]];
+                  if (a === 0) continue;
+                  // Saturated == max channel clearly exceeds min channel. Grey
+                  // axes/gridlines/text have r≈g≈b and are filtered out.
+                  if (Math.max(r, g, b) - Math.min(r, g, b) > 40) coloured++;
+                }
+              }
+              return coloured;
+            }),
+          { message: `canvas ${i} should have its data series drawn`, timeout: 5000 },
+        )
+        .toBeGreaterThan(20);
+    }
+  });
 });

--- a/frontend/src/views/environment/detail/DetailSitespeed.vue
+++ b/frontend/src/views/environment/detail/DetailSitespeed.vue
@@ -437,6 +437,9 @@ function createChart(config: ChartConfig) {
     options: {
       responsive: true,
       maintainAspectRatio: false,
+      // Draw synchronously: the entry animation could leave the data series
+      // unpainted when the chart was created just before layout settled.
+      animation: false,
       interaction: { mode: "index", intersect: false },
       plugins: {
         annotation: { annotations },
@@ -469,10 +472,29 @@ function createAllCharts() {
   chartConfigs.forEach((c) => createChart(c));
 }
 
-onMounted(async () => {
+// Recreate the charts once the canvases are actually laid out. On a tab switch
+// the environment data is already loaded, so the data watch below never fires and
+// onMounted alone can run before the v-if'd canvases have a measured size. If a
+// chart is created before layout settles, Chart.js paints the axes but the data
+// series never appears (the bug this view had: blank charts until a reload).
+// Waiting for the canvas to report a real size before creating avoids that.
+async function renderCharts() {
+  if (!showSitespeedData.value) return;
   await nextTick();
-  if (environment.value?.sitespeeds) createAllCharts();
-});
+
+  const waitForLayout = (attempt = 0) => {
+    const el = timeChartCanvas.value;
+    // The canvas reports 0 until its parent (h-72/h-56) is laid out.
+    if (el && el.clientWidth > 0 && el.clientHeight > 0) {
+      createAllCharts();
+    } else if (attempt < 30) {
+      requestAnimationFrame(() => waitForLayout(attempt + 1));
+    }
+  };
+  requestAnimationFrame(() => waitForLayout());
+}
+
+onMounted(renderCharts);
 
 onUnmounted(() => {
   chartConfigs.forEach((c) => c.chartInstance.value?.destroy());
@@ -480,10 +502,7 @@ onUnmounted(() => {
 
 watch(
   () => environment.value?.sitespeeds,
-  async () => {
-    await nextTick();
-    createAllCharts();
-  },
+  () => void renderCharts(),
   { deep: true },
 );
 </script>


### PR DESCRIPTION
## Problem

On the environment **Sitespeed** tab, the charts rendered their chrome (axes, gridlines, legend) but the **data series stayed blank** when switching to the tab. Selecting the tab and reloading the page fixed it.

## Root cause

Chart.js' entry **animation**. On the fast tab-switch path (data already loaded, no full mount delay) the chart was created right as layout settled, and the animation left the data series unpainted. A full reload was slow enough for the animation to complete — which is why reloading "fixed" it.

## Changes

- **`DetailSitespeed.vue`**
  - Disable chart `animation` so the data series draws synchronously and deterministically.
  - Wait (via rAF) for the canvas to report a real laid-out size before creating the chart; run on both `onMounted` (tab switch) and the `sitespeeds` watch (reload/refresh).
- **`api/fixtures.go`** — set `sitespeed_enabled = true` on seeded environments; it defaulted to `false`, so the tab only ever showed the "not enabled" alert and never exercised the charts.
- **`environment-detail.spec.ts`** — new e2e regression test asserting each chart canvas actually paints data-series (colored) pixels in the plot area when reached via the tab bar.

## Verification

- New test fails 3/3 without the fix (`Received: 0` colored pixels) and passes 3/3 with it.
- Full e2e suite green (30 passed); typecheck clean.

> Note: disabling animation is a deliberate trade-off — charts now appear instantly without the grow-in. Given they're monitoring charts and the animation caused the bug, this seems right; happy to keep animation + force a post-settle redraw instead if preferred.