### PR TITLE
Normalize Shopware store extensions into shared catalog

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/shyim/go-mailer/middleware/otelmw v0.1.0
 	github.com/shyim/go-mailer/transport/smtp v0.1.0
 	github.com/shyim/go-queue v0.0.0-20260606124220-e2aa789807c9
+	github.com/shyim/go-version v0.0.0-20260602054622-2f4aa95a0358
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.43.0

--- a/api/go.sum
+++ b/api/go.sum
@@ -262,6 +262,8 @@ github.com/shyim/go-mailer/transport/smtp v0.1.0 h1:WIVDl2TZ+yGPT63kF+CgtP9R5RS0
 github.com/shyim/go-mailer/transport/smtp v0.1.0/go.mod h1:0zhAZAudCho2eNmqCd3JXXu7oQ+MVLuwvMMHlpiAvAo=
 github.com/shyim/go-queue v0.0.0-20260606124220-e2aa789807c9 h1:8ypmSyLMJUO53fqLAmNKwO8lhyJnMCqTsj6GHLLUI0E=
 github.com/shyim/go-queue v0.0.0-20260606124220-e2aa789807c9/go.mod h1:fzclyVXELfyyBh6oX+apcYdduL/nHbzeBcMkAJbo0UA=
+github.com/shyim/go-version v0.0.0-20260602054622-2f4aa95a0358 h1:lynQeFLRGGzEbgqNmxXBSK+omBl56QsKcHwRVxIOqSw=
+github.com/shyim/go-version v0.0.0-20260602054622-2f4aa95a0358/go.mod h1:BlGslYZMvN2D5rVZhaXBGoJfIEMdJe2QXGwFByxAyV4=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=

