### PR TITLE
fix: retain environment changelog history

### DIFF
--- a/api/internal/database/queries/cleanup.sql.go
+++ b/api/internal/database/queries/cleanup.sql.go
@@ -28,15 +28,6 @@ func (q *Queries) CleanupExpiredSessions(ctx context.Context) error {
 	return err
 }
 
-const cleanupOldChangelogData = `-- name: CleanupOldChangelogData :exec
-DELETE FROM environment_changelog WHERE date < NOW() - interval '180 days'
-`
-
-func (q *Queries) CleanupOldChangelogData(ctx context.Context) error {
-	_, err := q.db.Exec(ctx, cleanupOldChangelogData)
-	return err
-}
-
 const cleanupOldNotifications = `-- name: CleanupOldNotifications :exec
 DELETE FROM user_notification WHERE read = true AND created_at < NOW() - interval '90 days'
 `

--- a/api/internal/jobs/cleanup.go
+++ b/api/internal/jobs/cleanup.go
@@ -44,12 +44,9 @@ func (h *CleanupHandler) HandleOldDataCleanup(ctx context.Context, _ OldDataClea
 	if err := h.queries.CleanupOldSitespeedData(ctx); err != nil {
 		return fmt.Errorf("cleanup old sitespeed data: %w", err)
 	}
-	if err := h.queries.CleanupOldChangelogData(ctx); err != nil {
-		return fmt.Errorf("cleanup old changelog data: %w", err)
-	}
 	if err := h.queries.CleanupExpiredBans(ctx); err != nil {
 		return fmt.Errorf("cleanup expired bans: %w", err)
 	}
-	slog.Info("cleaned up old data: sessions, notifications, sitespeed, changelog, bans")
+	slog.Info("cleaned up old data: sessions, notifications, sitespeed, bans")
 	return nil
 }

--- a/api/sql/queries/cleanup.sql
+++ b/api/sql/queries/cleanup.sql
@@ -7,9 +7,6 @@ DELETE FROM user_notification WHERE read = true AND created_at < NOW() - interva
 -- name: CleanupOldSitespeedData :exec
 DELETE FROM environment_sitespeed WHERE created_at < NOW() - interval '90 days';
 
--- name: CleanupOldChangelogData :exec
-DELETE FROM environment_changelog WHERE date < NOW() - interval '180 days';
-
 -- name: CleanupExpiredBans :exec
 UPDATE "user" SET banned = false, ban_reason = NULL, ban_expires = NULL
 WHERE banned = true AND ban_expires IS NOT NULL AND ban_expires < NOW();


### PR DESCRIPTION
Removes the `CleanupOldChangelogData` query and its call in the old-data cleanup job, so environment changelogs are no longer deleted after 180 days and the full history is retained.

Fixes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)