### PR TITLE
fix(jobs): parse Shopware queue size sent as string

### DIFF
--- a/api/internal/jobs/environment_scrape.go
+++ b/api/internal/jobs/environment_scrape.go
@@ -228,7 +228,7 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 	var queueEntries []shopwareQueueEntry
 	if fr.queueErr == nil {
 		if err := json.Unmarshal(fr.queueData, &queueEntries); err != nil {
-			slog.Warn("failed to parse queue data", "environmentId", env.ID, "error", err)
+			slog.Error("failed to parse queue data", "environmentId", env.ID, "error", err)
 		}
 	}
 
@@ -288,9 +288,13 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 
 	checkerQueues := make([]checker.QueueInfo, len(queueEntries))
 	for i, q := range queueEntries {
+		size, err := q.Size.Int64()
+		if err != nil {
+			slog.Error("failed to parse queue size", "environmentId", env.ID, "queue", q.Name, "size", q.Size.String(), "error", err)
+		}
 		checkerQueues[i] = checker.QueueInfo{
 			Name: q.Name,
-			Size: int(q.Size),
+			Size: int(size),
 		}
 	}
 
@@ -429,10 +433,11 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 	queueNames := make([]string, 0, len(queueEntries))
 	for _, q := range queueEntries {
 		queueNames = append(queueNames, q.Name)
+		size, _ := q.Size.Int64()
 		if err := txQueries.UpsertEnvironmentQueue(ctx, queries.UpsertEnvironmentQueueParams{
 			EnvironmentID: env.ID,
 			Name:          q.Name,
-			Size:          q.Size,
+			Size:          int32(size),
 		}); err != nil {
 			persistSpan.RecordError(err)
 			persistSpan.SetStatus(codes.Error, err.Error())

--- a/api/internal/jobs/environment_scrape_types.go
+++ b/api/internal/jobs/environment_scrape_types.go
@@ -1,6 +1,9 @@
 package jobs
 
-import "time"
+import (
+	"encoding/json"
+	"time"
+)
 
 // ---- Shopware API response types ----
 
@@ -38,8 +41,8 @@ type shopwareSearchResponse[T any] struct {
 }
 
 type shopwareQueueEntry struct {
-	Name string `json:"name"`
-	Size int32  `json:"size"`
+	Name string      `json:"name"`
+	Size json.Number `json:"size"`
 }
 
 type shopwareScheduledTask struct {


### PR DESCRIPTION
## Problem

The environment scrape was logging a warning every cycle:

```
WARN failed to parse queue data
exception.message: json: cannot unmarshal string into Go struct field shopwareQueueEntry.size of type int32
```

Shopware's `/_info/queue.json` returns the queue `size` as a **string** (e.g. `"42"`), but `shopwareQueueEntry.Size` was typed `int32`. As a result `json.Unmarshal` failed and the **entire queue payload was dropped** — so the health checker silently ran with empty queue data and would not detect a backed-up queue.

## Changes

- `shopwareQueueEntry.Size` → `json.Number`, so both `42` and `"42"` parse correctly.
- Convert via `.Int64()` at the two consumers (checker input + DB upsert).
- Promote the parse-failure logs from `Warn` → `Error`, since a parse failure means queue health checks run blind — that's a visibility gap, not benign noise.

## Why Error, not Warn

Queue data feeds the health checker. A silent parse failure means a real "queue is backed up" condition goes undetected, so it should be loud. The known string-`size` case is now fixed, so in practice this error should no longer fire — it now only triggers on genuinely unexpected payloads.