### PR TITLE
fix(extensions): send language and shopwareVersion as query params for compatibility check

### DIFF
--- a/api/internal/handler/info_test.go
+++ b/api/internal/handler/info_test.go
@@ -23,10 +23,12 @@ func TestCheckExtensionCompatibility(t *testing.T) {
 		}
 		assert.Equal(t, "POST", r.Method)
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		// language and the current Shopware version are passed as query params.
+		assert.Equal(t, "en-GB", r.URL.Query().Get("language"))
+		assert.Equal(t, "6.5.0.0", r.URL.Query().Get("shopwareVersion"))
 
-		// Decode and verify the request body
+		// The body carries only the future version and the plugins.
 		var req struct {
-			ShopwareVersion       string `json:"shopwareVersion"`
 			FutureShopwareVersion string `json:"futureShopwareVersion"`
 			Plugins               []struct {
 				Name    string `json:"name"`
@@ -34,7 +36,6 @@ func TestCheckExtensionCompatibility(t *testing.T) {
 			} `json:"plugins"`
 		}
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
-		assert.Equal(t, "6.5.0.0", req.ShopwareVersion)
 		assert.Equal(t, "6.6.0.0", req.FutureShopwareVersion)
 		assert.Len(t, req.Plugins, 1)
 		assert.Equal(t, "SwagPayPal", req.Plugins[0].Name)

--- a/api/internal/shopwareaccount/compatibility.go
+++ b/api/internal/shopwareaccount/compatibility.go
@@ -15,11 +15,12 @@ type CompatibilityExtension struct {
 	Version string `json:"version"`
 }
 
-// compatibilityRequest is the payload the Shopware auto-update API expects.
+// compatibilityRequest is the JSON body the Shopware auto-update API expects.
+// The current Shopware version and language are passed as query parameters, not
+// in the body (see CheckExtensionCompatibility).
 type compatibilityRequest struct {
-	CurrentVersion string                   `json:"shopwareVersion"`
-	FutureVersion  string                   `json:"futureShopwareVersion"`
-	Plugins        []CompatibilityExtension `json:"plugins"`
+	FutureVersion string                   `json:"futureShopwareVersion"`
+	Plugins       []CompatibilityExtension `json:"plugins"`
 }
 
 // CompatibilityResponse is the raw result of an autoupdate compatibility check.
@@ -34,9 +35,8 @@ type CompatibilityResponse struct {
 // It returns the raw response so the caller controls response semantics.
 func (c *Client) CheckExtensionCompatibility(ctx context.Context, currentVersion, futureVersion string, extensions []CompatibilityExtension) (*CompatibilityResponse, error) {
 	reqBody, err := json.Marshal(compatibilityRequest{
-		CurrentVersion: currentVersion,
-		FutureVersion:  futureVersion,
-		Plugins:        extensions,
+		FutureVersion: futureVersion,
+		Plugins:       extensions,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal request: %w", err)
@@ -46,6 +46,15 @@ func (c *Client) CheckExtensionCompatibility(ctx context.Context, currentVersion
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
+	// The autoupdate API expects the current Shopware version and language as
+	// query parameters (the body only carries futureShopwareVersion + plugins);
+	// without `language` the store rejects the request with
+	// REQUEST_PARAMETER_LANGUAGE_NOT_GIVEN. The response is version compatibility
+	// data, not localized prose, so a fixed English locale is sufficient.
+	q := req.URL.Query()
+	q.Set("language", "en-GB")
+	q.Set("shopwareVersion", currentVersion)
+	req.URL.RawQuery = q.Encode()
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)


### PR DESCRIPTION
## Problem

`POST /api/info/extension-compatibility` was returning **502**. The Shopware autoupdate API (`/swplatform/autoupdate`) now rejects the call with:

```
ShopwarePlatformException-2 / REQUEST_PARAMETER_LANGUAGE_NOT_GIVEN
"Missing parameter language"
```

The client sent `shopwareVersion`, `futureShopwareVersion`, and `plugins` all in the JSON body and no `language` parameter at all.

## Fix

Match Shopware's own `StoreClient::getExtensionCompatibilities` contract:
- **Query params:** `language=en-GB` and `shopwareVersion` (current version)
- **Body:** only `futureShopwareVersion` + `plugins`

The response is version-compatibility data (not localized prose), so a fixed English locale is sufficient.

## Testing

- `go build`, `go vet`, and the handler tests pass; the mock now asserts the new query params + slimmed body.
- Verified end-to-end against the running app: the endpoint returns **200** with real data (e.g. `FroshTools → "Already compatible"`) instead of 502.

Standalone fix, independent of #713.

🤖 Generated with [Claude Code](https://claude.com/claude-code)