--- a/api/internal/api/server.gen.go
+++ b/api/internal/api/server.gen.go
@@ -536,8 +536,13 @@ type ErrorResponse struct {
 // ExtensionChangelogEntry defines model for ExtensionChangelogEntry.
 type ExtensionChangelogEntry struct {
 	CreationDate time.Time `json:"creationDate"`
-	Text         string    `json:"text"`
-	Version      string    `json:"version"`
+
+	// Text Changelog text in English (en_GB).
+	Text string `json:"text"`
+
+	// TextDe Changelog text in German (de_DE), when available.
+	TextDe  *string `json:"textDe,omitempty"`
+	Version string  `json:"version"`
 }
 
 // ExtensionCompatibilityRequest defines model for ExtensionCompatibilityRequest.

--- a/api/internal/database/queries/admin.sql.go
+++ b/api/internal/database/queries/admin.sql.go
@@ -129,9 +129,16 @@ func (q *Queries) AdminGetEnvironmentDetail(ctx context.Context, id int32) (Admi
 }
 
 const adminGetEnvironmentExtensions = `-- name: AdminGetEnvironmentExtensions :many
-SELECT id, name, label, active, version, latest_version, installed, store_link
-FROM environment_extension
-WHERE environment_id = $1
+SELECT ese.id, ese.extension_name AS name, ese.label, ese.active, ese.version,
+       ese.latest_version, ese.installed, se.store_link
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+WHERE ese.environment_id = $1
+UNION ALL
+SELECT ee.id, ee.name, ee.label, ee.active, ee.version,
+       ee.latest_version, ee.installed, NULL::text AS store_link
+FROM environment_extension ee
+WHERE ee.environment_id = $1
 ORDER BY name
 `
 

--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -116,6 +116,34 @@ func (q *Queries) DeleteEnvironmentScheduledTasksNotIn(ctx context.Context, arg 
 	return err
 }
 
+const deleteEnvironmentStoreExtensionsNotIn = `-- name: DeleteEnvironmentStoreExtensionsNotIn :exec
+DELETE FROM environment_store_extension WHERE environment_id = $1 AND extension_name != ALL($2::text[])
+`
+
+type DeleteEnvironmentStoreExtensionsNotInParams struct {
+	EnvironmentID int32    `json:"environment_id"`
+	Column2       []string `json:"column_2"`
+}
+
+func (q *Queries) DeleteEnvironmentStoreExtensionsNotIn(ctx context.Context, arg DeleteEnvironmentStoreExtensionsNotInParams) error {
+	_, err := q.db.Exec(ctx, deleteEnvironmentStoreExtensionsNotIn, arg.EnvironmentID, arg.Column2)
+	return err
+}
+
+const deleteStoreExtensionImagesNotIn = `-- name: DeleteStoreExtensionImagesNotIn :exec
+DELETE FROM store_extension_image WHERE extension_name = $1 AND url != ALL($2::text[])
+`
+
+type DeleteStoreExtensionImagesNotInParams struct {
+	ExtensionName string   `json:"extension_name"`
+	Column2       []string `json:"column_2"`
+}
+
+func (q *Queries) DeleteStoreExtensionImagesNotIn(ctx context.Context, arg DeleteStoreExtensionImagesNotInParams) error {
+	_, err := q.db.Exec(ctx, deleteStoreExtensionImagesNotIn, arg.ExtensionName, arg.Column2)
+	return err
+}
+
 const getAllEnvironments = `-- name: GetAllEnvironments :many
 SELECT e.id, e.name, e.url, e.client_id, e.client_secret, e.shopware_version,
        e.organization_id, e.ignores, e.last_scraped_at, e.last_scraped_error,
@@ -349,10 +377,12 @@ func (q *Queries) GetEnvironmentCredentials(ctx context.Context, id int32) (GetE
 }
 
 const getEnvironmentExtensions = `-- name: GetEnvironmentExtensions :many
-SELECT id, environment_id, name, label, active, version, latest_version, installed, rating_average, store_link, changelog, installed_at
+SELECT id, environment_id, name, label, active, version, latest_version, installed, installed_at
 FROM environment_extension WHERE environment_id = $1 ORDER BY name
 `
 
+// Extensions unknown to the Shopware store (everything else lives in the
+// normalized store_extension* tables, linked via environment_store_extension).
 func (q *Queries) GetEnvironmentExtensions(ctx context.Context, environmentID int32) ([]EnvironmentExtension, error) {
 	rows, err := q.db.Query(ctx, getEnvironmentExtensions, environmentID)
 	if err != nil {
@@ -371,9 +401,6 @@ func (q *Queries) GetEnvironmentExtensions(ctx context.Context, environmentID in
 			&i.Version,
 			&i.LatestVersion,
 			&i.Installed,
-			&i.RatingAverage,
-			&i.StoreLink,
-			&i.Changelog,
 			&i.InstalledAt,
 		); err != nil {
 			return nil, err
@@ -560,6 +587,155 @@ func (q *Queries) GetEnvironmentSitespeeds(ctx context.Context, environmentID *i
 			&i.FirstContentfulPaint,
 			&i.CumulativeLayoutShift,
 			&i.TransferSize,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getEnvironmentStoreExtensionChangelogs = `-- name: GetEnvironmentStoreExtensionChangelogs :many
+SELECT sev.extension_name, sev.version, sev.changelog_en, sev.changelog_de, sev.released_at
+FROM store_extension_version sev
+JOIN environment_store_extension ese ON ese.extension_name = sev.extension_name
+WHERE ese.environment_id = $1
+ORDER BY sev.extension_name, sev.version
+`
+
+type GetEnvironmentStoreExtensionChangelogsRow struct {
+	ExtensionName string  `json:"extension_name"`
+	Version       string  `json:"version"`
+	ChangelogEn   *string `json:"changelog_en"`
+	ChangelogDe   *string `json:"changelog_de"`
+	ReleasedAt    *string `json:"released_at"`
+}
+
+func (q *Queries) GetEnvironmentStoreExtensionChangelogs(ctx context.Context, environmentID int32) ([]GetEnvironmentStoreExtensionChangelogsRow, error) {
+	rows, err := q.db.Query(ctx, getEnvironmentStoreExtensionChangelogs, environmentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetEnvironmentStoreExtensionChangelogsRow{}
+	for rows.Next() {
+		var i GetEnvironmentStoreExtensionChangelogsRow
+		if err := rows.Scan(
+			&i.ExtensionName,
+			&i.Version,
+			&i.ChangelogEn,
+			&i.ChangelogDe,
+			&i.ReleasedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getEnvironmentStoreExtensionImages = `-- name: GetEnvironmentStoreExtensionImages :many
+SELECT sei.extension_name, sei.url, sei.preview, sei.priority
+FROM store_extension_image sei
+JOIN environment_store_extension ese ON ese.extension_name = sei.extension_name
+WHERE ese.environment_id = $1
+ORDER BY sei.extension_name, sei.priority DESC
+`
+
+type GetEnvironmentStoreExtensionImagesRow struct {
+	ExtensionName string `json:"extension_name"`
+	Url           string `json:"url"`
+	Preview       bool   `json:"preview"`
+	Priority      int32  `json:"priority"`
+}
+
+func (q *Queries) GetEnvironmentStoreExtensionImages(ctx context.Context, environmentID int32) ([]GetEnvironmentStoreExtensionImagesRow, error) {
+	rows, err := q.db.Query(ctx, getEnvironmentStoreExtensionImages, environmentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetEnvironmentStoreExtensionImagesRow{}
+	for rows.Next() {
+		var i GetEnvironmentStoreExtensionImagesRow
+		if err := rows.Scan(
+			&i.ExtensionName,
+			&i.Url,
+			&i.Preview,
+			&i.Priority,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getEnvironmentStoreExtensions = `-- name: GetEnvironmentStoreExtensions :many
+SELECT ese.id, ese.environment_id, ese.extension_name, ese.label, ese.active, ese.version,
+       ese.latest_version, ese.installed, ese.installed_at,
+       se.store_link, se.rating_average, se.icon_url,
+       se.label_en, se.label_de, se.short_description_en, se.short_description_de
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+WHERE ese.environment_id = $1
+ORDER BY ese.extension_name
+`
+
+type GetEnvironmentStoreExtensionsRow struct {
+	ID                 int32   `json:"id"`
+	EnvironmentID      int32   `json:"environment_id"`
+	ExtensionName      string  `json:"extension_name"`
+	Label              string  `json:"label"`
+	Active             bool    `json:"active"`
+	Version            string  `json:"version"`
+	LatestVersion      *string `json:"latest_version"`
+	Installed          bool    `json:"installed"`
+	InstalledAt        *string `json:"installed_at"`
+	StoreLink          *string `json:"store_link"`
+	RatingAverage      *int32  `json:"rating_average"`
+	IconUrl            *string `json:"icon_url"`
+	LabelEn            *string `json:"label_en"`
+	LabelDe            *string `json:"label_de"`
+	ShortDescriptionEn *string `json:"short_description_en"`
+	ShortDescriptionDe *string `json:"short_description_de"`
+}
+
+func (q *Queries) GetEnvironmentStoreExtensions(ctx context.Context, environmentID int32) ([]GetEnvironmentStoreExtensionsRow, error) {
+	rows, err := q.db.Query(ctx, getEnvironmentStoreExtensions, environmentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetEnvironmentStoreExtensionsRow{}
+	for rows.Next() {
+		var i GetEnvironmentStoreExtensionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.EnvironmentID,
+			&i.ExtensionName,
+			&i.Label,
+			&i.Active,
+			&i.Version,
+			&i.LatestVersion,
+			&i.Installed,
+			&i.InstalledAt,
+			&i.StoreLink,
+			&i.RatingAverage,
+			&i.IconUrl,
+			&i.LabelEn,
+			&i.LabelDe,
+			&i.ShortDescriptionEn,
+			&i.ShortDescriptionDe,
 		); err != nil {
 			return nil, err
 		}
@@ -920,9 +1096,9 @@ func (q *Queries) UpsertEnvironmentCache(ctx context.Context, arg UpsertEnvironm
 }
 
 const upsertEnvironmentExtension = `-- name: UpsertEnvironmentExtension :exec
-INSERT INTO environment_extension (environment_id, name, label, active, version, latest_version, installed, rating_average, store_link, changelog, installed_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-ON CONFLICT (environment_id, name) DO UPDATE SET label = $3, active = $4, version = $5, latest_version = $6, installed = $7, rating_average = $8, store_link = $9, changelog = $10, installed_at = $11
+INSERT INTO environment_extension (environment_id, name, label, active, version, latest_version, installed, installed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (environment_id, name) DO UPDATE SET label = $3, active = $4, version = $5, latest_version = $6, installed = $7, installed_at = $8
 `
 
 type UpsertEnvironmentExtensionParams struct {
@@ -933,9 +1109,6 @@ type UpsertEnvironmentExtensionParams struct {
 	Version       string  `json:"version"`
 	LatestVersion *string `json:"latest_version"`
 	Installed     bool    `json:"installed"`
-	RatingAverage *int32  `json:"rating_average"`
-	StoreLink     *string `json:"store_link"`
-	Changelog     []byte  `json:"changelog"`
 	InstalledAt   *string `json:"installed_at"`
 }
 
@@ -948,9 +1121,6 @@ func (q *Queries) UpsertEnvironmentExtension(ctx context.Context, arg UpsertEnvi
 		arg.Version,
 		arg.LatestVersion,
 		arg.Installed,
-		arg.RatingAverage,
-		arg.StoreLink,
-		arg.Changelog,
 		arg.InstalledAt,
 	)
 	return err
@@ -999,6 +1169,145 @@ func (q *Queries) UpsertEnvironmentScheduledTask(ctx context.Context, arg Upsert
 		arg.Overdue,
 		arg.LastExecutionTime,
 		arg.NextExecutionTime,
+	)
+	return err
+}
+
+const upsertEnvironmentStoreExtension = `-- name: UpsertEnvironmentStoreExtension :exec
+INSERT INTO environment_store_extension (environment_id, extension_name, label, version, latest_version, active, installed, installed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (environment_id, extension_name) DO UPDATE SET
+  label = $3, version = $4, latest_version = $5, active = $6, installed = $7, installed_at = $8
+`
+
+type UpsertEnvironmentStoreExtensionParams struct {
+	EnvironmentID int32   `json:"environment_id"`
+	ExtensionName string  `json:"extension_name"`
+	Label         string  `json:"label"`
+	Version       string  `json:"version"`
+	LatestVersion *string `json:"latest_version"`
+	Active        bool    `json:"active"`
+	Installed     bool    `json:"installed"`
+	InstalledAt   *string `json:"installed_at"`
+}
+
+func (q *Queries) UpsertEnvironmentStoreExtension(ctx context.Context, arg UpsertEnvironmentStoreExtensionParams) error {
+	_, err := q.db.Exec(ctx, upsertEnvironmentStoreExtension,
+		arg.EnvironmentID,
+		arg.ExtensionName,
+		arg.Label,
+		arg.Version,
+		arg.LatestVersion,
+		arg.Active,
+		arg.Installed,
+		arg.InstalledAt,
+	)
+	return err
+}
+
+const upsertStoreExtension = `-- name: UpsertStoreExtension :exec
+INSERT INTO store_extension (
+  name, store_id, icon_url, producer_name, producer_website, rating_average, store_link,
+  release_date, label_en, label_de, short_description_en, short_description_de,
+  description_en, description_de, installation_manual_en, installation_manual_de,
+  latest_version, last_refreshed_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
+ON CONFLICT (name) DO UPDATE SET
+  store_id = $2, icon_url = $3, producer_name = $4, producer_website = $5, rating_average = $6,
+  store_link = $7, release_date = $8, label_en = $9, label_de = $10,
+  short_description_en = $11, short_description_de = $12, description_en = $13, description_de = $14,
+  installation_manual_en = $15, installation_manual_de = $16, latest_version = $17,
+  last_refreshed_at = NOW()
+`
+
+type UpsertStoreExtensionParams struct {
+	Name                 string  `json:"name"`
+	StoreID              *int32  `json:"store_id"`
+	IconUrl              *string `json:"icon_url"`
+	ProducerName         *string `json:"producer_name"`
+	ProducerWebsite      *string `json:"producer_website"`
+	RatingAverage        *int32  `json:"rating_average"`
+	StoreLink            *string `json:"store_link"`
+	ReleaseDate          *string `json:"release_date"`
+	LabelEn              *string `json:"label_en"`
+	LabelDe              *string `json:"label_de"`
+	ShortDescriptionEn   *string `json:"short_description_en"`
+	ShortDescriptionDe   *string `json:"short_description_de"`
+	DescriptionEn        *string `json:"description_en"`
+	DescriptionDe        *string `json:"description_de"`
+	InstallationManualEn *string `json:"installation_manual_en"`
+	InstallationManualDe *string `json:"installation_manual_de"`
+	LatestVersion        *string `json:"latest_version"`
+}
+
+func (q *Queries) UpsertStoreExtension(ctx context.Context, arg UpsertStoreExtensionParams) error {
+	_, err := q.db.Exec(ctx, upsertStoreExtension,
+		arg.Name,
+		arg.StoreID,
+		arg.IconUrl,
+		arg.ProducerName,
+		arg.ProducerWebsite,
+		arg.RatingAverage,
+		arg.StoreLink,
+		arg.ReleaseDate,
+		arg.LabelEn,
+		arg.LabelDe,
+		arg.ShortDescriptionEn,
+		arg.ShortDescriptionDe,
+		arg.DescriptionEn,
+		arg.DescriptionDe,
+		arg.InstallationManualEn,
+		arg.InstallationManualDe,
+		arg.LatestVersion,
+	)
+	return err
+}
+
+const upsertStoreExtensionImage = `-- name: UpsertStoreExtensionImage :exec
+INSERT INTO store_extension_image (extension_name, url, preview, priority)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (extension_name, url) DO UPDATE SET preview = $3, priority = $4
+`
+
+type UpsertStoreExtensionImageParams struct {
+	ExtensionName string `json:"extension_name"`
+	Url           string `json:"url"`
+	Preview       bool   `json:"preview"`
+	Priority      int32  `json:"priority"`
+}
+
+func (q *Queries) UpsertStoreExtensionImage(ctx context.Context, arg UpsertStoreExtensionImageParams) error {
+	_, err := q.db.Exec(ctx, upsertStoreExtensionImage,
+		arg.ExtensionName,
+		arg.Url,
+		arg.Preview,
+		arg.Priority,
+	)
+	return err
+}
+
+const upsertStoreExtensionVersion = `-- name: UpsertStoreExtensionVersion :exec
+INSERT INTO store_extension_version (extension_name, version, changelog_en, changelog_de, released_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (extension_name, version) DO UPDATE SET
+  changelog_en = $3, changelog_de = $4, released_at = $5
+`
+
+type UpsertStoreExtensionVersionParams struct {
+	ExtensionName string  `json:"extension_name"`
+	Version       string  `json:"version"`
+	ChangelogEn   *string `json:"changelog_en"`
+	ChangelogDe   *string `json:"changelog_de"`
+	ReleasedAt    *string `json:"released_at"`
+}
+
+func (q *Queries) UpsertStoreExtensionVersion(ctx context.Context, arg UpsertStoreExtensionVersionParams) error {
+	_, err := q.db.Exec(ctx, upsertStoreExtensionVersion,
+		arg.ExtensionName,
+		arg.Version,
+		arg.ChangelogEn,
+		arg.ChangelogDe,
+		arg.ReleasedAt,
 	)
 	return err
 }

--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -1214,9 +1214,16 @@ INSERT INTO store_extension (
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
 ON CONFLICT (name) DO UPDATE SET
   store_id = $2, icon_url = $3, producer_name = $4, producer_website = $5, rating_average = $6,
-  store_link = $7, release_date = $8, label_en = $9, label_de = $10,
-  short_description_en = $11, short_description_de = $12, description_en = $13, description_de = $14,
-  installation_manual_en = $15, installation_manual_de = $16, latest_version = $17,
+  store_link = $7, release_date = $8,
+  label_en = COALESCE($9, store_extension.label_en),
+  label_de = COALESCE($10, store_extension.label_de),
+  short_description_en = COALESCE($11, store_extension.short_description_en),
+  short_description_de = COALESCE($12, store_extension.short_description_de),
+  description_en = COALESCE($13, store_extension.description_en),
+  description_de = COALESCE($14, store_extension.description_de),
+  installation_manual_en = COALESCE($15, store_extension.installation_manual_en),
+  installation_manual_de = COALESCE($16, store_extension.installation_manual_de),
+  latest_version = $17,
   last_refreshed_at = NOW()
 `
 
@@ -1240,6 +1247,8 @@ type UpsertStoreExtensionParams struct {
 	LatestVersion        *string `json:"latest_version"`
 }
 
+// Localized text fields use COALESCE so a failed locale fetch (NULL value) does
+// not erase the previously stored translation.
 func (q *Queries) UpsertStoreExtension(ctx context.Context, arg UpsertStoreExtensionParams) error {
 	_, err := q.db.Exec(ctx, upsertStoreExtension,
 		arg.Name,
@@ -1290,7 +1299,9 @@ const upsertStoreExtensionVersion = `-- name: UpsertStoreExtensionVersion :exec
 INSERT INTO store_extension_version (extension_name, version, changelog_en, changelog_de, released_at)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (extension_name, version) DO UPDATE SET
-  changelog_en = $3, changelog_de = $4, released_at = $5
+  changelog_en = COALESCE($3, store_extension_version.changelog_en),
+  changelog_de = COALESCE($4, store_extension_version.changelog_de),
+  released_at = COALESCE($5, store_extension_version.released_at)
 `
 
 type UpsertStoreExtensionVersionParams struct {
@@ -1301,6 +1312,9 @@ type UpsertStoreExtensionVersionParams struct {
 	ReleasedAt    *string `json:"released_at"`
 }
 
+// COALESCE keeps the existing per-language changelog text and date when a locale
+// fetch fails (NULL), so a transient single-locale store outage does not erase a
+// previously stored translation.
 func (q *Queries) UpsertStoreExtensionVersion(ctx context.Context, arg UpsertStoreExtensionVersionParams) error {
 	_, err := q.db.Exec(ctx, upsertStoreExtensionVersion,
 		arg.ExtensionName,

--- a/api/internal/database/queries/models.go
+++ b/api/internal/database/queries/models.go
@@ -110,9 +110,6 @@ type EnvironmentExtension struct {
 	Version       string  `json:"version"`
 	LatestVersion *string `json:"latest_version"`
 	Installed     bool    `json:"installed"`
-	RatingAverage *int32  `json:"rating_average"`
-	StoreLink     *string `json:"store_link"`
-	Changelog     []byte  `json:"changelog"`
 	InstalledAt   *string `json:"installed_at"`
 }
 
@@ -146,6 +143,18 @@ type EnvironmentSitespeed struct {
 	FirstContentfulPaint   *int32           `json:"first_contentful_paint"`
 	CumulativeLayoutShift  *float32         `json:"cumulative_layout_shift"`
 	TransferSize           *int32           `json:"transfer_size"`
+}
+
+type EnvironmentStoreExtension struct {
+	ID            int32   `json:"id"`
+	EnvironmentID int32   `json:"environment_id"`
+	ExtensionName string  `json:"extension_name"`
+	Label         string  `json:"label"`
+	Version       string  `json:"version"`
+	LatestVersion *string `json:"latest_version"`
+	Active        bool    `json:"active"`
+	Installed     bool    `json:"installed"`
+	InstalledAt   *string `json:"installed_at"`
 }
 
 type Invitation struct {
@@ -236,6 +245,44 @@ type SsoProvider struct {
 	ProviderID     string  `json:"provider_id"`
 	OrganizationID *string `json:"organization_id"`
 	Domain         string  `json:"domain"`
+}
+
+type StoreExtension struct {
+	Name                 string           `json:"name"`
+	StoreID              *int32           `json:"store_id"`
+	IconUrl              *string          `json:"icon_url"`
+	ProducerName         *string          `json:"producer_name"`
+	ProducerWebsite      *string          `json:"producer_website"`
+	RatingAverage        *int32           `json:"rating_average"`
+	StoreLink            *string          `json:"store_link"`
+	ReleaseDate          *string          `json:"release_date"`
+	LabelEn              *string          `json:"label_en"`
+	LabelDe              *string          `json:"label_de"`
+	ShortDescriptionEn   *string          `json:"short_description_en"`
+	ShortDescriptionDe   *string          `json:"short_description_de"`
+	DescriptionEn        *string          `json:"description_en"`
+	DescriptionDe        *string          `json:"description_de"`
+	InstallationManualEn *string          `json:"installation_manual_en"`
+	InstallationManualDe *string          `json:"installation_manual_de"`
+	LatestVersion        *string          `json:"latest_version"`
+	LastRefreshedAt      pgtype.Timestamp `json:"last_refreshed_at"`
+}
+
+type StoreExtensionImage struct {
+	ID            int32  `json:"id"`
+	ExtensionName string `json:"extension_name"`
+	Url           string `json:"url"`
+	Preview       bool   `json:"preview"`
+	Priority      int32  `json:"priority"`
+}
+
+type StoreExtensionVersion struct {
+	ID            int32   `json:"id"`
+	ExtensionName string  `json:"extension_name"`
+	Version       string  `json:"version"`
+	ChangelogEn   *string `json:"changelog_en"`
+	ChangelogDe   *string `json:"changelog_de"`
+	ReleasedAt    *string `json:"released_at"`
 }
 
 type User struct {

--- a/api/internal/database/queries/user.sql.go
+++ b/api/internal/database/queries/user.sql.go
@@ -330,143 +330,6 @@ func (q *Queries) GetUserEnvironmentsByOrg(ctx context.Context, arg GetUserEnvir
 	return items, nil
 }
 
-const getUserExtensions = `-- name: GetUserExtensions :many
-SELECT ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed,
-       ee.store_link, ee.rating_average, ee.installed_at, ee.changelog,
-       ee.environment_id, e.name AS environment_name, e.url AS environment_url, o.name AS environment_organization_name, e.organization_id AS environment_organization_id
-FROM environment_extension ee
-JOIN environment e ON e.id = ee.environment_id
-JOIN organization o ON o.id = e.organization_id
-JOIN member m ON m.organization_id = e.organization_id
-WHERE m.user_id = $1
-ORDER BY ee.name, e.name
-`
-
-type GetUserExtensionsRow struct {
-	Name                        string  `json:"name"`
-	Label                       string  `json:"label"`
-	Version                     string  `json:"version"`
-	LatestVersion               *string `json:"latest_version"`
-	Active                      bool    `json:"active"`
-	Installed                   bool    `json:"installed"`
-	StoreLink                   *string `json:"store_link"`
-	RatingAverage               *int32  `json:"rating_average"`
-	InstalledAt                 *string `json:"installed_at"`
-	Changelog                   []byte  `json:"changelog"`
-	EnvironmentID               int32   `json:"environment_id"`
-	EnvironmentName             string  `json:"environment_name"`
-	EnvironmentUrl              string  `json:"environment_url"`
-	EnvironmentOrganizationName string  `json:"environment_organization_name"`
-	EnvironmentOrganizationID   string  `json:"environment_organization_id"`
-}
-
-func (q *Queries) GetUserExtensions(ctx context.Context, userID string) ([]GetUserExtensionsRow, error) {
-	rows, err := q.db.Query(ctx, getUserExtensions, userID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []GetUserExtensionsRow{}
-	for rows.Next() {
-		var i GetUserExtensionsRow
-		if err := rows.Scan(
-			&i.Name,
-			&i.Label,
-			&i.Version,
-			&i.LatestVersion,
-			&i.Active,
-			&i.Installed,
-			&i.StoreLink,
-			&i.RatingAverage,
-			&i.InstalledAt,
-			&i.Changelog,
-			&i.EnvironmentID,
-			&i.EnvironmentName,
-			&i.EnvironmentUrl,
-			&i.EnvironmentOrganizationName,
-			&i.EnvironmentOrganizationID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getUserExtensionsByOrg = `-- name: GetUserExtensionsByOrg :many
-SELECT ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed,
-       ee.store_link, ee.rating_average, ee.installed_at, ee.changelog,
-       ee.environment_id, e.name AS environment_name, e.url AS environment_url, o.name AS environment_organization_name, e.organization_id AS environment_organization_id
-FROM environment_extension ee
-JOIN environment e ON e.id = ee.environment_id
-JOIN organization o ON o.id = e.organization_id
-JOIN member m ON m.organization_id = e.organization_id
-WHERE m.user_id = $1 AND e.organization_id = $2
-ORDER BY ee.name, e.name
-`
-
-type GetUserExtensionsByOrgParams struct {
-	UserID         string `json:"user_id"`
-	OrganizationID string `json:"organization_id"`
-}
-
-type GetUserExtensionsByOrgRow struct {
-	Name                        string  `json:"name"`
-	Label                       string  `json:"label"`
-	Version                     string  `json:"version"`
-	LatestVersion               *string `json:"latest_version"`
-	Active                      bool    `json:"active"`
-	Installed                   bool    `json:"installed"`
-	StoreLink                   *string `json:"store_link"`
-	RatingAverage               *int32  `json:"rating_average"`
-	InstalledAt                 *string `json:"installed_at"`
-	Changelog                   []byte  `json:"changelog"`
-	EnvironmentID               int32   `json:"environment_id"`
-	EnvironmentName             string  `json:"environment_name"`
-	EnvironmentUrl              string  `json:"environment_url"`
-	EnvironmentOrganizationName string  `json:"environment_organization_name"`
-	EnvironmentOrganizationID   string  `json:"environment_organization_id"`
-}
-
-func (q *Queries) GetUserExtensionsByOrg(ctx context.Context, arg GetUserExtensionsByOrgParams) ([]GetUserExtensionsByOrgRow, error) {
-	rows, err := q.db.Query(ctx, getUserExtensionsByOrg, arg.UserID, arg.OrganizationID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []GetUserExtensionsByOrgRow{}
-	for rows.Next() {
-		var i GetUserExtensionsByOrgRow
-		if err := rows.Scan(
-			&i.Name,
-			&i.Label,
-			&i.Version,
-			&i.LatestVersion,
-			&i.Active,
-			&i.Installed,
-			&i.StoreLink,
-			&i.RatingAverage,
-			&i.InstalledAt,
-			&i.Changelog,
-			&i.EnvironmentID,
-			&i.EnvironmentName,
-			&i.EnvironmentUrl,
-			&i.EnvironmentOrganizationName,
-			&i.EnvironmentOrganizationID,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getUserNotifications = `-- name: GetUserNotifications :one
 SELECT notifications FROM "user" WHERE id = $1
 `
@@ -612,6 +475,199 @@ func (q *Queries) GetUserShopsByOrg(ctx context.Context, arg GetUserShopsByOrgPa
 			&i.DefaultEnvironmentID,
 			&i.OrganizationID,
 			&i.OrganizationName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserStoreExtensionChangelogsByOrg = `-- name: GetUserStoreExtensionChangelogsByOrg :many
+SELECT DISTINCT sev.extension_name, sev.version, sev.changelog_en, sev.changelog_de, sev.released_at
+FROM store_extension_version sev
+WHERE sev.extension_name IN (
+  SELECT ese.extension_name
+  FROM environment_store_extension ese
+  JOIN environment e ON e.id = ese.environment_id
+  JOIN member m ON m.organization_id = e.organization_id
+  WHERE m.user_id = $1 AND e.organization_id = $2
+)
+ORDER BY sev.extension_name, sev.version
+`
+
+type GetUserStoreExtensionChangelogsByOrgParams struct {
+	UserID         string `json:"user_id"`
+	OrganizationID string `json:"organization_id"`
+}
+
+type GetUserStoreExtensionChangelogsByOrgRow struct {
+	ExtensionName string  `json:"extension_name"`
+	Version       string  `json:"version"`
+	ChangelogEn   *string `json:"changelog_en"`
+	ChangelogDe   *string `json:"changelog_de"`
+	ReleasedAt    *string `json:"released_at"`
+}
+
+func (q *Queries) GetUserStoreExtensionChangelogsByOrg(ctx context.Context, arg GetUserStoreExtensionChangelogsByOrgParams) ([]GetUserStoreExtensionChangelogsByOrgRow, error) {
+	rows, err := q.db.Query(ctx, getUserStoreExtensionChangelogsByOrg, arg.UserID, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserStoreExtensionChangelogsByOrgRow{}
+	for rows.Next() {
+		var i GetUserStoreExtensionChangelogsByOrgRow
+		if err := rows.Scan(
+			&i.ExtensionName,
+			&i.Version,
+			&i.ChangelogEn,
+			&i.ChangelogDe,
+			&i.ReleasedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserStoreExtensionsByOrg = `-- name: GetUserStoreExtensionsByOrg :many
+SELECT ese.extension_name AS name, ese.label, ese.version, ese.latest_version, ese.active, ese.installed,
+       se.store_link, se.rating_average, ese.installed_at,
+       ese.environment_id, e.name AS environment_name, e.url AS environment_url,
+       o.name AS environment_organization_name, e.organization_id AS environment_organization_id
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+JOIN environment e ON e.id = ese.environment_id
+JOIN organization o ON o.id = e.organization_id
+JOIN member m ON m.organization_id = e.organization_id
+WHERE m.user_id = $1 AND e.organization_id = $2
+ORDER BY ese.extension_name, e.name
+`
+
+type GetUserStoreExtensionsByOrgParams struct {
+	UserID         string `json:"user_id"`
+	OrganizationID string `json:"organization_id"`
+}
+
+type GetUserStoreExtensionsByOrgRow struct {
+	Name                        string  `json:"name"`
+	Label                       string  `json:"label"`
+	Version                     string  `json:"version"`
+	LatestVersion               *string `json:"latest_version"`
+	Active                      bool    `json:"active"`
+	Installed                   bool    `json:"installed"`
+	StoreLink                   *string `json:"store_link"`
+	RatingAverage               *int32  `json:"rating_average"`
+	InstalledAt                 *string `json:"installed_at"`
+	EnvironmentID               int32   `json:"environment_id"`
+	EnvironmentName             string  `json:"environment_name"`
+	EnvironmentUrl              string  `json:"environment_url"`
+	EnvironmentOrganizationName string  `json:"environment_organization_name"`
+	EnvironmentOrganizationID   string  `json:"environment_organization_id"`
+}
+
+func (q *Queries) GetUserStoreExtensionsByOrg(ctx context.Context, arg GetUserStoreExtensionsByOrgParams) ([]GetUserStoreExtensionsByOrgRow, error) {
+	rows, err := q.db.Query(ctx, getUserStoreExtensionsByOrg, arg.UserID, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserStoreExtensionsByOrgRow{}
+	for rows.Next() {
+		var i GetUserStoreExtensionsByOrgRow
+		if err := rows.Scan(
+			&i.Name,
+			&i.Label,
+			&i.Version,
+			&i.LatestVersion,
+			&i.Active,
+			&i.Installed,
+			&i.StoreLink,
+			&i.RatingAverage,
+			&i.InstalledAt,
+			&i.EnvironmentID,
+			&i.EnvironmentName,
+			&i.EnvironmentUrl,
+			&i.EnvironmentOrganizationName,
+			&i.EnvironmentOrganizationID,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserUnknownExtensionsByOrg = `-- name: GetUserUnknownExtensionsByOrg :many
+SELECT ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed,
+       NULL::text AS store_link, NULL::integer AS rating_average, ee.installed_at,
+       ee.environment_id, e.name AS environment_name, e.url AS environment_url,
+       o.name AS environment_organization_name, e.organization_id AS environment_organization_id
+FROM environment_extension ee
+JOIN environment e ON e.id = ee.environment_id
+JOIN organization o ON o.id = e.organization_id
+JOIN member m ON m.organization_id = e.organization_id
+WHERE m.user_id = $1 AND e.organization_id = $2
+ORDER BY ee.name, e.name
+`
+
+type GetUserUnknownExtensionsByOrgParams struct {
+	UserID         string `json:"user_id"`
+	OrganizationID string `json:"organization_id"`
+}
+
+type GetUserUnknownExtensionsByOrgRow struct {
+	Name                        string  `json:"name"`
+	Label                       string  `json:"label"`
+	Version                     string  `json:"version"`
+	LatestVersion               *string `json:"latest_version"`
+	Active                      bool    `json:"active"`
+	Installed                   bool    `json:"installed"`
+	StoreLink                   *string `json:"store_link"`
+	RatingAverage               *int32  `json:"rating_average"`
+	InstalledAt                 *string `json:"installed_at"`
+	EnvironmentID               int32   `json:"environment_id"`
+	EnvironmentName             string  `json:"environment_name"`
+	EnvironmentUrl              string  `json:"environment_url"`
+	EnvironmentOrganizationName string  `json:"environment_organization_name"`
+	EnvironmentOrganizationID   string  `json:"environment_organization_id"`
+}
+
+func (q *Queries) GetUserUnknownExtensionsByOrg(ctx context.Context, arg GetUserUnknownExtensionsByOrgParams) ([]GetUserUnknownExtensionsByOrgRow, error) {
+	rows, err := q.db.Query(ctx, getUserUnknownExtensionsByOrg, arg.UserID, arg.OrganizationID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserUnknownExtensionsByOrgRow{}
+	for rows.Next() {
+		var i GetUserUnknownExtensionsByOrgRow
+		if err := rows.Scan(
+			&i.Name,
+			&i.Label,
+			&i.Version,
+			&i.LatestVersion,
+			&i.Active,
+			&i.Installed,
+			&i.StoreLink,
+			&i.RatingAverage,
+			&i.InstalledAt,
+			&i.EnvironmentID,
+			&i.EnvironmentName,
+			&i.EnvironmentUrl,
+			&i.EnvironmentOrganizationName,
+			&i.EnvironmentOrganizationID,
 		); err != nil {
 			return nil, err
 		}

--- a/api/internal/handler/account.go
+++ b/api/internal/handler/account.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
@@ -52,15 +52,71 @@ func (h *Handler) GetAccountExtensions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rows, err := h.queries.GetUserExtensionsByOrg(r.Context(), queries.GetUserExtensionsByOrgParams{
+	storeRows, err := h.queries.GetUserStoreExtensionsByOrg(r.Context(), queries.GetUserStoreExtensionsByOrgParams{
 		UserID:         user.ID,
 		OrganizationID: *activeOrgID,
 	})
 	if err != nil {
-		slog.Error("failed to get user extensions", "error", err)
+		slog.Error("failed to get user store extensions", "error", err)
 		httputil.WriteError(w, http.StatusInternalServerError, "failed to get extensions")
 		return
 	}
+	unknownRows, err := h.queries.GetUserUnknownExtensionsByOrg(r.Context(), queries.GetUserUnknownExtensionsByOrgParams{
+		UserID:         user.ID,
+		OrganizationID: *activeOrgID,
+	})
+	if err != nil {
+		slog.Error("failed to get user unknown extensions", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get extensions")
+		return
+	}
+	changelogRows, err := h.queries.GetUserStoreExtensionChangelogsByOrg(r.Context(), queries.GetUserStoreExtensionChangelogsByOrgParams{
+		UserID:         user.ID,
+		OrganizationID: *activeOrgID,
+	})
+	if err != nil {
+		slog.Error("failed to get user store extension changelogs", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get extensions")
+		return
+	}
+
+	changelogByExt := make(map[string][]changelogVersion)
+	for _, r := range changelogRows {
+		changelogByExt[r.ExtensionName] = append(changelogByExt[r.ExtensionName], changelogVersion{
+			Version:    r.Version,
+			TextEn:     deref(r.ChangelogEn),
+			TextDe:     deref(r.ChangelogDe),
+			ReleasedAt: deref(r.ReleasedAt),
+		})
+	}
+
+	// Normalize both sources into a single iteration order (by name, then
+	// environment) so grouping is stable.
+	rows := make([]accountExtRow, 0, len(storeRows)+len(unknownRows))
+	for _, row := range storeRows {
+		rows = append(rows, accountExtRow{
+			Name: row.Name, Label: row.Label, Version: row.Version, LatestVersion: row.LatestVersion,
+			Active: row.Active, Installed: row.Installed, StoreLink: row.StoreLink, RatingAverage: row.RatingAverage,
+			InstalledAt: row.InstalledAt, EnvironmentID: row.EnvironmentID, EnvironmentName: row.EnvironmentName,
+			EnvironmentUrl: row.EnvironmentUrl, EnvironmentOrganizationName: row.EnvironmentOrganizationName,
+			EnvironmentOrganizationID: row.EnvironmentOrganizationID, isStore: true,
+		})
+	}
+	for _, row := range unknownRows {
+		rows = append(rows, accountExtRow{
+			Name: row.Name, Label: row.Label, Version: row.Version, LatestVersion: row.LatestVersion,
+			Active: row.Active, Installed: row.Installed, StoreLink: row.StoreLink, RatingAverage: row.RatingAverage,
+			InstalledAt: row.InstalledAt, EnvironmentID: row.EnvironmentID, EnvironmentName: row.EnvironmentName,
+			EnvironmentUrl: row.EnvironmentUrl, EnvironmentOrganizationName: row.EnvironmentOrganizationName,
+			EnvironmentOrganizationID: row.EnvironmentOrganizationID, isStore: false,
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Name != rows[j].Name {
+			return rows[i].Name < rows[j].Name
+		}
+		return rows[i].EnvironmentName < rows[j].EnvironmentName
+	})
 
 	// Group extensions by name, aggregating environments
 	extMap := make(map[string]*api.AccountExtension)
@@ -71,11 +127,6 @@ func (h *Handler) GetAccountExtensions(w http.ResponseWriter, r *http.Request) {
 
 		ext, exists := extMap[key]
 		if !exists {
-			latestVersion := ""
-			if row.LatestVersion != nil {
-				latestVersion = *row.LatestVersion
-			}
-
 			var ratingAvg *float32
 			if row.RatingAverage != nil {
 				v := float32(*row.RatingAverage)
@@ -83,42 +134,25 @@ func (h *Handler) GetAccountExtensions(w http.ResponseWriter, r *http.Request) {
 			}
 
 			var changelog *[]api.ExtensionChangelogEntry
-			if len(row.Changelog) > 0 {
-				var entries []api.ExtensionChangelogEntry
-				if err := json.Unmarshal(row.Changelog, &entries); err != nil {
-					slog.Warn("failed to unmarshal extension changelog", "extension", row.Name, "error", err)
-				} else if len(entries) > 0 {
-					changelog = &entries
-				}
-			}
-
-			var installedAt *time.Time
-			if row.InstalledAt != nil {
-				if t, err := time.Parse(time.RFC3339, *row.InstalledAt); err == nil {
-					installedAt = &t
-				}
+			if row.isStore {
+				changelog = buildCompatibleChangelog(changelogByExt[row.Name], row.Version, deref(row.LatestVersion))
 			}
 
 			ext = &api.AccountExtension{
 				Name:          row.Name,
 				Label:         row.Label,
 				Version:       row.Version,
-				LatestVersion: latestVersion,
+				LatestVersion: deref(row.LatestVersion),
 				Active:        row.Active,
 				Installed:     row.Installed,
 				StoreLink:     row.StoreLink,
 				RatingAverage: ratingAvg,
 				Changelog:     changelog,
-				InstalledAt:   installedAt,
+				InstalledAt:   parseInstalledAt(row.InstalledAt),
 				Environments:  []api.AccountExtensionEnvironment{},
 			}
 			extMap[key] = ext
 			extOrder = append(extOrder, key)
-		}
-
-		latestVersion := ""
-		if row.LatestVersion != nil {
-			latestVersion = *row.LatestVersion
 		}
 
 		env := api.AccountExtensionEnvironment{
@@ -128,7 +162,7 @@ func (h *Handler) GetAccountExtensions(w http.ResponseWriter, r *http.Request) {
 			EnvironmentOrganizationName: row.EnvironmentOrganizationName,
 			EnvironmentOrganizationId:   row.EnvironmentOrganizationID,
 			Version:                     row.Version,
-			LatestVersion:               latestVersion,
+			LatestVersion:               deref(row.LatestVersion),
 			Active:                      row.Active,
 			Installed:                   row.Installed,
 		}
@@ -141,6 +175,26 @@ func (h *Handler) GetAccountExtensions(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteJSON(w, http.StatusOK, result)
+}
+
+// accountExtRow is a unified row for aggregating account extensions from the
+// store and unknown sources.
+type accountExtRow struct {
+	Name                        string
+	Label                       string
+	Version                     string
+	LatestVersion               *string
+	Active                      bool
+	Installed                   bool
+	StoreLink                   *string
+	RatingAverage               *int32
+	InstalledAt                 *string
+	EnvironmentID               int32
+	EnvironmentName             string
+	EnvironmentUrl              string
+	EnvironmentOrganizationName string
+	EnvironmentOrganizationID   string
+	isStore                     bool
 }
 
 // GetAccountOrganizations returns the organizations the user belongs to.

--- a/api/internal/handler/environment_convert.go
+++ b/api/internal/handler/environment_convert.go
@@ -3,7 +3,9 @@ package handler
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
@@ -42,39 +44,40 @@ func toAccountEnvironments(rows []queries.ListEnvironmentsByOrganizationRow) []a
 	return result
 }
 
-func mapEnvironmentExtensions(rows []queries.EnvironmentExtension) []api.EnvironmentExtension {
-	extensions := make([]api.EnvironmentExtension, 0, len(rows))
-	for _, row := range rows {
+// mergeEnvironmentExtensions assembles the unified extension list for an
+// environment from the normalized store tables and the unknown-extension table.
+// Store extensions carry catalog metadata (store link, rating) and a
+// compatibility-capped changelog (both languages) built from the version
+// catalog; unknown extensions carry only the shop-reported fields.
+func mergeEnvironmentExtensions(
+	storeRows []queries.GetEnvironmentStoreExtensionsRow,
+	unknownRows []queries.EnvironmentExtension,
+	changelogRows []queries.GetEnvironmentStoreExtensionChangelogsRow,
+) []api.EnvironmentExtension {
+	changelogByExt := make(map[string][]changelogVersion)
+	for _, r := range changelogRows {
+		changelogByExt[r.ExtensionName] = append(changelogByExt[r.ExtensionName], changelogVersion{
+			Version:    r.Version,
+			TextEn:     deref(r.ChangelogEn),
+			TextDe:     deref(r.ChangelogDe),
+			ReleasedAt: deref(r.ReleasedAt),
+		})
+	}
+
+	extensions := make([]api.EnvironmentExtension, 0, len(storeRows)+len(unknownRows))
+
+	for _, row := range storeRows {
 		var ratingAvg *float32
 		if row.RatingAverage != nil {
 			v := float32(*row.RatingAverage)
 			ratingAvg = &v
 		}
 
-		var changelog *[]api.ExtensionChangelogEntry
-		if len(row.Changelog) > 0 {
-			var entries []api.ExtensionChangelogEntry
-			if err := json.Unmarshal(row.Changelog, &entries); err != nil {
-				slog.Warn("failed to unmarshal extension changelog", "extension", row.Name, "error", err)
-			} else if len(entries) > 0 {
-				changelog = &entries
-			}
-		}
-
-		var installedAt *time.Time
-		if row.InstalledAt != nil {
-			if parsed, err := time.Parse(time.RFC3339, *row.InstalledAt); err == nil {
-				installedAt = &parsed
-			}
-		}
-
-		latestVersion := ""
-		if row.LatestVersion != nil {
-			latestVersion = *row.LatestVersion
-		}
+		latestVersion := deref(row.LatestVersion)
+		changelog := buildCompatibleChangelog(changelogByExt[row.ExtensionName], row.Version, latestVersion)
 
 		extensions = append(extensions, api.EnvironmentExtension{
-			Name:          row.Name,
+			Name:          row.ExtensionName,
 			Label:         row.Label,
 			Version:       row.Version,
 			LatestVersion: latestVersion,
@@ -83,11 +86,117 @@ func mapEnvironmentExtensions(rows []queries.EnvironmentExtension) []api.Environ
 			StoreLink:     row.StoreLink,
 			RatingAverage: ratingAvg,
 			Changelog:     changelog,
-			InstalledAt:   installedAt,
+			InstalledAt:   parseInstalledAt(row.InstalledAt),
 		})
 	}
 
+	for _, row := range unknownRows {
+		extensions = append(extensions, api.EnvironmentExtension{
+			Name:          row.Name,
+			Label:         row.Label,
+			Version:       row.Version,
+			LatestVersion: deref(row.LatestVersion),
+			Active:        row.Active,
+			Installed:     row.Installed,
+			InstalledAt:   parseInstalledAt(row.InstalledAt),
+		})
+	}
+
+	sort.Slice(extensions, func(i, j int) bool {
+		return extensions[i].Name < extensions[j].Name
+	})
 	return extensions
+}
+
+// changelogVersion is an intermediate, language-agnostic store changelog entry.
+type changelogVersion struct {
+	Version    string
+	TextEn     string
+	TextDe     string
+	ReleasedAt string
+}
+
+// buildCompatibleChangelog returns changelog entries strictly newer than the
+// installed version and not newer than the latest compatible version (when
+// known), ordered oldest-first, with both language texts. Returns nil when there
+// is nothing to show.
+func buildCompatibleChangelog(versions []changelogVersion, installedVersion, latestVersion string) *[]api.ExtensionChangelogEntry {
+	entries := make([]api.ExtensionChangelogEntry, 0, len(versions))
+	for _, v := range versions {
+		if compareVersions(v.Version, installedVersion) <= 0 {
+			continue
+		}
+		if latestVersion != "" && compareVersions(v.Version, latestVersion) > 0 {
+			continue
+		}
+		entry := api.ExtensionChangelogEntry{
+			Version: v.Version,
+			Text:    v.TextEn,
+		}
+		if v.TextDe != "" {
+			textDe := v.TextDe
+			entry.TextDe = &textDe
+		}
+		if v.ReleasedAt != "" {
+			if t, err := time.Parse(time.RFC3339, v.ReleasedAt); err == nil {
+				entry.CreationDate = t
+			}
+		}
+		entries = append(entries, entry)
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return compareVersions(entries[i].Version, entries[j].Version) < 0
+	})
+	return &entries
+}
+
+// parseInstalledAt parses the RFC3339 installed-at timestamp, returning nil when
+// absent or unparseable.
+func parseInstalledAt(s *string) *time.Time {
+	if s == nil {
+		return nil
+	}
+	if t, err := time.Parse(time.RFC3339, *s); err == nil {
+		return &t
+	}
+	return nil
+}
+
+func deref(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// compareVersions compares two dot-separated numeric version strings.
+// Returns 1 if a > b, -1 if a < b, 0 if equal.
+func compareVersions(a, b string) int {
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+	maxLen := len(ap)
+	if len(bp) > maxLen {
+		maxLen = len(bp)
+	}
+	for i := 0; i < maxLen; i++ {
+		var an, bn int
+		if i < len(ap) {
+			an, _ = strconv.Atoi(ap[i])
+		}
+		if i < len(bp) {
+			bn, _ = strconv.Atoi(bp[i])
+		}
+		if an > bn {
+			return 1
+		}
+		if bn > an {
+			return -1
+		}
+	}
+	return 0
 }
 
 func mapEnvironmentScheduledTasks(rows []queries.EnvironmentScheduledTask) []api.ScheduledTask {

--- a/api/internal/handler/environment_convert.go
+++ b/api/internal/handler/environment_convert.go
@@ -4,12 +4,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/version"
 )
 
 // toAccountEnvironment maps a single organization environment row to its API DTO.
@@ -123,10 +122,10 @@ type changelogVersion struct {
 func buildCompatibleChangelog(versions []changelogVersion, installedVersion, latestVersion string) *[]api.ExtensionChangelogEntry {
 	entries := make([]api.ExtensionChangelogEntry, 0, len(versions))
 	for _, v := range versions {
-		if compareVersions(v.Version, installedVersion) <= 0 {
+		if version.Compare(v.Version, installedVersion) <= 0 {
 			continue
 		}
-		if latestVersion != "" && compareVersions(v.Version, latestVersion) > 0 {
+		if latestVersion != "" && version.Compare(v.Version, latestVersion) > 0 {
 			continue
 		}
 		entry := api.ExtensionChangelogEntry{
@@ -148,7 +147,7 @@ func buildCompatibleChangelog(versions []changelogVersion, installedVersion, lat
 		return nil
 	}
 	sort.Slice(entries, func(i, j int) bool {
-		return compareVersions(entries[i].Version, entries[j].Version) < 0
+		return version.Compare(entries[i].Version, entries[j].Version) < 0
 	})
 	return &entries
 }
@@ -170,33 +169,6 @@ func deref(s *string) string {
 		return ""
 	}
 	return *s
-}
-
-// compareVersions compares two dot-separated numeric version strings.
-// Returns 1 if a > b, -1 if a < b, 0 if equal.
-func compareVersions(a, b string) int {
-	ap := strings.Split(a, ".")
-	bp := strings.Split(b, ".")
-	maxLen := len(ap)
-	if len(bp) > maxLen {
-		maxLen = len(bp)
-	}
-	for i := 0; i < maxLen; i++ {
-		var an, bn int
-		if i < len(ap) {
-			an, _ = strconv.Atoi(ap[i])
-		}
-		if i < len(bp) {
-			bn, _ = strconv.Atoi(bp[i])
-		}
-		if an > bn {
-			return 1
-		}
-		if bn > an {
-			return -1
-		}
-	}
-	return 0
 }
 
 func mapEnvironmentScheduledTasks(rows []queries.EnvironmentScheduledTask) []api.ScheduledTask {

--- a/api/internal/handler/environment_detail.go
+++ b/api/internal/handler/environment_detail.go
@@ -13,7 +13,7 @@ import (
 )
 
 type environmentDetailAggregate struct {
-	extensions  []queries.EnvironmentExtension
+	extensions  []api.EnvironmentExtension
 	tasks       []queries.EnvironmentScheduledTask
 	queues      []queries.EnvironmentQueue
 	cache       *queries.EnvironmentCache
@@ -71,14 +71,21 @@ func (h *Handler) loadEnvironmentDetailAggregate(ctx context.Context, environmen
 	return aggregate
 }
 
-func (h *Handler) loadEnvironmentExtensions(ctx context.Context, environmentID int32) []queries.EnvironmentExtension {
-	rows, err := h.queries.GetEnvironmentExtensions(ctx, environmentID)
+func (h *Handler) loadEnvironmentExtensions(ctx context.Context, environmentID int32) []api.EnvironmentExtension {
+	storeRows, err := h.queries.GetEnvironmentStoreExtensions(ctx, environmentID)
+	if err != nil {
+		slog.Error("failed to get environment store extensions", "error", err)
+	}
+	unknownRows, err := h.queries.GetEnvironmentExtensions(ctx, environmentID)
 	if err != nil {
 		slog.Error("failed to get environment extensions", "error", err)
-		return nil
+	}
+	changelogRows, err := h.queries.GetEnvironmentStoreExtensionChangelogs(ctx, environmentID)
+	if err != nil {
+		slog.Error("failed to get environment store extension changelogs", "error", err)
 	}
 
-	return rows
+	return mergeEnvironmentExtensions(storeRows, unknownRows, changelogRows)
 }
 
 func (h *Handler) loadEnvironmentScheduledTasks(ctx context.Context, environmentID int32) []queries.EnvironmentScheduledTask {
@@ -195,7 +202,7 @@ func (h *Handler) buildEnvironmentDetail(environment *queries.GetEnvironmentByID
 		SitespeedEnabled:   environment.SitespeedEnabled,
 		SitespeedDetailUrl: sitespeedDetailUrl(h.cfg, environment.ID, environment.SitespeedEnabled),
 		SitespeedUrls:      sitespeedURLs,
-		Extensions:         mapEnvironmentExtensions(aggregate.extensions),
+		Extensions:         aggregate.extensions,
 		ScheduledTasks:     mapEnvironmentScheduledTasks(aggregate.tasks),
 		Queues:             mapEnvironmentQueues(aggregate.queues),
 		Cache:              mapEnvironmentCache(aggregate.cache),

--- a/api/internal/handler/environment_detail.go
+++ b/api/internal/handler/environment_detail.go
@@ -72,14 +72,22 @@ func (h *Handler) loadEnvironmentDetailAggregate(ctx context.Context, environmen
 }
 
 func (h *Handler) loadEnvironmentExtensions(ctx context.Context, environmentID int32) []api.EnvironmentExtension {
+	// The store and unknown queries together make up the full extension list, so
+	// a failure in either must not silently produce a partial list (which would
+	// look like a successful empty/short response). Bail out like the sibling
+	// load* helpers instead.
 	storeRows, err := h.queries.GetEnvironmentStoreExtensions(ctx, environmentID)
 	if err != nil {
 		slog.Error("failed to get environment store extensions", "error", err)
+		return nil
 	}
 	unknownRows, err := h.queries.GetEnvironmentExtensions(ctx, environmentID)
 	if err != nil {
 		slog.Error("failed to get environment extensions", "error", err)
+		return nil
 	}
+	// The changelog is supplementary; on failure we still return the extensions
+	// without it rather than dropping the whole list.
 	changelogRows, err := h.queries.GetEnvironmentStoreExtensionChangelogs(ctx, environmentID)
 	if err != nil {
 		slog.Error("failed to get environment store extension changelogs", "error", err)

--- a/api/internal/handler/extension_changelog_test.go
+++ b/api/internal/handler/extension_changelog_test.go
@@ -1,0 +1,45 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildCompatibleChangelog(t *testing.T) {
+	versions := []changelogVersion{
+		{Version: "1.9.0", TextEn: "en 1.9.0", TextDe: "de 1.9.0"},
+		{Version: "2.0.0", TextEn: "en 2.0.0"},
+		{Version: "2.0.5", TextEn: "en 2.0.5", TextDe: "de 2.0.5", ReleasedAt: "2024-01-15T08:30:00Z"},
+		{Version: "2.1.0", TextEn: "en 2.1.0", TextDe: "de 2.1.0"},
+		{Version: "2.2.0", TextEn: "en 2.2.0"}, // above latest compatible -> excluded
+	}
+
+	// Installed 2.0.0, latest compatible 2.1.0 -> 2.0.5 and 2.1.0, oldest-first.
+	got := buildCompatibleChangelog(versions, "2.0.0", "2.1.0")
+	require.NotNil(t, got)
+	require.Len(t, *got, 2)
+
+	first := (*got)[0]
+	assert.Equal(t, "2.0.5", first.Version)
+	assert.Equal(t, "en 2.0.5", first.Text)
+	require.NotNil(t, first.TextDe)
+	assert.Equal(t, "de 2.0.5", *first.TextDe)
+	assert.False(t, first.CreationDate.IsZero())
+
+	second := (*got)[1]
+	assert.Equal(t, "2.1.0", second.Version)
+	require.NotNil(t, second.TextDe)
+	assert.Equal(t, "de 2.1.0", *second.TextDe)
+
+	// No German text -> TextDe stays nil.
+	got = buildCompatibleChangelog(versions, "1.9.0", "2.0.0")
+	require.NotNil(t, got)
+	require.Len(t, *got, 1)
+	assert.Equal(t, "2.0.0", (*got)[0].Version)
+	assert.Nil(t, (*got)[0].TextDe)
+
+	// Nothing newer than installed -> nil.
+	assert.Nil(t, buildCompatibleChangelog(versions, "2.2.0", ""))
+}

--- a/api/internal/jobs/environment_scrape.go
+++ b/api/internal/jobs/environment_scrape.go
@@ -247,11 +247,7 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 		enrichSpan.End()
 	}
 
-	oldExtensions, err := h.queries.GetEnvironmentExtensions(ctx, env.ID)
-	if err != nil {
-		slog.Warn("failed to get old extensions", "environmentId", env.ID, "error", err)
-		oldExtensions = nil
-	}
+	oldExtensions := h.loadExistingExtensions(ctx, env.ID)
 
 	extensionsDiff := calculateExtensionDiff(oldExtensions, extensions)
 
@@ -352,44 +348,54 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 		return fmt.Errorf("delete environment checks: %w", err)
 	}
 
-	extNames := make([]string, 0, len(extensions))
-	for _, ext := range extensions {
-		extNames = append(extNames, ext.Name)
-
-		var ratingAvg *int32
-		if ext.RatingAverage != nil {
-			v := int32(math.Round(*ext.RatingAverage))
-			ratingAvg = &v
+	// Split extensions into store-known (normalized store_extension* tables) and
+	// unknown (environment_extension), then prune rows no longer present. Skipped
+	// entirely when the shop returned no extensions (likely a fetch error) so a
+	// transient failure does not wipe stored extensions.
+	if len(extensions) > 0 {
+		storeNames := make([]string, 0, len(extensions))
+		unknownNames := make([]string, 0, len(extensions))
+		for _, ext := range extensions {
+			if ext.Store != nil && ext.Store.primary() != nil {
+				storeNames = append(storeNames, ext.Name)
+				if err := h.persistStoreExtension(ctx, txQueries, env.ID, ext); err != nil {
+					persistSpan.RecordError(err)
+					persistSpan.SetStatus(codes.Error, err.Error())
+					persistSpan.End()
+					return err
+				}
+			} else {
+				unknownNames = append(unknownNames, ext.Name)
+				if err := txQueries.UpsertEnvironmentExtension(ctx, queries.UpsertEnvironmentExtensionParams{
+					EnvironmentID: env.ID,
+					Name:          ext.Name,
+					Label:         ext.Label,
+					Active:        ext.Active,
+					Version:       ext.Version,
+					LatestVersion: ext.LatestVersion,
+					Installed:     ext.Installed,
+					InstalledAt:   ext.InstalledAt,
+				}); err != nil {
+					persistSpan.RecordError(err)
+					persistSpan.SetStatus(codes.Error, err.Error())
+					persistSpan.End()
+					return fmt.Errorf("upsert environment extension %s: %w", ext.Name, err)
+				}
+			}
 		}
 
-		var changelogJSON []byte
-		if ext.Changelog != nil {
-			changelogJSON, _ = json.Marshal(ext.Changelog)
-		}
-
-		if err := txQueries.UpsertEnvironmentExtension(ctx, queries.UpsertEnvironmentExtensionParams{
+		if err := txQueries.DeleteEnvironmentStoreExtensionsNotIn(ctx, queries.DeleteEnvironmentStoreExtensionsNotInParams{
 			EnvironmentID: env.ID,
-			Name:          ext.Name,
-			Label:         ext.Label,
-			Active:        ext.Active,
-			Version:       ext.Version,
-			LatestVersion: ext.LatestVersion,
-			Installed:     ext.Installed,
-			RatingAverage: ratingAvg,
-			StoreLink:     ext.StoreLink,
-			Changelog:     changelogJSON,
-			InstalledAt:   ext.InstalledAt,
+			Column2:       storeNames,
 		}); err != nil {
 			persistSpan.RecordError(err)
 			persistSpan.SetStatus(codes.Error, err.Error())
 			persistSpan.End()
-			return fmt.Errorf("upsert environment extension %s: %w", ext.Name, err)
+			return fmt.Errorf("delete stale store extensions: %w", err)
 		}
-	}
-	if len(extNames) > 0 {
 		if err := txQueries.DeleteEnvironmentExtensionsNotIn(ctx, queries.DeleteEnvironmentExtensionsNotInParams{
 			EnvironmentID: env.ID,
-			Column2:       extNames,
+			Column2:       unknownNames,
 		}); err != nil {
 			persistSpan.RecordError(err)
 			persistSpan.SetStatus(codes.Error, err.Error())
@@ -567,4 +573,108 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 
 	slog.Info("scraped environment", "environmentId", env.ID, "name", env.Name, "version", shopConfig.Version)
 	return nil
+}
+
+// persistStoreExtension writes a store-known extension into the normalized
+// catalog (store_extension), its per-version changelogs (store_extension_version),
+// its listing images (store_extension_image), and the per-environment link
+// (environment_store_extension).
+func (h *EnvironmentScrapeHandler) persistStoreExtension(ctx context.Context, q *queries.Queries, envID int32, ext extensionEntry) error {
+	sd := ext.Store
+	p := sd.primary()
+
+	var storeID *int32
+	if p.ID != 0 {
+		v := int32(p.ID)
+		storeID = &v
+	}
+	var rating *int32
+	if p.RatingAverage != 0 {
+		v := int32(math.Round(p.RatingAverage))
+		rating = &v
+	}
+
+	var enLabel, enShort, enDesc, enManual string
+	if sd.en != nil {
+		enLabel, enShort, enDesc, enManual = sd.en.Label, sd.en.ShortDescription, sd.en.Description, sd.en.InstallationManual
+	}
+	var deLabel, deShort, deDesc, deManual string
+	if sd.de != nil {
+		deLabel, deShort, deDesc, deManual = sd.de.Label, sd.de.ShortDescription, sd.de.Description, sd.de.InstallationManual
+	}
+
+	if err := q.UpsertStoreExtension(ctx, queries.UpsertStoreExtensionParams{
+		Name:                 ext.Name,
+		StoreID:              storeID,
+		IconUrl:              nilIfEmpty(p.IconPath),
+		ProducerName:         nilIfEmpty(p.ProducerName),
+		ProducerWebsite:      nilIfEmpty(p.ProducerWebsite),
+		RatingAverage:        rating,
+		StoreLink:            nilIfEmpty(p.StoreLink),
+		ReleaseDate:          nilIfEmpty(p.ReleaseDate),
+		LabelEn:              nilIfEmpty(enLabel),
+		LabelDe:              nilIfEmpty(deLabel),
+		ShortDescriptionEn:   nilIfEmpty(enShort),
+		ShortDescriptionDe:   nilIfEmpty(deShort),
+		DescriptionEn:        nilIfEmpty(enDesc),
+		DescriptionDe:        nilIfEmpty(deDesc),
+		InstallationManualEn: nilIfEmpty(enManual),
+		InstallationManualDe: nilIfEmpty(deManual),
+		LatestVersion:        nilIfEmpty(p.Version),
+	}); err != nil {
+		return fmt.Errorf("upsert store extension %s: %w", ext.Name, err)
+	}
+
+	for _, mc := range sd.mergedChangelogs() {
+		if err := q.UpsertStoreExtensionVersion(ctx, queries.UpsertStoreExtensionVersionParams{
+			ExtensionName: ext.Name,
+			Version:       mc.Version,
+			ChangelogEn:   nilIfEmpty(mc.En),
+			ChangelogDe:   nilIfEmpty(mc.De),
+			ReleasedAt:    nilIfEmpty(mc.ReleasedAt),
+		}); err != nil {
+			return fmt.Errorf("upsert store extension version %s@%s: %w", ext.Name, mc.Version, err)
+		}
+	}
+
+	imageURLs := make([]string, 0, len(p.Pictures))
+	for _, pic := range p.Pictures {
+		imageURLs = append(imageURLs, pic.URL)
+		if err := q.UpsertStoreExtensionImage(ctx, queries.UpsertStoreExtensionImageParams{
+			ExtensionName: ext.Name,
+			Url:           pic.URL,
+			Preview:       pic.Preview,
+			Priority:      int32(pic.Priority),
+		}); err != nil {
+			return fmt.Errorf("upsert store extension image %s: %w", ext.Name, err)
+		}
+	}
+	if err := q.DeleteStoreExtensionImagesNotIn(ctx, queries.DeleteStoreExtensionImagesNotInParams{
+		ExtensionName: ext.Name,
+		Column2:       imageURLs,
+	}); err != nil {
+		return fmt.Errorf("delete stale store extension images %s: %w", ext.Name, err)
+	}
+
+	if err := q.UpsertEnvironmentStoreExtension(ctx, queries.UpsertEnvironmentStoreExtensionParams{
+		EnvironmentID: envID,
+		ExtensionName: ext.Name,
+		Label:         ext.Label,
+		Version:       ext.Version,
+		LatestVersion: ext.LatestVersion,
+		Active:        ext.Active,
+		Installed:     ext.Installed,
+		InstalledAt:   ext.InstalledAt,
+	}); err != nil {
+		return fmt.Errorf("upsert environment store extension %s: %w", ext.Name, err)
+	}
+
+	return nil
+}
+
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }

--- a/api/internal/jobs/environment_scrape.go
+++ b/api/internal/jobs/environment_scrape.go
@@ -372,7 +372,6 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 			oldLatest, wasStore := oldStoreLatest[ext.Name]
 			switch {
 			case ext.Store != nil && ext.Store.primary() != nil:
-				// Fresh store data: write the full catalog + link.
 				storeNames = append(storeNames, ext.Name)
 				if err := h.persistStoreExtension(ctx, txQueries, env.ID, ext); err != nil {
 					persistSpan.RecordError(err)
@@ -381,12 +380,9 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 					return err
 				}
 			case !storeOK && wasStore:
-				// The store API is unreachable this scrape but this extension was
-				// store-known: keep it classified as store and update only the
-				// per-environment link from shop data (the catalog row already
-				// exists and its compatible latest version is preserved). This
-				// avoids wiping the catalog link or duplicating the row into the
-				// unknown table on a transient store outage.
+				// Store API unreachable but this was a store extension: keep it as a
+				// store link and refresh only the shop-side fields, so a transient
+				// outage neither wipes the link nor duplicates it into the unknown table.
 				storeNames = append(storeNames, ext.Name)
 				if err := txQueries.UpsertEnvironmentStoreExtension(ctx, queries.UpsertEnvironmentStoreExtensionParams{
 					EnvironmentID: env.ID,

--- a/api/internal/jobs/environment_scrape.go
+++ b/api/internal/jobs/environment_scrape.go
@@ -620,7 +620,10 @@ func (h *EnvironmentScrapeHandler) persistStoreExtension(ctx context.Context, q 
 		DescriptionDe:        nilIfEmpty(deDesc),
 		InstallationManualEn: nilIfEmpty(enManual),
 		InstallationManualDe: nilIfEmpty(deManual),
-		LatestVersion:        nilIfEmpty(p.Version),
+		// The catalog row is shared across environments, so it stores the
+		// environment-independent global latest version rather than the
+		// Shopware-version-capped value (which lives on the link row).
+		LatestVersion: nilIfEmpty(sd.globalLatestVersion()),
 	}); err != nil {
 		return fmt.Errorf("upsert store extension %s: %w", ext.Name, err)
 	}
@@ -649,11 +652,16 @@ func (h *EnvironmentScrapeHandler) persistStoreExtension(ctx context.Context, q 
 			return fmt.Errorf("upsert store extension image %s: %w", ext.Name, err)
 		}
 	}
-	if err := q.DeleteStoreExtensionImagesNotIn(ctx, queries.DeleteStoreExtensionImagesNotInParams{
-		ExtensionName: ext.Name,
-		Column2:       imageURLs,
-	}); err != nil {
-		return fmt.Errorf("delete stale store extension images %s: %w", ext.Name, err)
+	// Only prune when the store returned pictures: an empty list would make
+	// "url != ALL('{}')" match every row and wipe all stored images on a scrape
+	// that momentarily returned no pictures.
+	if len(imageURLs) > 0 {
+		if err := q.DeleteStoreExtensionImagesNotIn(ctx, queries.DeleteStoreExtensionImagesNotInParams{
+			ExtensionName: ext.Name,
+			Column2:       imageURLs,
+		}); err != nil {
+			return fmt.Errorf("delete stale store extension images %s: %w", ext.Name, err)
+		}
 	}
 
 	if err := q.UpsertEnvironmentStoreExtension(ctx, queries.UpsertEnvironmentStoreExtensionParams{

--- a/api/internal/jobs/environment_scrape.go
+++ b/api/internal/jobs/environment_scrape.go
@@ -239,15 +239,28 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 		}
 	}
 
+	// storeOK reports whether the store membership is known this scrape. It stays
+	// true when there are no extensions to enrich (nothing to misclassify).
+	storeOK := true
 	if len(extensions) > 0 {
 		_, enrichSpan := tracer.Start(ctx, "environment.scrape.enrich_extensions",
 			trace.WithAttributes(attribute.Int("extension.count", len(extensions))),
 		)
-		h.enrichExtensionsFromStore(extensions, shopConfig.Version)
+		storeOK = h.enrichExtensionsFromStore(extensions, shopConfig.Version)
 		enrichSpan.End()
 	}
 
 	oldExtensions := h.loadExistingExtensions(ctx, env.ID)
+
+	// oldStoreLatest maps the names of extensions that were store-known before this
+	// scrape to their prior compatible latest version. Used to preserve the store
+	// classification (and link data) when the store API is unreachable.
+	oldStoreLatest := make(map[string]*string)
+	for _, e := range oldExtensions {
+		if e.IsStore {
+			oldStoreLatest[e.Name] = e.LatestVersion
+		}
+	}
 
 	extensionsDiff := calculateExtensionDiff(oldExtensions, extensions)
 
@@ -356,7 +369,10 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 		storeNames := make([]string, 0, len(extensions))
 		unknownNames := make([]string, 0, len(extensions))
 		for _, ext := range extensions {
-			if ext.Store != nil && ext.Store.primary() != nil {
+			oldLatest, wasStore := oldStoreLatest[ext.Name]
+			switch {
+			case ext.Store != nil && ext.Store.primary() != nil:
+				// Fresh store data: write the full catalog + link.
 				storeNames = append(storeNames, ext.Name)
 				if err := h.persistStoreExtension(ctx, txQueries, env.ID, ext); err != nil {
 					persistSpan.RecordError(err)
@@ -364,7 +380,30 @@ func (h *EnvironmentScrapeHandler) scrapeEnvironment(ctx context.Context, env qu
 					persistSpan.End()
 					return err
 				}
-			} else {
+			case !storeOK && wasStore:
+				// The store API is unreachable this scrape but this extension was
+				// store-known: keep it classified as store and update only the
+				// per-environment link from shop data (the catalog row already
+				// exists and its compatible latest version is preserved). This
+				// avoids wiping the catalog link or duplicating the row into the
+				// unknown table on a transient store outage.
+				storeNames = append(storeNames, ext.Name)
+				if err := txQueries.UpsertEnvironmentStoreExtension(ctx, queries.UpsertEnvironmentStoreExtensionParams{
+					EnvironmentID: env.ID,
+					ExtensionName: ext.Name,
+					Label:         ext.Label,
+					Version:       ext.Version,
+					LatestVersion: oldLatest,
+					Active:        ext.Active,
+					Installed:     ext.Installed,
+					InstalledAt:   ext.InstalledAt,
+				}); err != nil {
+					persistSpan.RecordError(err)
+					persistSpan.SetStatus(codes.Error, err.Error())
+					persistSpan.End()
+					return fmt.Errorf("upsert environment store extension %s: %w", ext.Name, err)
+				}
+			default:
 				unknownNames = append(unknownNames, ext.Name)
 				if err := txQueries.UpsertEnvironmentExtension(ctx, queries.UpsertEnvironmentExtensionParams{
 					EnvironmentID: env.ID,

--- a/api/internal/jobs/environment_scrape_changelog_test.go
+++ b/api/internal/jobs/environment_scrape_changelog_test.go
@@ -105,6 +105,31 @@ func TestStoreChangelogsBetween(t *testing.T) {
 	assert.Nil(t, sd.changelogsBetween("2.1.0", "2.1.0"))
 }
 
+func TestGlobalLatestVersion(t *testing.T) {
+	// The global latest is the newest changelog version (uncapped), not the
+	// Shopware-version-capped Version field.
+	sd := &storeExtensionData{
+		en: &shopwareaccount.StorePlugin{
+			Name:    "AcmeExt",
+			Version: "9.12.4", // compatible cap for this environment
+			Changelogs: []shopwareaccount.StoreChangelog{
+				{Version: "10.6.4"}, // newest, requires newer Shopware
+				{Version: "9.12.4"},
+				{Version: "9.10.0"},
+			},
+		},
+	}
+	if got := sd.globalLatestVersion(); got != "10.6.4" {
+		t.Fatalf("globalLatestVersion() = %q, want 10.6.4", got)
+	}
+
+	// Falls back to the compatible version when no changelog is available.
+	sd = &storeExtensionData{en: &shopwareaccount.StorePlugin{Name: "AcmeExt", Version: "1.2.3"}}
+	if got := sd.globalLatestVersion(); got != "1.2.3" {
+		t.Fatalf("globalLatestVersion() fallback = %q, want 1.2.3", got)
+	}
+}
+
 func TestCalculateExtensionDiffUsesStoreChangelog(t *testing.T) {
 	// Shop updates AcmeExt 2.1.0 -> 2.2.1; the diff changelog must contain the
 	// store entries strictly between the two versions, in both languages.

--- a/api/internal/jobs/environment_scrape_changelog_test.go
+++ b/api/internal/jobs/environment_scrape_changelog_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
-	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -66,68 +65,70 @@ func TestExtensionDiffRoundTrip(t *testing.T) {
 	assert.True(t, created.Equal(entry.CreationDate))
 }
 
-func TestBuildCompatibleChangelogs(t *testing.T) {
-	mkEntry := func(v string) shopwareaccount.StoreChangelog {
-		cl := shopwareaccount.StoreChangelog{Version: v, Text: "notes " + v}
+func TestStoreChangelogsBetween(t *testing.T) {
+	mkEn := func(v string) shopwareaccount.StoreChangelog {
+		cl := shopwareaccount.StoreChangelog{Version: v, Text: "en " + v}
 		cl.CreationDate.Date = "2024-01-15 08:30:00"
 		return cl
 	}
+	mkDe := func(v string) shopwareaccount.StoreChangelog {
+		return shopwareaccount.StoreChangelog{Version: v, Text: "de " + v}
+	}
 
-	sp := &shopwareaccount.StorePlugin{
-		Name:    "AcmeExt",
-		Version: "2.1.0", // latest version compatible with shop's Shopware version
-		Changelogs: []shopwareaccount.StoreChangelog{
-			mkEntry("1.9.0"), // older than installed -> excluded
-			mkEntry("2.0.0"), // == installed       -> excluded
-			mkEntry("2.0.5"), // in range            -> included
-			mkEntry("2.1.0"), // == cap              -> included
-			mkEntry("2.2.0"), // requires newer SW   -> excluded
-			mkEntry("3.0.0"), // requires newer SW   -> excluded
+	sd := &storeExtensionData{
+		en: &shopwareaccount.StorePlugin{
+			Name: "AcmeExt", Version: "2.1.0",
+			Changelogs: []shopwareaccount.StoreChangelog{
+				mkEn("2.1.0"), // store returns newest-first
+				mkEn("2.0.5"),
+				mkEn("2.0.0"),
+				mkEn("1.9.0"),
+			},
+		},
+		de: &shopwareaccount.StorePlugin{
+			Name: "AcmeExt", Version: "2.1.0",
+			Changelogs: []shopwareaccount.StoreChangelog{mkDe("2.1.0"), mkDe("2.0.5")},
 		},
 	}
 
-	got := buildCompatibleChangelogs(sp, "2.0.0")
-
+	// Window (installed 2.0.0, new 2.1.0] -> 2.0.5 and 2.1.0, oldest-first.
+	got := sd.changelogsBetween("2.0.0", "2.1.0")
 	require.Len(t, got, 2)
 	assert.Equal(t, "2.0.5", got[0].Version)
+	assert.Equal(t, "en 2.0.5", got[0].Text)
+	assert.Equal(t, "de 2.0.5", got[0].TextDe, "German changelog text must be merged in")
 	assert.Equal(t, "2.1.0", got[1].Version)
+	assert.Equal(t, "de 2.1.0", got[1].TextDe)
+	assert.True(t, time.Date(2024, 1, 15, 8, 30, 0, 0, time.UTC).Equal(got[0].CreationDate))
 
-	// When installed == sp.Version there's nothing newer compatible.
-	assert.Nil(t, buildCompatibleChangelogs(sp, "2.1.0"))
+	// Nothing newer than the new version.
+	assert.Nil(t, sd.changelogsBetween("2.1.0", "2.1.0"))
 }
 
-func TestCalculateExtensionDiffCapsChangelogToNewVersion(t *testing.T) {
-	// Stored changelog at scrape time was capped at the latest compatible
-	// version (2.2.4). Shop actually updates 2.1.0 -> 2.2.1, so the diff
-	// must drop entries above 2.2.1.
-	stored := []extensionChangelog{
-		{Version: "2.1.1", Text: "patch 1"},
-		{Version: "2.2.0", Text: "minor"},
-		{Version: "2.2.1", Text: "target"},
-		{Version: "2.2.2", Text: "above target"},
-		{Version: "2.2.4", Text: "latest compatible"},
+func TestCalculateExtensionDiffUsesStoreChangelog(t *testing.T) {
+	// Shop updates AcmeExt 2.1.0 -> 2.2.1; the diff changelog must contain the
+	// store entries strictly between the two versions, in both languages.
+	old := []existingExtension{
+		{Name: "AcmeExt", Label: "Acme", Active: true, Version: "2.1.0", Installed: true},
 	}
-	raw, err := json.Marshal(stored)
-	require.NoError(t, err)
-
-	old := []queries.EnvironmentExtension{
-		{
-			Name:      "AcmeExt",
-			Label:     "Acme",
-			Active:    true,
-			Version:   "2.1.0",
-			Installed: true,
-			Changelog: raw,
+	sd := &storeExtensionData{
+		en: &shopwareaccount.StorePlugin{
+			Name: "AcmeExt", Version: "2.2.1",
+			Changelogs: []shopwareaccount.StoreChangelog{
+				{Version: "2.2.2", Text: "above target"},
+				{Version: "2.2.1", Text: "target"},
+				{Version: "2.2.0", Text: "minor"},
+				{Version: "2.1.1", Text: "patch 1"},
+				{Version: "2.1.0", Text: "installed"},
+			},
+		},
+		de: &shopwareaccount.StorePlugin{
+			Name: "AcmeExt", Version: "2.2.1",
+			Changelogs: []shopwareaccount.StoreChangelog{{Version: "2.2.1", Text: "ziel"}},
 		},
 	}
 	newExts := []extensionEntry{
-		{
-			Name:      "AcmeExt",
-			Label:     "Acme",
-			Active:    true,
-			Version:   "2.2.1",
-			Installed: true,
-		},
+		{Name: "AcmeExt", Label: "Acme", Active: true, Version: "2.2.1", Installed: true, Store: sd},
 	}
 
 	diffs := calculateExtensionDiff(old, newExts)
@@ -142,6 +143,7 @@ func TestCalculateExtensionDiffCapsChangelogToNewVersion(t *testing.T) {
 	require.Len(t, d.Changelog, 3)
 	got := []string{d.Changelog[0].Version, d.Changelog[1].Version, d.Changelog[2].Version}
 	assert.Equal(t, []string{"2.1.1", "2.2.0", "2.2.1"}, got)
+	assert.Equal(t, "ziel", d.Changelog[2].TextDe)
 }
 
 func TestParseStoreDate(t *testing.T) {

--- a/api/internal/jobs/environment_scrape_types.go
+++ b/api/internal/jobs/environment_scrape_types.go
@@ -3,6 +3,8 @@ package jobs
 import (
 	"encoding/json"
 	"time"
+
+	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 )
 
 // ---- Shopware API response types ----
@@ -60,23 +62,45 @@ type shopwareCacheInfo struct {
 	CacheAdapter string `json:"cacheAdapter"`
 }
 
-// extensionEntry is a combined representation of plugins and apps.
+// extensionEntry is a combined representation of plugins and apps. Store is set
+// when the extension is known to the Shopware store (api.shopware.com); such
+// extensions are persisted into the normalized store_extension* tables, while
+// the rest land in environment_extension.
 type extensionEntry struct {
-	Name          string               `json:"name"`
-	Label         string               `json:"label"`
-	Active        bool                 `json:"active"`
-	Version       string               `json:"version"`
-	LatestVersion *string              `json:"latestVersion"`
-	Installed     bool                 `json:"installed"`
-	RatingAverage *float64             `json:"ratingAverage"`
-	StoreLink     *string              `json:"storeLink"`
-	Changelog     []extensionChangelog `json:"changelog,omitempty"`
-	InstalledAt   *string              `json:"installedAt"`
+	Name          string              `json:"name"`
+	Label         string              `json:"label"`
+	Active        bool                `json:"active"`
+	Version       string              `json:"version"`
+	LatestVersion *string             `json:"latestVersion"`
+	Installed     bool                `json:"installed"`
+	InstalledAt   *string             `json:"installedAt"`
+	Store         *storeExtensionData `json:"-"`
+}
+
+// storeExtensionData holds the per-locale store metadata fetched for an
+// extension. en is the en_GB response, de the de_DE response; either may be nil
+// if that locale call failed.
+type storeExtensionData struct {
+	en *shopwareaccount.StorePlugin
+	de *shopwareaccount.StorePlugin
+}
+
+// primary returns the locale response to use for locale-independent fields,
+// preferring en_GB and falling back to de_DE.
+func (s *storeExtensionData) primary() *shopwareaccount.StorePlugin {
+	if s == nil {
+		return nil
+	}
+	if s.en != nil {
+		return s.en
+	}
+	return s.de
 }
 
 type extensionChangelog struct {
 	Version      string    `json:"version"`
 	Text         string    `json:"text"`
+	TextDe       string    `json:"textDe,omitempty"`
 	CreationDate time.Time `json:"creationDate"`
 }
 

--- a/api/internal/jobs/environment_scrape_util.go
+++ b/api/internal/jobs/environment_scrape_util.go
@@ -2,24 +2,30 @@ package jobs
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
-	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 )
 
-// enrichExtensionsFromStore queries the Shopware Store API and updates extensions
-// with latestVersion, ratingAverage, storeLink, and changelog information.
+// enrichExtensionsFromStore fetches store metadata for the given extensions in
+// both English (en_GB) and German (de_DE) and attaches it to the entries the
+// store knows about. The latest compatible version is recorded per entry.
+// Extensions the store does not return are left untouched and later persisted as
+// unknown extensions. If the store request fails entirely the extensions are
+// treated as unknown for this scrape and reclassified on the next successful one.
+// The store locale must use the underscore form ("en_GB"/"de_DE"); the
+// hyphenated form is silently ignored by the API.
 func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extensionEntry, shopwareVersion string) {
 	technicalNames := make([]string, 0, len(extensions))
 	for _, ext := range extensions {
@@ -27,140 +33,233 @@ func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extens
 	}
 
 	client := shopwareaccount.NewClient("", nil)
-	storePlugins, err := client.PluginsByName(context.Background(), "en-GB", shopwareVersion, technicalNames)
-	if err != nil {
-		slog.Warn("failed to fetch store plugins", "error", err)
-		return
+
+	var (
+		enPlugins, dePlugins []shopwareaccount.StorePlugin
+		enErr, deErr         error
+		wg                   sync.WaitGroup
+	)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		enPlugins, enErr = client.PluginsByName(context.Background(), "en_GB", shopwareVersion, technicalNames)
+	}()
+	go func() {
+		defer wg.Done()
+		dePlugins, deErr = client.PluginsByName(context.Background(), "de_DE", shopwareVersion, technicalNames)
+	}()
+	wg.Wait()
+
+	if enErr != nil {
+		slog.Warn("failed to fetch store plugins", "locale", "en_GB", "error", enErr)
+	}
+	if deErr != nil {
+		slog.Warn("failed to fetch store plugins", "locale", "de_DE", "error", deErr)
 	}
 
-	storeMap := make(map[string]*shopwareaccount.StorePlugin, len(storePlugins))
-	for i := range storePlugins {
-		storeMap[storePlugins[i].Name] = &storePlugins[i]
-	}
+	enMap := indexStorePlugins(enPlugins)
+	deMap := indexStorePlugins(dePlugins)
 
 	for i := range extensions {
-		sp, ok := storeMap[extensions[i].Name]
-		if !ok {
+		en := enMap[extensions[i].Name]
+		de := deMap[extensions[i].Name]
+		if en == nil && de == nil {
 			continue
 		}
-
-		extensions[i].LatestVersion = strPtr(sp.Version)
-		extensions[i].RatingAverage = &sp.RatingAverage
-
-		storeLink := strings.ReplaceAll(sp.StoreLink, "http://store.shopware.com:80", "https://store.shopware.com")
-		extensions[i].StoreLink = &storeLink
-
-		if changelogs := buildCompatibleChangelogs(sp, extensions[i].Version); len(changelogs) > 0 {
-			extensions[i].Changelog = changelogs
+		data := &storeExtensionData{en: en, de: de}
+		extensions[i].Store = data
+		// latest_version is the latest release the store reports as compatible
+		// with this environment's Shopware version (the shopwareVersion query
+		// param caps it), so it is recorded per environment on the link row.
+		if p := data.primary(); p != nil && p.Version != "" {
+			v := p.Version
+			extensions[i].LatestVersion = &v
 		}
 	}
 }
 
-// buildCompatibleChangelogs returns store changelog entries strictly newer than
-// the installed version and not exceeding sp.Version. sp.Version is the latest
-// extension version the store reports as compatible with the shop's Shopware
-// version (controlled by the shopwareVersion query param to the store API),
-// so capping at it excludes entries that require a newer Shopware.
-func buildCompatibleChangelogs(sp *shopwareaccount.StorePlugin, installedVersion string) []extensionChangelog {
-	var changelogs []extensionChangelog
-	for _, cl := range sp.Changelogs {
-		if versionCompare(cl.Version, installedVersion) > 0 &&
-			versionCompare(cl.Version, sp.Version) <= 0 {
-			changelogs = append(changelogs, extensionChangelog{
-				Version:      cl.Version,
-				Text:         cl.Text,
-				CreationDate: parseStoreDate(cl.CreationDate.Date),
-			})
+func indexStorePlugins(plugins []shopwareaccount.StorePlugin) map[string]*shopwareaccount.StorePlugin {
+	m := make(map[string]*shopwareaccount.StorePlugin, len(plugins))
+	for i := range plugins {
+		m[plugins[i].Name] = &plugins[i]
+	}
+	return m
+}
+
+// mergedChangelog is a single store changelog version with both language texts.
+type mergedChangelog struct {
+	Version    string
+	En         string
+	De         string
+	ReleasedAt string
+}
+
+// mergedChangelogs combines the English and German changelog entries by version.
+func (s *storeExtensionData) mergedChangelogs() []mergedChangelog {
+	byVersion := make(map[string]*mergedChangelog)
+	order := make([]string, 0)
+	add := func(cls []shopwareaccount.StoreChangelog, isDe bool) {
+		for _, cl := range cls {
+			mc, ok := byVersion[cl.Version]
+			if !ok {
+				mc = &mergedChangelog{Version: cl.Version}
+				byVersion[cl.Version] = mc
+				order = append(order, cl.Version)
+			}
+			if isDe {
+				mc.De = cl.Text
+			} else {
+				mc.En = cl.Text
+			}
+			if mc.ReleasedAt == "" && cl.CreationDate.Date != "" {
+				if t := parseStoreDate(cl.CreationDate.Date); !t.IsZero() {
+					mc.ReleasedAt = t.Format(time.RFC3339)
+				}
+			}
 		}
 	}
-	return changelogs
+	if s.en != nil {
+		add(s.en.Changelogs, false)
+	}
+	if s.de != nil {
+		add(s.de.Changelogs, true)
+	}
+	result := make([]mergedChangelog, 0, len(order))
+	for _, v := range order {
+		result = append(result, *byVersion[v])
+	}
+	return result
+}
+
+// changelogsBetween returns store changelog entries (both languages) strictly
+// newer than oldVersion and not newer than newVersion, ordered oldest-first.
+func (s *storeExtensionData) changelogsBetween(oldVersion, newVersion string) []extensionChangelog {
+	var out []extensionChangelog
+	for _, mc := range s.mergedChangelogs() {
+		if versionCompare(mc.Version, oldVersion) > 0 && versionCompare(mc.Version, newVersion) <= 0 {
+			entry := extensionChangelog{Version: mc.Version, Text: mc.En, TextDe: mc.De}
+			if mc.ReleasedAt != "" {
+				if t, err := time.Parse(time.RFC3339, mc.ReleasedAt); err == nil {
+					entry.CreationDate = t
+				}
+			}
+			out = append(out, entry)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return versionCompare(out[i].Version, out[j].Version) < 0
+	})
+	return out
+}
+
+// existingExtension is the unified prior state of an extension (store-known or
+// unknown) used to diff against the freshly scraped extensions.
+type existingExtension struct {
+	Name      string
+	Label     string
+	Version   string
+	Active    bool
+	Installed bool
+}
+
+// loadExistingExtensions returns the prior persisted state of all extensions of
+// an environment, merging the unknown (environment_extension) and store-known
+// (environment_store_extension) tables.
+func (h *EnvironmentScrapeHandler) loadExistingExtensions(ctx context.Context, envID int32) []existingExtension {
+	var result []existingExtension
+
+	unknown, err := h.queries.GetEnvironmentExtensions(ctx, envID)
+	if err != nil {
+		slog.Warn("failed to get old unknown extensions", "environmentId", envID, "error", err)
+	}
+	for _, e := range unknown {
+		result = append(result, existingExtension{
+			Name: e.Name, Label: e.Label, Version: e.Version, Active: e.Active, Installed: e.Installed,
+		})
+	}
+
+	store, err := h.queries.GetEnvironmentStoreExtensions(ctx, envID)
+	if err != nil {
+		slog.Warn("failed to get old store extensions", "environmentId", envID, "error", err)
+	}
+	for _, e := range store {
+		result = append(result, existingExtension{
+			Name: e.ExtensionName, Label: e.Label, Version: e.Version, Active: e.Active, Installed: e.Installed,
+		})
+	}
+
+	return result
 }
 
 // calculateExtensionDiff compares old (from DB) and new (from scrape) extensions.
-func calculateExtensionDiff(oldExtensions []queries.EnvironmentExtension, newExtensions []extensionEntry) []extensionDiff {
+// For updated store extensions the changelog between the old and new version is
+// taken from the freshly fetched store data (both languages).
+func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []extensionEntry) []extensionDiff {
 	if len(oldExtensions) == 0 {
 		return nil
 	}
 
+	newByName := make(map[string]*extensionEntry, len(newExtensions))
+	for i := range newExtensions {
+		newByName[newExtensions[i].Name] = &newExtensions[i]
+	}
+
 	var diffs []extensionDiff
+	seen := make(map[string]struct{}, len(oldExtensions))
 
-	// Check for updated/deactivated/activated/removed
 	for _, old := range oldExtensions {
-		found := false
-		for _, newExt := range newExtensions {
-			if old.Name == newExt.Name {
-				found = true
+		seen[old.Name] = struct{}{}
 
-				var state string
-				if old.Version != newExt.Version {
-					state = "updated"
-				} else if old.Active && !newExt.Active {
-					state = "deactivated"
-				} else if !old.Active && newExt.Active {
-					state = "activated"
-				}
-
-				if state != "" {
-					diff := extensionDiff{
-						Name:       newExt.Name,
-						Label:      newExt.Label,
-						State:      state,
-						OldVersion: &old.Version,
-						NewVersion: &newExt.Version,
-						Active:     newExt.Active,
-					}
-					if state == "updated" && old.Changelog != nil {
-						var cl []extensionChangelog
-						if json.Unmarshal(old.Changelog, &cl) == nil {
-							// Stored changelog was capped at the latest compatible version
-							// at scrape time, which may be ahead of the version the shop
-							// actually updated to. Keep only entries up to newExt.Version.
-							filtered := cl[:0]
-							for _, entry := range cl {
-								if versionCompare(entry.Version, newExt.Version) <= 0 {
-									filtered = append(filtered, entry)
-								}
-							}
-							diff.Changelog = filtered
-						}
-					}
-					diffs = append(diffs, diff)
-				}
-				break
-			}
-		}
-
+		newExt, found := newByName[old.Name]
 		if !found {
 			diffs = append(diffs, extensionDiff{
 				Name:       old.Name,
 				Label:      old.Label,
 				State:      "removed",
-				OldVersion: &old.Version,
-				NewVersion: nil,
+				OldVersion: strPtr(old.Version),
 				Active:     old.Active,
 			})
+			continue
 		}
+
+		var state string
+		if old.Version != newExt.Version {
+			state = "updated"
+		} else if old.Active && !newExt.Active {
+			state = "deactivated"
+		} else if !old.Active && newExt.Active {
+			state = "activated"
+		}
+		if state == "" {
+			continue
+		}
+
+		diff := extensionDiff{
+			Name:       newExt.Name,
+			Label:      newExt.Label,
+			State:      state,
+			OldVersion: strPtr(old.Version),
+			NewVersion: strPtr(newExt.Version),
+			Active:     newExt.Active,
+		}
+		if state == "updated" && newExt.Store != nil {
+			diff.Changelog = newExt.Store.changelogsBetween(old.Version, newExt.Version)
+		}
+		diffs = append(diffs, diff)
 	}
 
-	// Check for newly installed
-	for _, newExt := range newExtensions {
-		found := false
-		for _, old := range oldExtensions {
-			if old.Name == newExt.Name {
-				found = true
-				break
-			}
+	for i := range newExtensions {
+		if _, found := seen[newExtensions[i].Name]; found {
+			continue
 		}
-		if !found {
-			diffs = append(diffs, extensionDiff{
-				Name:       newExt.Name,
-				Label:      newExt.Label,
-				State:      "installed",
-				OldVersion: nil,
-				NewVersion: &newExt.Version,
-				Active:     newExt.Active,
-			})
-		}
+		ne := &newExtensions[i]
+		diffs = append(diffs, extensionDiff{
+			Name:       ne.Name,
+			Label:      ne.Label,
+			State:      "installed",
+			NewVersion: strPtr(ne.Version),
+			Active:     ne.Active,
+		})
 	}
 
 	return diffs

--- a/api/internal/jobs/environment_scrape_util.go
+++ b/api/internal/jobs/environment_scrape_util.go
@@ -26,7 +26,12 @@ import (
 // treated as unknown for this scrape and reclassified on the next successful one.
 // The store locale must use the underscore form ("en_GB"/"de_DE"); the
 // hyphenated form is silently ignored by the API.
-func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extensionEntry, shopwareVersion string) {
+//
+// It returns whether the store membership is known for this scrape: true if at
+// least one locale call succeeded (the successful response authoritatively says
+// which extensions the store knows), false if both calls failed. Callers use
+// this to avoid reclassifying or pruning store extensions on a transient outage.
+func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extensionEntry, shopwareVersion string) bool {
 	technicalNames := make([]string, 0, len(extensions))
 	for _, ext := range extensions {
 		technicalNames = append(technicalNames, ext.Name)
@@ -76,6 +81,8 @@ func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extens
 			extensions[i].LatestVersion = &v
 		}
 	}
+
+	return enErr == nil || deErr == nil
 }
 
 func indexStorePlugins(plugins []shopwareaccount.StorePlugin) map[string]*shopwareaccount.StorePlugin {
@@ -179,6 +186,11 @@ type existingExtension struct {
 	Version   string
 	Active    bool
 	Installed bool
+	// IsStore reports whether the prior row came from environment_store_extension.
+	IsStore bool
+	// LatestVersion is the prior link's compatible latest version (store only),
+	// preserved when the store API is unavailable for a scrape.
+	LatestVersion *string
 }
 
 // loadExistingExtensions returns the prior persisted state of all extensions of
@@ -204,6 +216,7 @@ func (h *EnvironmentScrapeHandler) loadExistingExtensions(ctx context.Context, e
 	for _, e := range store {
 		result = append(result, existingExtension{
 			Name: e.ExtensionName, Label: e.Label, Version: e.Version, Active: e.Active, Installed: e.Installed,
+			IsStore: true, LatestVersion: e.LatestVersion,
 		})
 	}
 

--- a/api/internal/jobs/environment_scrape_util.go
+++ b/api/internal/jobs/environment_scrape_util.go
@@ -20,17 +20,10 @@ import (
 
 // enrichExtensionsFromStore fetches store metadata for the given extensions in
 // both English (en_GB) and German (de_DE) and attaches it to the entries the
-// store knows about. The latest compatible version is recorded per entry.
-// Extensions the store does not return are left untouched and later persisted as
-// unknown extensions. If the store request fails entirely the extensions are
-// treated as unknown for this scrape and reclassified on the next successful one.
-// The store locale must use the underscore form ("en_GB"/"de_DE"); the
-// hyphenated form is silently ignored by the API.
-//
-// It returns whether the store membership is known for this scrape: true if at
-// least one locale call succeeded (the successful response authoritatively says
-// which extensions the store knows), false if both calls failed. Callers use
-// this to avoid reclassifying or pruning store extensions on a transient outage.
+// store knows about, recording the latest compatible version per entry. The
+// locale must use the underscore form; the hyphenated form is silently ignored
+// by the API. It returns false only when both locale calls fail, meaning store
+// membership is unknown for this scrape.
 func (h *EnvironmentScrapeHandler) enrichExtensionsFromStore(extensions []extensionEntry, shopwareVersion string) bool {
 	technicalNames := make([]string, 0, len(extensions))
 	for _, ext := range extensions {

--- a/api/internal/jobs/environment_scrape_util.go
+++ b/api/internal/jobs/environment_scrape_util.go
@@ -9,13 +9,13 @@ import (
 	"net/url"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/version"
 )
 
 // enrichExtensionsFromStore fetches store metadata for the given extensions in
@@ -131,12 +131,31 @@ func (s *storeExtensionData) mergedChangelogs() []mergedChangelog {
 	return result
 }
 
+// globalLatestVersion returns the newest version known from the store changelog,
+// which (unlike the compatible Version field) is not capped to a specific
+// Shopware version and is therefore environment-independent. It falls back to the
+// compatible version when no changelog is available.
+func (s *storeExtensionData) globalLatestVersion() string {
+	latest := ""
+	for _, mc := range s.mergedChangelogs() {
+		if latest == "" || version.Compare(mc.Version, latest) > 0 {
+			latest = mc.Version
+		}
+	}
+	if latest == "" {
+		if p := s.primary(); p != nil {
+			latest = p.Version
+		}
+	}
+	return latest
+}
+
 // changelogsBetween returns store changelog entries (both languages) strictly
 // newer than oldVersion and not newer than newVersion, ordered oldest-first.
 func (s *storeExtensionData) changelogsBetween(oldVersion, newVersion string) []extensionChangelog {
 	var out []extensionChangelog
 	for _, mc := range s.mergedChangelogs() {
-		if versionCompare(mc.Version, oldVersion) > 0 && versionCompare(mc.Version, newVersion) <= 0 {
+		if version.Compare(mc.Version, oldVersion) > 0 && version.Compare(mc.Version, newVersion) <= 0 {
 			entry := extensionChangelog{Version: mc.Version, Text: mc.En, TextDe: mc.De}
 			if mc.ReleasedAt != "" {
 				if t, err := time.Parse(time.RFC3339, mc.ReleasedAt); err == nil {
@@ -147,7 +166,7 @@ func (s *storeExtensionData) changelogsBetween(oldVersion, newVersion string) []
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
-		return versionCompare(out[i].Version, out[j].Version) < 0
+		return version.Compare(out[i].Version, out[j].Version) < 0
 	})
 	return out
 }
@@ -285,35 +304,6 @@ func isScheduledTaskOverdue(task shopwareScheduledTask) bool {
 		}
 	}
 	return false
-}
-
-// versionCompare compares two version strings.
-// Returns 1 if a > b, -1 if a < b, 0 if equal.
-func versionCompare(a, b string) int {
-	ap := strings.Split(a, ".")
-	bp := strings.Split(b, ".")
-
-	maxLen := len(ap)
-	if len(bp) > maxLen {
-		maxLen = len(bp)
-	}
-
-	for i := 0; i < maxLen; i++ {
-		var an, bn int
-		if i < len(ap) {
-			an, _ = strconv.Atoi(ap[i])
-		}
-		if i < len(bp) {
-			bn, _ = strconv.Atoi(bp[i])
-		}
-		if an > bn {
-			return 1
-		}
-		if bn > an {
-			return -1
-		}
-	}
-	return 0
 }
 
 // getFavicon fetches the shop URL and parses the HTML for a favicon link.

--- a/api/internal/shopwareaccount/store.go
+++ b/api/internal/shopwareaccount/store.go
@@ -9,27 +9,82 @@ import (
 	"net/url"
 )
 
-// StorePlugin is a plugin entry returned by the store pluginsByName endpoint.
+// StorePlugin is a plugin entry returned by the store pluginsByName endpoint,
+// flattened to the fields shopmon stores. Localized fields (label, description,
+// short description, installation manual, changelog text) reflect the locale
+// passed to PluginsByName.
 type StorePlugin struct {
-	Name          string           `json:"name"`
-	Label         string           `json:"label"`
-	Version       string           `json:"version"`
-	RatingAverage float64          `json:"ratingAverage"`
-	StoreLink     string           `json:"link"`
-	Changelogs    []StoreChangelog `json:"changelog"`
+	ID                 int
+	Name               string
+	Label              string
+	Description        string
+	ShortDescription   string
+	InstallationManual string
+	Version            string
+	RatingAverage      float64
+	StoreLink          string
+	IconPath           string
+	ReleaseDate        string
+	ProducerName       string
+	ProducerWebsite    string
+	Pictures           []StorePicture
+	Changelogs         []StoreChangelog
+}
+
+// StorePicture is a listing image (screenshot) of a store plugin.
+type StorePicture struct {
+	URL      string
+	Preview  bool
+	Priority int
 }
 
 // StoreChangelog is a single changelog entry for a store plugin.
 type StoreChangelog struct {
-	Version      string `json:"version"`
-	Text         string `json:"text"`
-	CreationDate struct {
-		Date string `json:"date"`
-	} `json:"creationDate"`
+	Version      string
+	Text         string
+	CreationDate StoreDate
 }
 
-// PluginsByName fetches store metadata (latest version, rating, changelogs,
-// store link) for the given technical names, scoped to a Shopware version.
+// StoreDate is the date wrapper the store API uses for timestamp fields.
+type StoreDate struct {
+	Date string `json:"date"`
+}
+
+// rawStorePlugin mirrors the raw pluginsByName response shape.
+type rawStorePlugin struct {
+	ID                 int       `json:"id"`
+	Name               string    `json:"name"`
+	Label              string    `json:"label"`
+	Description        string    `json:"description"`
+	InstallationManual string    `json:"installationManual"`
+	Version            string    `json:"version"`
+	RatingAverage      float64   `json:"ratingAverage"`
+	Link               string    `json:"link"`
+	IconPath           string    `json:"iconPath"`
+	ReleaseDate        StoreDate `json:"releaseDate"`
+	Producer           struct {
+		Name    string `json:"name"`
+		Website string `json:"website"`
+	} `json:"producer"`
+	Infos []struct {
+		ShortDescription string `json:"shortDescription"`
+	} `json:"infos"`
+	Pictures []struct {
+		RemoteLink string `json:"remoteLink"`
+		Preview    bool   `json:"preview"`
+		Priority   int    `json:"priority"`
+	} `json:"pictures"`
+	Changelog []struct {
+		Version      string    `json:"version"`
+		Text         string    `json:"text"`
+		CreationDate StoreDate `json:"creationDate"`
+	} `json:"changelog"`
+}
+
+// PluginsByName fetches store metadata (versions, rating, changelogs, pictures,
+// localized descriptions, store link, ...) for the given technical names, scoped
+// to a Shopware version. The locale must be in the store's underscore form
+// (e.g. "en_GB", "de_DE"); hyphenated locales are silently ignored by the API.
 func (c *Client) PluginsByName(ctx context.Context, locale, shopwareVersion string, technicalNames []string) ([]StorePlugin, error) {
 	q := url.Values{}
 	q.Set("locale", locale)
@@ -58,9 +113,69 @@ func (c *Client) PluginsByName(ctx context.Context, locale, shopwareVersion stri
 		return nil, fmt.Errorf("read response: %w", err)
 	}
 
-	var plugins []StorePlugin
-	if err := json.Unmarshal(body, &plugins); err != nil {
+	var raw []rawStorePlugin
+	if err := json.Unmarshal(body, &raw); err != nil {
 		return nil, fmt.Errorf("parse store plugins response: %w", err)
 	}
+
+	plugins := make([]StorePlugin, 0, len(raw))
+	for i := range raw {
+		plugins = append(plugins, raw[i].toStorePlugin())
+	}
 	return plugins, nil
+}
+
+func (r *rawStorePlugin) toStorePlugin() StorePlugin {
+	sp := StorePlugin{
+		ID:                 r.ID,
+		Name:               r.Name,
+		Label:              r.Label,
+		Description:        r.Description,
+		InstallationManual: r.InstallationManual,
+		Version:            r.Version,
+		RatingAverage:      r.RatingAverage,
+		StoreLink:          normalizeStoreLink(r.Link),
+		IconPath:           r.IconPath,
+		ReleaseDate:        r.ReleaseDate.Date,
+		ProducerName:       r.Producer.Name,
+		ProducerWebsite:    r.Producer.Website,
+	}
+	if len(r.Infos) > 0 {
+		sp.ShortDescription = r.Infos[0].ShortDescription
+	}
+	for _, p := range r.Pictures {
+		if p.RemoteLink == "" {
+			continue
+		}
+		sp.Pictures = append(sp.Pictures, StorePicture{
+			URL:      p.RemoteLink,
+			Preview:  p.Preview,
+			Priority: p.Priority,
+		})
+	}
+	for _, cl := range r.Changelog {
+		sp.Changelogs = append(sp.Changelogs, StoreChangelog{
+			Version:      cl.Version,
+			Text:         cl.Text,
+			CreationDate: cl.CreationDate,
+		})
+	}
+	return sp
+}
+
+// normalizeStoreLink rewrites the explicit-port store URLs the API returns
+// (e.g. http://store.shopware.com:80/... or https://store.shopware.com:443/...)
+// to a clean https URL.
+func normalizeStoreLink(link string) string {
+	replacer := []struct{ from, to string }{
+		{"http://store.shopware.com:80", "https://store.shopware.com"},
+		{"https://store.shopware.com:443", "https://store.shopware.com"},
+		{"http://store.shopware.com", "https://store.shopware.com"},
+	}
+	for _, rep := range replacer {
+		if len(link) >= len(rep.from) && link[:len(rep.from)] == rep.from {
+			return rep.to + link[len(rep.from):]
+		}
+	}
+	return link
 }

--- a/api/internal/version/version.go
+++ b/api/internal/version/version.go
@@ -1,39 +1,24 @@
-// Package version provides comparison of dot-separated numeric version strings
-// (e.g. Shopware extension versions like "6.6.1.0"). It is shared by the scrape
-// write path and the read/handler path so both filter changelogs identically.
+// Package version compares version strings (e.g. Shopware extension versions
+// like "6.6.1.0") using github.com/shyim/go-version. It exposes a small
+// string-friendly, error-tolerant helper shared by the scrape write path and the
+// read/handler path so both filter changelogs with identical semantics.
 package version
 
 import (
-	"strconv"
 	"strings"
+
+	goversion "github.com/shyim/go-version"
 )
 
-// Compare compares two dot-separated numeric version strings.
-// It returns 1 if a > b, -1 if a < b, and 0 if they are equal. Non-numeric or
-// missing segments are treated as 0.
+// Compare compares two version strings via go-version. It returns 1 if a > b,
+// -1 if a < b, and 0 if they are equal. If either value cannot be parsed it
+// falls back to a plain string comparison so callers still get a deterministic
+// ordering.
 func Compare(a, b string) int {
-	ap := strings.Split(a, ".")
-	bp := strings.Split(b, ".")
-
-	maxLen := len(ap)
-	if len(bp) > maxLen {
-		maxLen = len(bp)
+	va, errA := goversion.NewVersion(a)
+	vb, errB := goversion.NewVersion(b)
+	if errA != nil || errB != nil {
+		return strings.Compare(a, b)
 	}
-
-	for i := 0; i < maxLen; i++ {
-		var an, bn int
-		if i < len(ap) {
-			an, _ = strconv.Atoi(ap[i])
-		}
-		if i < len(bp) {
-			bn, _ = strconv.Atoi(bp[i])
-		}
-		if an > bn {
-			return 1
-		}
-		if bn > an {
-			return -1
-		}
-	}
-	return 0
+	return va.Compare(vb)
 }

--- a/api/internal/version/version.go
+++ b/api/internal/version/version.go
@@ -1,0 +1,39 @@
+// Package version provides comparison of dot-separated numeric version strings
+// (e.g. Shopware extension versions like "6.6.1.0"). It is shared by the scrape
+// write path and the read/handler path so both filter changelogs identically.
+package version
+
+import (
+	"strconv"
+	"strings"
+)
+
+// Compare compares two dot-separated numeric version strings.
+// It returns 1 if a > b, -1 if a < b, and 0 if they are equal. Non-numeric or
+// missing segments are treated as 0.
+func Compare(a, b string) int {
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+
+	maxLen := len(ap)
+	if len(bp) > maxLen {
+		maxLen = len(bp)
+	}
+
+	for i := 0; i < maxLen; i++ {
+		var an, bn int
+		if i < len(ap) {
+			an, _ = strconv.Atoi(ap[i])
+		}
+		if i < len(bp) {
+			bn, _ = strconv.Atoi(bp[i])
+		}
+		if an > bn {
+			return 1
+		}
+		if bn > an {
+			return -1
+		}
+	}
+	return 0
+}

--- a/api/internal/version/version_test.go
+++ b/api/internal/version/version_test.go
@@ -1,0 +1,23 @@
+package version
+
+import "testing"
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"2.0.0", "1.9.9", 1},
+		{"1.9.9", "2.0.0", -1},
+		{"10.0.0", "9.0.0", 1}, // numeric, not lexicographic
+		{"1.2", "1.2.0", 0},    // missing segments treated as 0
+		{"1.2.1", "1.2", 1},
+		{"6.6.1.0", "6.6.0.0", 1},
+	}
+	for _, c := range cases {
+		if got := Compare(c.a, c.b); got != c.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/api/migrations/000013_normalize_store_extensions.down.sql
+++ b/api/migrations/000013_normalize_store_extensions.down.sql
@@ -1,0 +1,39 @@
+-- Reverse the store-extension normalization: re-add the denormalized columns to
+-- environment_extension, move store-linked extensions back into it (rebuilding
+-- the English changelog JSON from the version catalog), then drop the new tables.
+
+ALTER TABLE environment_extension ADD COLUMN IF NOT EXISTS rating_average integer;
+ALTER TABLE environment_extension ADD COLUMN IF NOT EXISTS store_link text;
+ALTER TABLE environment_extension ADD COLUMN IF NOT EXISTS changelog jsonb;
+
+INSERT INTO environment_extension
+  (environment_id, name, label, active, version, latest_version, installed, rating_average, store_link, changelog, installed_at)
+SELECT
+  ese.environment_id,
+  ese.extension_name,
+  ese.label,
+  ese.active,
+  ese.version,
+  ese.latest_version,
+  ese.installed,
+  se.rating_average,
+  se.store_link,
+  (
+    SELECT jsonb_agg(jsonb_build_object(
+      'version', v.version,
+      'text', v.changelog_en,
+      'creationDate', v.released_at
+    ) ORDER BY v.version)
+    FROM store_extension_version v
+    WHERE v.extension_name = ese.extension_name
+      AND v.changelog_en IS NOT NULL
+  ),
+  ese.installed_at
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+ON CONFLICT (environment_id, name) DO NOTHING;
+
+DROP TABLE IF EXISTS environment_store_extension;
+DROP TABLE IF EXISTS store_extension_image;
+DROP TABLE IF EXISTS store_extension_version;
+DROP TABLE IF EXISTS store_extension;

--- a/api/migrations/000013_normalize_store_extensions.up.sql
+++ b/api/migrations/000013_normalize_store_extensions.up.sql
@@ -1,0 +1,114 @@
+-- Normalize Shopware-store extension data out of the per-environment
+-- environment_extension table into a shared catalog (store_extension), a
+-- per-version changelog catalog (store_extension_version), a listing-image
+-- table (store_extension_image), and a per-environment link table
+-- (environment_store_extension). After this migration environment_extension
+-- holds only extensions that are unknown to the store.
+
+CREATE TABLE IF NOT EXISTS "store_extension" (
+  "name" text PRIMARY KEY NOT NULL,
+  "store_id" integer,
+  "icon_url" text,
+  "producer_name" text,
+  "producer_website" text,
+  "rating_average" integer,
+  "store_link" text,
+  "release_date" text,
+  "label_en" text,
+  "label_de" text,
+  "short_description_en" text,
+  "short_description_de" text,
+  "description_en" text,
+  "description_de" text,
+  "installation_manual_en" text,
+  "installation_manual_de" text,
+  "latest_version" text,
+  "last_refreshed_at" timestamp NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS "store_extension_version" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "version" text NOT NULL,
+  "changelog_en" text,
+  "changelog_de" text,
+  "released_at" text,
+  UNIQUE ("extension_name", "version")
+);
+
+CREATE TABLE IF NOT EXISTS "store_extension_image" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "url" text NOT NULL,
+  "preview" boolean NOT NULL DEFAULT false,
+  "priority" integer NOT NULL DEFAULT 0,
+  UNIQUE ("extension_name", "url")
+);
+
+CREATE TABLE IF NOT EXISTS "environment_store_extension" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "environment_id" integer NOT NULL REFERENCES "environment"("id") ON DELETE cascade,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "label" text NOT NULL,
+  "version" text NOT NULL,
+  "latest_version" text,
+  "active" boolean NOT NULL,
+  "installed" boolean NOT NULL,
+  "installed_at" text,
+  UNIQUE ("environment_id", "extension_name")
+);
+
+CREATE INDEX IF NOT EXISTS idx_store_extension_version_name ON store_extension_version (extension_name);
+CREATE INDEX IF NOT EXISTS idx_store_extension_image_name ON store_extension_image (extension_name);
+CREATE INDEX IF NOT EXISTS idx_environment_store_extension_env ON environment_store_extension (environment_id);
+CREATE INDEX IF NOT EXISTS idx_environment_store_extension_name ON environment_store_extension (extension_name);
+
+-- Backfill the catalog. An extension is considered store-known if it was
+-- enriched with a store_link during a previous scrape. Rich metadata (icon,
+-- producer, descriptions, pictures, German changelog) is not available from the
+-- old denormalized rows and will be populated on the next scrape; the existing
+-- label is kept as the English label as a best-effort fallback.
+INSERT INTO store_extension (name, rating_average, store_link, label_en, latest_version, last_refreshed_at)
+SELECT DISTINCT ON (ee.name)
+  ee.name,
+  ee.rating_average,
+  ee.store_link,
+  ee.label,
+  ee.latest_version,
+  NOW()
+FROM environment_extension ee
+WHERE ee.store_link IS NOT NULL
+ORDER BY ee.name, ee.id
+ON CONFLICT (name) DO NOTHING;
+
+-- Backfill the per-version changelog catalog from the stored (English) changelog
+-- JSON. Different environments may carry overlapping version subsets, so collapse
+-- duplicates by (name, version).
+INSERT INTO store_extension_version (extension_name, version, changelog_en, released_at)
+SELECT DISTINCT ON (ee.name, elem->>'version')
+  ee.name,
+  elem->>'version',
+  elem->>'text',
+  NULLIF(elem->>'creationDate', '')
+FROM environment_extension ee
+CROSS JOIN LATERAL jsonb_array_elements(ee.changelog) AS elem
+WHERE ee.store_link IS NOT NULL
+  AND ee.changelog IS NOT NULL
+  AND jsonb_typeof(ee.changelog) = 'array'
+  AND COALESCE(elem->>'version', '') <> ''
+ORDER BY ee.name, elem->>'version', ee.id
+ON CONFLICT (extension_name, version) DO NOTHING;
+
+-- Backfill the per-environment links.
+INSERT INTO environment_store_extension (environment_id, extension_name, label, version, latest_version, active, installed, installed_at)
+SELECT ee.environment_id, ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed, ee.installed_at
+FROM environment_extension ee
+WHERE ee.store_link IS NOT NULL
+ON CONFLICT (environment_id, extension_name) DO NOTHING;
+
+-- Remove the migrated rows; environment_extension now holds unknown extensions only.
+DELETE FROM environment_extension WHERE store_link IS NOT NULL;
+
+ALTER TABLE environment_extension DROP COLUMN IF EXISTS rating_average;
+ALTER TABLE environment_extension DROP COLUMN IF EXISTS store_link;
+ALTER TABLE environment_extension DROP COLUMN IF EXISTS changelog;

--- a/api/openapi/spec.yaml
+++ b/api/openapi/spec.yaml
@@ -2920,7 +2920,12 @@ components:
         version:
           type: string
         text:
+          description: Changelog text in English (en_GB).
           type: string
+        textDe:
+          description: Changelog text in German (de_DE), when available.
+          type: string
+          nullable: true
         creationDate:
           type: string
           format: date-time

--- a/api/sql/queries/admin.sql
+++ b/api/sql/queries/admin.sql
@@ -133,9 +133,16 @@ WHERE environment_id = $1
 ORDER BY level, check_id;
 
 -- name: AdminGetEnvironmentExtensions :many
-SELECT id, name, label, active, version, latest_version, installed, store_link
-FROM environment_extension
-WHERE environment_id = $1
+SELECT ese.id, ese.extension_name AS name, ese.label, ese.active, ese.version,
+       ese.latest_version, ese.installed, se.store_link
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+WHERE ese.environment_id = $1
+UNION ALL
+SELECT ee.id, ee.name, ee.label, ee.active, ee.version,
+       ee.latest_version, ee.installed, NULL::text AS store_link
+FROM environment_extension ee
+WHERE ee.environment_id = $1
 ORDER BY name;
 
 -- name: AdminGetEnvironmentTasks :many

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -123,6 +123,8 @@ ON CONFLICT (environment_id, name) DO UPDATE SET label = $3, active = $4, versio
 DELETE FROM environment_extension WHERE environment_id = $1 AND name != ALL($2::text[]);
 
 -- name: UpsertStoreExtension :exec
+-- Localized text fields use COALESCE so a failed locale fetch (NULL value) does
+-- not erase the previously stored translation.
 INSERT INTO store_extension (
   name, store_id, icon_url, producer_name, producer_website, rating_average, store_link,
   release_date, label_en, label_de, short_description_en, short_description_de,
@@ -131,16 +133,28 @@ INSERT INTO store_extension (
 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
 ON CONFLICT (name) DO UPDATE SET
   store_id = $2, icon_url = $3, producer_name = $4, producer_website = $5, rating_average = $6,
-  store_link = $7, release_date = $8, label_en = $9, label_de = $10,
-  short_description_en = $11, short_description_de = $12, description_en = $13, description_de = $14,
-  installation_manual_en = $15, installation_manual_de = $16, latest_version = $17,
+  store_link = $7, release_date = $8,
+  label_en = COALESCE($9, store_extension.label_en),
+  label_de = COALESCE($10, store_extension.label_de),
+  short_description_en = COALESCE($11, store_extension.short_description_en),
+  short_description_de = COALESCE($12, store_extension.short_description_de),
+  description_en = COALESCE($13, store_extension.description_en),
+  description_de = COALESCE($14, store_extension.description_de),
+  installation_manual_en = COALESCE($15, store_extension.installation_manual_en),
+  installation_manual_de = COALESCE($16, store_extension.installation_manual_de),
+  latest_version = $17,
   last_refreshed_at = NOW();
 
 -- name: UpsertStoreExtensionVersion :exec
+-- COALESCE keeps the existing per-language changelog text and date when a locale
+-- fetch fails (NULL), so a transient single-locale store outage does not erase a
+-- previously stored translation.
 INSERT INTO store_extension_version (extension_name, version, changelog_en, changelog_de, released_at)
 VALUES ($1, $2, $3, $4, $5)
 ON CONFLICT (extension_name, version) DO UPDATE SET
-  changelog_en = $3, changelog_de = $4, released_at = $5;
+  changelog_en = COALESCE($3, store_extension_version.changelog_en),
+  changelog_de = COALESCE($4, store_extension_version.changelog_de),
+  released_at = COALESCE($5, store_extension_version.released_at);
 
 -- name: UpsertStoreExtensionImage :exec
 INSERT INTO store_extension_image (extension_name, url, preview, priority)

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -42,8 +42,27 @@ WHERE default_environment_id = $1;
 DELETE FROM environment WHERE id = $1;
 
 -- name: GetEnvironmentExtensions :many
-SELECT id, environment_id, name, label, active, version, latest_version, installed, rating_average, store_link, changelog, installed_at
+-- Extensions unknown to the Shopware store (everything else lives in the
+-- normalized store_extension* tables, linked via environment_store_extension).
+SELECT id, environment_id, name, label, active, version, latest_version, installed, installed_at
 FROM environment_extension WHERE environment_id = $1 ORDER BY name;
+
+-- name: GetEnvironmentStoreExtensions :many
+SELECT ese.id, ese.environment_id, ese.extension_name, ese.label, ese.active, ese.version,
+       ese.latest_version, ese.installed, ese.installed_at,
+       se.store_link, se.rating_average, se.icon_url,
+       se.label_en, se.label_de, se.short_description_en, se.short_description_de
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+WHERE ese.environment_id = $1
+ORDER BY ese.extension_name;
+
+-- name: GetEnvironmentStoreExtensionChangelogs :many
+SELECT sev.extension_name, sev.version, sev.changelog_en, sev.changelog_de, sev.released_at
+FROM store_extension_version sev
+JOIN environment_store_extension ese ON ese.extension_name = sev.extension_name
+WHERE ese.environment_id = $1
+ORDER BY sev.extension_name, sev.version;
 
 -- name: GetEnvironmentScheduledTasks :many
 SELECT id, environment_id, task_id, name, status, interval, overdue, last_execution_time, next_execution_time
@@ -96,12 +115,56 @@ UPDATE environment SET environment_image = $1 WHERE id = $2;
 UPDATE environment SET last_scraped_error = $1, last_scraped_at = NOW(), connection_issue_count = connection_issue_count + 1 WHERE id = $2;
 
 -- name: UpsertEnvironmentExtension :exec
-INSERT INTO environment_extension (environment_id, name, label, active, version, latest_version, installed, rating_average, store_link, changelog, installed_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-ON CONFLICT (environment_id, name) DO UPDATE SET label = $3, active = $4, version = $5, latest_version = $6, installed = $7, rating_average = $8, store_link = $9, changelog = $10, installed_at = $11;
+INSERT INTO environment_extension (environment_id, name, label, active, version, latest_version, installed, installed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (environment_id, name) DO UPDATE SET label = $3, active = $4, version = $5, latest_version = $6, installed = $7, installed_at = $8;
 
 -- name: DeleteEnvironmentExtensionsNotIn :exec
 DELETE FROM environment_extension WHERE environment_id = $1 AND name != ALL($2::text[]);
+
+-- name: UpsertStoreExtension :exec
+INSERT INTO store_extension (
+  name, store_id, icon_url, producer_name, producer_website, rating_average, store_link,
+  release_date, label_en, label_de, short_description_en, short_description_de,
+  description_en, description_de, installation_manual_en, installation_manual_de,
+  latest_version, last_refreshed_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, NOW())
+ON CONFLICT (name) DO UPDATE SET
+  store_id = $2, icon_url = $3, producer_name = $4, producer_website = $5, rating_average = $6,
+  store_link = $7, release_date = $8, label_en = $9, label_de = $10,
+  short_description_en = $11, short_description_de = $12, description_en = $13, description_de = $14,
+  installation_manual_en = $15, installation_manual_de = $16, latest_version = $17,
+  last_refreshed_at = NOW();
+
+-- name: UpsertStoreExtensionVersion :exec
+INSERT INTO store_extension_version (extension_name, version, changelog_en, changelog_de, released_at)
+VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (extension_name, version) DO UPDATE SET
+  changelog_en = $3, changelog_de = $4, released_at = $5;
+
+-- name: UpsertStoreExtensionImage :exec
+INSERT INTO store_extension_image (extension_name, url, preview, priority)
+VALUES ($1, $2, $3, $4)
+ON CONFLICT (extension_name, url) DO UPDATE SET preview = $3, priority = $4;
+
+-- name: DeleteStoreExtensionImagesNotIn :exec
+DELETE FROM store_extension_image WHERE extension_name = $1 AND url != ALL($2::text[]);
+
+-- name: UpsertEnvironmentStoreExtension :exec
+INSERT INTO environment_store_extension (environment_id, extension_name, label, version, latest_version, active, installed, installed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (environment_id, extension_name) DO UPDATE SET
+  label = $3, version = $4, latest_version = $5, active = $6, installed = $7, installed_at = $8;
+
+-- name: DeleteEnvironmentStoreExtensionsNotIn :exec
+DELETE FROM environment_store_extension WHERE environment_id = $1 AND extension_name != ALL($2::text[]);
+
+-- name: GetEnvironmentStoreExtensionImages :many
+SELECT sei.extension_name, sei.url, sei.preview, sei.priority
+FROM store_extension_image sei
+JOIN environment_store_extension ese ON ese.extension_name = sei.extension_name
+WHERE ese.environment_id = $1
+ORDER BY sei.extension_name, sei.priority DESC;
 
 -- name: UpsertEnvironmentQueue :exec
 INSERT INTO environment_queue (environment_id, name, size) VALUES ($1, $2, $3)

--- a/api/sql/queries/user.sql
+++ b/api/sql/queries/user.sql
@@ -52,17 +52,6 @@ WHERE m.user_id = $1
 ORDER BY ec.date DESC
 LIMIT 10;
 
--- name: GetUserExtensions :many
-SELECT ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed,
-       ee.store_link, ee.rating_average, ee.installed_at, ee.changelog,
-       ee.environment_id, e.name AS environment_name, e.url AS environment_url, o.name AS environment_organization_name, e.organization_id AS environment_organization_id
-FROM environment_extension ee
-JOIN environment e ON e.id = ee.environment_id
-JOIN organization o ON o.id = e.organization_id
-JOIN member m ON m.organization_id = e.organization_id
-WHERE m.user_id = $1
-ORDER BY ee.name, e.name;
-
 -- name: GetUserEnvironmentsByOrg :many
 SELECT e.id, e.name, e.url, e.favicon, e.status, e.shopware_version, e.last_scraped_at, e.last_scraped_error,
        e.organization_id, o.name AS organization_name, s.id AS shop_id, s.name AS shop_name
@@ -92,16 +81,42 @@ WHERE m.user_id = $1 AND e.organization_id = $2
 ORDER BY ec.date DESC
 LIMIT 10;
 
--- name: GetUserExtensionsByOrg :many
+-- name: GetUserStoreExtensionsByOrg :many
+SELECT ese.extension_name AS name, ese.label, ese.version, ese.latest_version, ese.active, ese.installed,
+       se.store_link, se.rating_average, ese.installed_at,
+       ese.environment_id, e.name AS environment_name, e.url AS environment_url,
+       o.name AS environment_organization_name, e.organization_id AS environment_organization_id
+FROM environment_store_extension ese
+JOIN store_extension se ON se.name = ese.extension_name
+JOIN environment e ON e.id = ese.environment_id
+JOIN organization o ON o.id = e.organization_id
+JOIN member m ON m.organization_id = e.organization_id
+WHERE m.user_id = $1 AND e.organization_id = $2
+ORDER BY ese.extension_name, e.name;
+
+-- name: GetUserUnknownExtensionsByOrg :many
 SELECT ee.name, ee.label, ee.version, ee.latest_version, ee.active, ee.installed,
-       ee.store_link, ee.rating_average, ee.installed_at, ee.changelog,
-       ee.environment_id, e.name AS environment_name, e.url AS environment_url, o.name AS environment_organization_name, e.organization_id AS environment_organization_id
+       NULL::text AS store_link, NULL::integer AS rating_average, ee.installed_at,
+       ee.environment_id, e.name AS environment_name, e.url AS environment_url,
+       o.name AS environment_organization_name, e.organization_id AS environment_organization_id
 FROM environment_extension ee
 JOIN environment e ON e.id = ee.environment_id
 JOIN organization o ON o.id = e.organization_id
 JOIN member m ON m.organization_id = e.organization_id
 WHERE m.user_id = $1 AND e.organization_id = $2
 ORDER BY ee.name, e.name;
+
+-- name: GetUserStoreExtensionChangelogsByOrg :many
+SELECT DISTINCT sev.extension_name, sev.version, sev.changelog_en, sev.changelog_de, sev.released_at
+FROM store_extension_version sev
+WHERE sev.extension_name IN (
+  SELECT ese.extension_name
+  FROM environment_store_extension ese
+  JOIN environment e ON e.id = ese.environment_id
+  JOIN member m ON m.organization_id = e.organization_id
+  WHERE m.user_id = $1 AND e.organization_id = $2
+)
+ORDER BY sev.extension_name, sev.version;
 
 -- name: IsOrganizationMember :one
 SELECT COUNT(*) > 0 AS is_member FROM member WHERE organization_id = $1 AND user_id = $2;

--- a/api/sql/schema.sql
+++ b/api/sql/schema.sql
@@ -218,6 +218,10 @@ CREATE TABLE "environment_check" (
   UNIQUE ("environment_id", "check_id")
 );
 
+-- environment_extension holds only extensions that are NOT known to the Shopware
+-- store (api.shopware.com). Store-known extensions live in the normalized
+-- store_extension* tables and are linked per environment via
+-- environment_store_extension.
 CREATE TABLE "environment_extension" (
   "id" serial PRIMARY KEY NOT NULL,
   "environment_id" integer NOT NULL REFERENCES "environment"("id") ON DELETE cascade,
@@ -227,12 +231,80 @@ CREATE TABLE "environment_extension" (
   "version" text NOT NULL,
   "latest_version" text,
   "installed" boolean NOT NULL,
-  "rating_average" integer,
-  "store_link" text,
-  "changelog" jsonb,
   "installed_at" text,
   UNIQUE ("environment_id", "name")
 );
+
+-- store_extension is the deduplicated catalog of extensions available on the
+-- Shopware store. One row per technical name, shared across all environments.
+-- Localized text fields are stored per language (en / de). The
+-- compatibility-capped "latest version" is environment-specific and therefore
+-- lives on the link table environment_store_extension, not here.
+CREATE TABLE "store_extension" (
+  "name" text PRIMARY KEY NOT NULL,
+  "store_id" integer,
+  "icon_url" text,
+  "producer_name" text,
+  "producer_website" text,
+  "rating_average" integer,
+  "store_link" text,
+  "release_date" text,
+  "label_en" text,
+  "label_de" text,
+  "short_description_en" text,
+  "short_description_de" text,
+  "description_en" text,
+  "description_de" text,
+  "installation_manual_en" text,
+  "installation_manual_de" text,
+  "latest_version" text,
+  "last_refreshed_at" timestamp NOT NULL DEFAULT NOW()
+);
+
+-- store_extension_version is the per-version changelog catalog for a store
+-- extension, with the changelog text stored per language (en / de).
+CREATE TABLE "store_extension_version" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "version" text NOT NULL,
+  "changelog_en" text,
+  "changelog_de" text,
+  "released_at" text,
+  UNIQUE ("extension_name", "version")
+);
+
+-- store_extension_image holds the store listing pictures (screenshots) for a
+-- store extension, used to build a richer extension listing in the UI.
+CREATE TABLE "store_extension_image" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "url" text NOT NULL,
+  "preview" boolean NOT NULL DEFAULT false,
+  "priority" integer NOT NULL DEFAULT 0,
+  UNIQUE ("extension_name", "url")
+);
+
+-- environment_store_extension links an environment to a store_extension and
+-- records the per-environment install state. latest_version is the latest
+-- release the store reports as compatible with this environment's Shopware
+-- version, so it is stored here rather than on the shared catalog row.
+CREATE TABLE "environment_store_extension" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "environment_id" integer NOT NULL REFERENCES "environment"("id") ON DELETE cascade,
+  "extension_name" text NOT NULL REFERENCES "store_extension"("name") ON DELETE cascade,
+  "label" text NOT NULL,
+  "version" text NOT NULL,
+  "latest_version" text,
+  "active" boolean NOT NULL,
+  "installed" boolean NOT NULL,
+  "installed_at" text,
+  UNIQUE ("environment_id", "extension_name")
+);
+
+CREATE INDEX IF NOT EXISTS idx_store_extension_version_name ON store_extension_version (extension_name);
+CREATE INDEX IF NOT EXISTS idx_store_extension_image_name ON store_extension_image (extension_name);
+CREATE INDEX IF NOT EXISTS idx_environment_store_extension_env ON environment_store_extension (environment_id);
+CREATE INDEX IF NOT EXISTS idx_environment_store_extension_name ON environment_store_extension (extension_name);
 
 CREATE TABLE "environment_queue" (
   "id" serial PRIMARY KEY NOT NULL,

--- a/api/sql/schema.sql
+++ b/api/sql/schema.sql
@@ -236,10 +236,8 @@ CREATE TABLE "environment_extension" (
 );
 
 -- store_extension is the deduplicated catalog of extensions available on the
--- Shopware store. One row per technical name, shared across all environments.
--- Localized text fields are stored per language (en / de). The
--- compatibility-capped "latest version" is environment-specific and therefore
--- lives on the link table environment_store_extension, not here.
+-- Shopware store, one row per technical name. The compatibility-capped "latest
+-- version" is environment-specific and lives on environment_store_extension, not here.
 CREATE TABLE "store_extension" (
   "name" text PRIMARY KEY NOT NULL,
   "store_id" integer,

--- a/frontend/src/components/modal/ExtensionChangelog.vue
+++ b/frontend/src/components/modal/ExtensionChangelog.vue
@@ -21,7 +21,10 @@
           </div>
 
           <!-- eslint-disable vue/no-v-html -->
-          <div class="prose prose-sm dark:prose-invert max-w-none" v-html="changeLog.text" />
+          <div
+            class="prose prose-sm dark:prose-invert max-w-none"
+            v-html="changelogText(changeLog)"
+          />
           <!-- eslint-enable vue/no-v-html -->
         </li>
       </ul>
@@ -40,7 +43,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/u
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CircleX } from "lucide-vue-next";
 import { formatDate } from "@/helpers/formatter";
+import { useChangelogText } from "@/helpers/changelog";
 import type { ExtensionWithChangelog } from "@/composables/useExtensionChangelogModal";
+
+const changelogText = useChangelogText();
 
 interface Props {
   show: boolean;

--- a/frontend/src/components/modal/ShopChangelog.vue
+++ b/frontend/src/components/modal/ShopChangelog.vue
@@ -64,7 +64,10 @@
                     }}</span>
                   </div>
                   <!-- eslint-disable vue/no-v-html -->
-                  <div class="prose prose-sm dark:prose-invert max-w-none" v-html="entry.text" />
+                  <div
+                    class="prose prose-sm dark:prose-invert max-w-none"
+                    v-html="changelogText(entry)"
+                  />
                   <!-- eslint-enable vue/no-v-html -->
                 </li>
               </ul>
@@ -79,9 +82,12 @@
 <script setup lang="ts">
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { formatDateTime } from "@/helpers/formatter";
+import { useChangelogText } from "@/helpers/changelog";
 import type { components } from "@/types/api";
 
 type AccountChangelog = components["schemas"]["AccountChangelog"];
+
+const changelogText = useChangelogText();
 
 interface Props {
   show: boolean;

--- a/frontend/src/helpers/changelog.ts
+++ b/frontend/src/helpers/changelog.ts
@@ -1,3 +1,26 @@
+import { useLocale } from "@/composables/useLocale";
+
+interface LocalizedChangelogEntry {
+  text: string;
+  textDe?: string | null;
+}
+
+/**
+ * Returns a function that resolves an extension changelog entry's text for the
+ * active UI locale, falling back to the English text when no German translation
+ * is available.
+ */
+export function useChangelogText() {
+  const { locale } = useLocale();
+
+  return (entry: LocalizedChangelogEntry): string => {
+    if (locale.value === "de" && entry.textDe) {
+      return entry.textDe;
+    }
+    return entry.text;
+  };
+}
+
 export function sumChanges(changes: {
   oldShopwareVersion?: string | null;
   newShopwareVersion?: string | null;

--- a/frontend/src/helpers/changelog.ts
+++ b/frontend/src/helpers/changelog.ts
@@ -5,11 +5,8 @@ interface LocalizedChangelogEntry {
   textDe?: string | null;
 }
 
-/**
- * Returns a function that resolves an extension changelog entry's text for the
- * active UI locale, falling back to the English text when no German translation
- * is available.
- */
+// Resolves an extension changelog entry's text for the active UI locale, falling
+// back to English when no German translation is available.
 export function useChangelogText() {
   const { locale } = useLocale();
 

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -1735,7 +1735,10 @@ export interface components {
     };
     ExtensionChangelogEntry: {
       version: string;
+      /** @description Changelog text in English (en_GB). */
       text: string;
+      /** @description Changelog text in German (de_DE), when available. */
+      textDe?: string | null;
       /** Format: date-time */
       creationDate: string;
     };

--- a/frontend/src/views/admin/DetailEnvironment.vue
+++ b/frontend/src/views/admin/DetailEnvironment.vue
@@ -124,7 +124,7 @@
           <div v-else class="space-y-2">
             <div
               v-for="ext in environment.extensions"
-              :key="ext.id"
+              :key="ext.name"
               class="flex items-center gap-3 rounded-xl border bg-card px-4 py-3"
             >
               <div class="min-w-0 flex-1">

--- a/frontend/src/views/environment/detail/DetailChangelog.vue
+++ b/frontend/src/views/environment/detail/DetailChangelog.vue
@@ -158,7 +158,7 @@
                   <!-- eslint-disable vue/no-v-html -->
                   <div
                     class="prose prose-sm dark:prose-invert max-w-none text-xs"
-                    v-html="entryLog.text"
+                    v-html="changelogText(entryLog)"
                   />
                   <!-- eslint-enable vue/no-v-html -->
                 </div>
@@ -174,6 +174,7 @@
 <script setup lang="ts">
 import { reactive } from "vue";
 import { formatDate } from "@/helpers/formatter";
+import { useChangelogText } from "@/helpers/changelog";
 import type { components } from "@/types/api";
 import { useEnvironmentDetail } from "@/composables/useEnvironmentDetail";
 
@@ -182,6 +183,7 @@ import { Badge } from "@/components/ui/badge";
 type AccountChangelog = components["schemas"]["AccountChangelog"];
 
 const { environment } = useEnvironmentDetail();
+const changelogText = useChangelogText();
 
 const expanded = reactive(new Set<number>());
 

--- a/k8s/preview/manifests.yml
+++ b/k8s/preview/manifests.yml
@@ -25,7 +25,9 @@ stringData:
   POSTGRES_DB: "shopmon"
   POSTGRES_USER: "shopmon"
   POSTGRES_PASSWORD: "shopmon"
-  APP_SECRET: "preview-secret"
+  # APP_SECRET is the AES key for credential encryption and must be exactly
+  # 16, 24, or 32 bytes. This 32-byte value targets AES-256.
+  APP_SECRET: "preview-app-secret-32-bytes-long"
   APP_SITESPEED_API_KEY: "secret"
   APP_S3_ACCESS_KEY_ID: "rustfsadmin"
   APP_S3_SECRET_ACCESS_KEY: "rustfsadmin"


### PR DESCRIPTION
Per-environment extension rows previously duplicated store metadata
(latest version, rating, store link, changelog) on every environment.
This normalizes store-known extensions into a deduplicated catalog and
links each environment to it, keeping the per-environment table for
extensions that are unknown to api.shopware.com.

New tables:
- store_extension: deduplicated catalog (one row per technical name) with
  rich metadata for a future listing UI (icon, producer, pictures via
  store_extension_image, localized label/description/short description/
  installation manual in en + de, rating, store link, release date).
- store_extension_version: per-version changelog catalog, English and
  German text per version.
- store_extension_image: store listing pictures.
- environment_store_extension: per-environment link carrying install
  state and the compatibility-capped latest version (which is
  Shopware-version specific and therefore stays per environment).

environment_extension keeps only extensions not found in the store; its
store-specific columns are dropped. Migration 000013 backfills the new
tables from existing rows and is reversible.

Changelog is now fetched in both English (en_GB) and German (de_DE). The
store locale must use the underscore form; the previous hyphenated
"en-GB" was ignored by the API, so changelog text always came back in the
producer's default language. The API exposes the German text via a new
optional ExtensionChangelogEntry.textDe field and the frontend renders
the changelog in the active UI locale.

Read handlers reassemble the unified extension list from the normalized
tables, computing the compatibility-capped changelog at read time, so the
existing API response shape is preserved (aside from the additive textDe).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DSrY2yUFyVsYq1dF4kB3qe