### PR TITLE
Fix extension update detection across multiple environments

### DIFF
--- a/frontend/src/composables/useAccountExtensions.spec.ts
+++ b/frontend/src/composables/useAccountExtensions.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  type AccountExtension,
+  type AccountExtensionEnvironment,
+  envHasUpdate,
+  hasUpdate,
+  updateCount,
+} from "./useAccountExtensions";
+
+function env(overrides: Partial<AccountExtensionEnvironment> = {}): AccountExtensionEnvironment {
+  return {
+    environmentId: 1,
+    environmentName: "prod",
+    environmentOrganizationName: "org",
+    environmentOrganizationId: "org-1",
+    environmentUrl: "https://example.com",
+    shopId: 1,
+    shopName: "Shop",
+    active: true,
+    version: "1.0.0",
+    latestVersion: "1.0.0",
+    installed: true,
+    ...overrides,
+  };
+}
+
+function ext(overrides: Partial<AccountExtension> = {}): AccountExtension {
+  return {
+    name: "SwagExample",
+    label: "Example",
+    version: "1.0.0",
+    latestVersion: "1.0.0",
+    active: true,
+    installed: true,
+    environments: [],
+    ...overrides,
+  } as AccountExtension;
+}
+
+describe("envHasUpdate", () => {
+  it("is true when an installed environment runs behind the latest version", () => {
+    expect(envHasUpdate(env({ version: "1.0.0", latestVersion: "1.1.0" }))).toBe(true);
+  });
+
+  it("is false when up to date or not installed", () => {
+    expect(envHasUpdate(env({ version: "1.1.0", latestVersion: "1.1.0" }))).toBe(false);
+    expect(envHasUpdate(env({ version: "1.0.0", latestVersion: "1.1.0", installed: false }))).toBe(
+      false,
+    );
+  });
+});
+
+describe("hasUpdate", () => {
+  it("is true when any environment runs an outdated version", () => {
+    const extension = ext({
+      // Aggregate top-level fields report the extension as up to date...
+      version: "1.1.0",
+      latestVersion: "1.1.0",
+      environments: [
+        env({ environmentId: 1, version: "1.1.0", latestVersion: "1.1.0" }),
+        // ...but a second environment is still behind and must be counted.
+        env({ environmentId: 2, version: "1.0.0", latestVersion: "1.1.0" }),
+      ],
+    });
+
+    expect(hasUpdate(extension)).toBe(true);
+  });
+
+  it("is false when every environment is up to date", () => {
+    const extension = ext({
+      environments: [
+        env({ environmentId: 1, version: "1.1.0", latestVersion: "1.1.0" }),
+        env({ environmentId: 2, version: "1.1.0", latestVersion: "1.1.0" }),
+      ],
+    });
+
+    expect(hasUpdate(extension)).toBe(false);
+  });
+});
+
+describe("updateCount", () => {
+  it("counts every environment that has an update available", () => {
+    const extension = ext({
+      environments: [
+        env({ environmentId: 1, version: "1.0.0", latestVersion: "1.1.0" }),
+        env({ environmentId: 2, version: "1.1.0", latestVersion: "1.1.0" }),
+        env({ environmentId: 3, version: "1.0.0", latestVersion: "1.1.0" }),
+      ],
+    });
+
+    expect(updateCount(extension)).toBe(2);
+  });
+});

--- a/frontend/src/composables/useAccountExtensions.spec.ts
+++ b/frontend/src/composables/useAccountExtensions.spec.ts
@@ -76,6 +76,11 @@ describe("hasUpdate", () => {
 
     expect(hasUpdate(extension)).toBe(false);
   });
+
+  it("is false when the environments list is empty", () => {
+    // ext() defaults to environments: [] — no environment to check means no update.
+    expect(hasUpdate(ext())).toBe(false);
+  });
 });
 
 describe("updateCount", () => {

--- a/frontend/src/composables/useAccountExtensions.ts
+++ b/frontend/src/composables/useAccountExtensions.ts
@@ -13,12 +13,15 @@ export function normalizeWebsite(url?: string | null): string | null {
   return url;
 }
 
-export function hasUpdate(ext: AccountExtension): boolean {
-  return !!(ext.installed && ext.latestVersion && ext.version !== ext.latestVersion);
-}
-
 export function envHasUpdate(env: AccountExtensionEnvironment): boolean {
   return !!(env.installed && env.latestVersion && env.version !== env.latestVersion);
+}
+
+// An extension has an update when any environment it is installed in runs an
+// outdated version. The aggregate top-level version fields only reflect a single
+// environment, so they cannot be used here without missing updates in others.
+export function hasUpdate(ext: AccountExtension): boolean {
+  return ext.environments.some((e) => envHasUpdate(e));
 }
 
 export function updateCount(ext: AccountExtension): number {

--- a/frontend/src/views/Dashboard.vue
+++ b/frontend/src/views/Dashboard.vue
@@ -235,6 +235,7 @@ import { useI18n } from "vue-i18n";
 import { sumChanges } from "@/helpers/changelog";
 import { formatDate } from "@/helpers/formatter";
 import { api } from "@/helpers/api";
+import { hasUpdate } from "@/composables/useAccountExtensions";
 import type { components } from "@/types/api";
 import {
   useAccountEnvironments,
@@ -315,12 +316,10 @@ const errorCount = computed(
   () => (shops.value ?? []).filter((s) => defaultEnv(s)?.status === "red").length,
 );
 
-// Outdated extensions count
-const outdatedExtensionCount = computed(
-  () =>
-    extensions.value.filter((e) => e.installed && e.latestVersion && e.version !== e.latestVersion)
-      .length,
-);
+// Outdated extensions count. Uses the shared helper so it stays consistent with
+// the extensions list, which counts an extension as outdated when any of its
+// environments runs a version behind the latest.
+const outdatedExtensionCount = computed(() => extensions.value.filter((e) => hasUpdate(e)).length);
 
 // Shopware version distribution (still per-environment for accuracy)
 const versionDistribution = computed(() => {


### PR DESCRIPTION
## Summary
Fixed extension update detection to correctly identify outdated extensions across all environments, not just the aggregate top-level version fields.

## Key Changes
- **Updated `hasUpdate()` logic**: Changed from checking only the top-level `version` and `latestVersion` fields to checking if any environment has an update available via `envHasUpdate()`
- **Added comprehensive test coverage**: Created `useAccountExtensions.spec.ts` with tests for `envHasUpdate()`, `hasUpdate()`, and `updateCount()` functions
- **Fixed Dashboard outdated count**: Updated the `outdatedExtensionCount` computed property to use the corrected `hasUpdate()` helper for consistency

## Implementation Details
The previous implementation only compared aggregate top-level version fields, which represent a single environment's state. This caused extensions with updates available in some environments to be missed if the aggregate fields showed the extension as up-to-date. The fix ensures that an extension is marked as having an update if **any** of its installed environments runs a version behind the latest version.

The test suite validates:
- Individual environment update detection
- Extension-level update detection across multiple environments
- Accurate counting of environments with available updates

https://claude.ai/code/session_01JYJFHGjtDNgeCoZiUzQE3N