### PR TITLE
refactor: consolidate pointer and timestamp helpers with generics

### DIFF
--- a/api/internal/database/timestamp.go
+++ b/api/internal/database/timestamp.go
@@ -1,0 +1,20 @@
+package database
+
+import (
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// Time returns the wall time stored in ts. Invalid timestamps yield the zero time.
+func Time(ts pgtype.Timestamp) time.Time {
+	return ts.Time
+}
+
+// TimePtr returns a pointer to the wall time stored in ts, or nil when invalid.
+func TimePtr(ts pgtype.Timestamp) *time.Time {
+	if !ts.Valid {
+		return nil
+	}
+	return &ts.Time
+}

--- a/api/internal/deployment/postgres/repository.go
+++ b/api/internal/deployment/postgres/repository.go
@@ -5,8 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"time"
 
+	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/deployment"
 	"github.com/jackc/pgx/v5"
@@ -155,7 +155,7 @@ func (r *Repository) ListAPIKeys(ctx context.Context, shopID int32) ([]deploymen
 			Name:       row.Name,
 			Scopes:     scopes,
 			CreatedAt:  row.CreatedAt.Time,
-			LastUsedAt: timestampPtr(row.LastUsedAt),
+			LastUsedAt: database.TimePtr(row.LastUsedAt),
 		})
 	}
 	return result, nil
@@ -205,7 +205,7 @@ func (r *Repository) FindAPIKeyByTokenHash(ctx context.Context, tokenHash string
 		TokenHash:      row.Token,
 		Scopes:         scopes,
 		CreatedAt:      row.CreatedAt.Time,
-		LastUsedAt:     timestampPtr(row.LastUsedAt),
+		LastUsedAt:     database.TimePtr(row.LastUsedAt),
 	}, nil
 }
 
@@ -228,11 +228,4 @@ func decodeScopes(raw json.RawMessage) ([]string, error) {
 		return []string{}, nil
 	}
 	return scopes, nil
-}
-
-func timestampPtr(value pgtype.Timestamp) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	return &value.Time
 }

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -101,13 +101,3 @@ func (h *Handler) getActiveOrganizationID(r *http.Request) *string {
 	}
 	return session.ActiveOrganizationID
 }
-
-// int32PtrToIntPtr preserves nullability while mapping storage identifiers to
-// their OpenAPI representation.
-func int32PtrToIntPtr(value *int32) *int {
-	if value == nil {
-		return nil
-	}
-	converted := int(*value)
-	return &converted
-}

--- a/api/internal/handler/shop.go
+++ b/api/internal/handler/shop.go
@@ -8,6 +8,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
 	"github.com/friendsofshopware/shopmon/api/internal/monitoring"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	environmentread "github.com/friendsofshopware/shopmon/api/internal/readmodel/environment"
 )
 
@@ -80,7 +81,7 @@ func (h *Handler) CreateShop(w http.ResponseWriter, r *http.Request, orgId api.O
 		Description:          req.Description,
 		GitUrl:               req.GitUrl,
 		OrganizationId:       orgId,
-		DefaultEnvironmentId: int32PtrToIntPtr(&result.EnvironmentID),
+		DefaultEnvironmentId: ptr.Int(&result.EnvironmentID),
 	})
 }
 

--- a/api/internal/handler/shop_test.go
+++ b/api/internal/handler/shop_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
+
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +64,7 @@ func TestCreateShop(t *testing.T) {
 
 	body, _ := json.Marshal(api.CreateShopRequest{
 		Name:            "New Shop",
-		Description:     strPtr("A test shop"),
+		Description:     ptr.Of("A test shop"),
 		EnvironmentName: "Production",
 		EnvironmentUrl:  mockShopware.URL,
 		ClientId:        "test-client-id",
@@ -149,8 +151,4 @@ func TestDeleteShop_WithEnvironments_Fails(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assert.Equal(t, http.StatusConflict, resp.StatusCode)
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/api/internal/monitoring/scrape/persist_test.go
+++ b/api/internal/monitoring/scrape/persist_test.go
@@ -9,6 +9,7 @@ import (
 	catalogsync "github.com/friendsofshopware/shopmon/api/internal/catalog/sync"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -103,17 +104,17 @@ func baseScrapeResult() scrapeResult {
 		extensions: []extensionEntry{
 			{
 				Name: "FroshTools", Label: "Frosh Tools", Active: true, Version: "1.0.0",
-				LatestVersion: strPtr("1.2.0"), Installed: true, InstalledAt: strPtr("2024-01-01T00:00:00Z"),
+				LatestVersion: ptr.Of("1.2.0"), Installed: true, InstalledAt: ptr.Of("2024-01-01T00:00:00Z"),
 				isStore: true,
 			},
 			{
 				Name: "CustomPlugin", Label: "Custom Plugin", Active: true, Version: "2.0.0",
-				Installed: true, InstalledAt: strPtr("2024-02-01T00:00:00Z"),
+				Installed: true, InstalledAt: ptr.Of("2024-02-01T00:00:00Z"),
 			},
 		},
 		scheduledTasks: []shopwareScheduledTask{
 			{ID: "task-1", Name: "log_entry.cleanup", Status: "scheduled", RunInterval: 86400,
-				LastExecutionTime: strPtr("2024-01-01T00:00:00Z"), NextExecutionTime: strPtr("2999-01-01T00:00:00Z")},
+				LastExecutionTime: ptr.Of("2024-01-01T00:00:00Z"), NextExecutionTime: ptr.Of("2999-01-01T00:00:00Z")},
 		},
 		queueEntries: []shopwareQueueEntry{
 			{Name: "async", Size: json.Number("42")},
@@ -123,7 +124,7 @@ func baseScrapeResult() scrapeResult {
 			{ID: "check.a", Level: checker.StatusGreen, MessageKey: "check.a", Source: "env"},
 			{ID: "check.b", Level: checker.StatusYellow, MessageKey: "check.b", Source: "worker", Link: "https://docs.example.com"},
 		},
-		favicon: strPtr("https://shop.example.com/favicon.ico"),
+		favicon: ptr.Of("https://shop.example.com/favicon.ico"),
 	}
 }
 
@@ -340,13 +341,13 @@ func TestResolveExtensionsFromCatalog(t *testing.T) {
 	require.NoError(t, err, "seed extra catalog rows")
 
 	extensions := []extensionEntry{
-		{Name: "FroshTools", Version: "1.0.0", LatestVersion: strPtr("1.1.0")}, // compat row 1.2.0 must win
-		{Name: "AcmeNull", Version: "2.0.0", LatestVersion: strPtr("2.5.0")},   // NULL compat row keeps shop value
+		{Name: "FroshTools", Version: "1.0.0", LatestVersion: ptr.Of("1.1.0")}, // compat row 1.2.0 must win
+		{Name: "AcmeNull", Version: "2.0.0", LatestVersion: ptr.Of("2.5.0")},   // NULL compat row keeps shop value
 		{Name: "AcmePending", Version: "3.0.0"},                                // no compat row: prior link value
 		{Name: "CustomPlugin", Version: "2.0.0"},                               // not in catalog
 	}
 	oldExtensions := []existingExtension{
-		{Name: "AcmePending", Version: "3.0.0", IsStore: true, LatestVersion: strPtr("3.9.0")},
+		{Name: "AcmePending", Version: "3.0.0", IsStore: true, LatestVersion: ptr.Of("3.9.0")},
 	}
 
 	catalog, err := h.resolveExtensionsFromCatalog(ctx, extensions, oldExtensions, "6.5.0.0")
@@ -366,8 +367,8 @@ func TestResolveExtensionsFromCatalog(t *testing.T) {
 		assert.Equalf(t, wantStore, ext.isStore, "%s: isStore", ext.Name)
 		assert.Equalf(t, wantLatest, ext.LatestVersion, "%s: latest version", ext.Name)
 	}
-	assertExt(0, true, strPtr("1.2.0"))
-	assertExt(1, true, strPtr("2.5.0"))
-	assertExt(2, true, strPtr("3.9.0"))
+	assertExt(0, true, ptr.Of("1.2.0"))
+	assertExt(1, true, ptr.Of("2.5.0"))
+	assertExt(2, true, ptr.Of("3.9.0"))
 	assertExt(3, false, nil)
 }

--- a/api/internal/monitoring/scrape/service.go
+++ b/api/internal/monitoring/scrape/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/environment"
 	"github.com/friendsofshopware/shopmon/api/internal/mail"
 	"github.com/friendsofshopware/shopmon/api/internal/notify"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel"
@@ -123,7 +124,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 			log.Warn("authentication failed", "error", err)
 			h.notifyAuthError(ctx, env, err)
 			if err := h.queries.UpdateEnvironmentScrapeError(ctx, queries.UpdateEnvironmentScrapeErrorParams{
-				LastScrapedError: strPtr(fmt.Sprintf("Authentication failed: %v", err)),
+				LastScrapedError: ptr.Of(fmt.Sprintf("Authentication failed: %v", err)),
 				ID:               env.ID,
 			}); err != nil {
 				slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
@@ -185,7 +186,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		errMsg := fmt.Sprintf("failed to fetch environment config: %v", fr.configErr)
 		h.notifyDataFetchError(ctx, env, errMsg)
 		if err := h.queries.UpdateEnvironmentScrapeError(ctx, queries.UpdateEnvironmentScrapeErrorParams{
-			LastScrapedError: strPtr(errMsg),
+			LastScrapedError: ptr.Of(errMsg),
 			ID:               env.ID,
 		}); err != nil {
 			slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
@@ -236,7 +237,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 					Active:      a.Active,
 					Version:     a.Version,
 					Installed:   true,
-					InstalledAt: strPtr(a.CreatedAt),
+					InstalledAt: ptr.Of(a.CreatedAt),
 				})
 			}
 		}

--- a/api/internal/monitoring/scrape/util.go
+++ b/api/internal/monitoring/scrape/util.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 )
 
 // existingExtension is the unified prior state of an extension (store-known or
@@ -90,7 +91,7 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 				Name:       old.Name,
 				Label:      old.Label,
 				State:      "removed",
-				OldVersion: strPtr(old.Version),
+				OldVersion: ptr.Of(old.Version),
 				Active:     old.Active,
 			})
 			continue
@@ -112,8 +113,8 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 			Name:       newExt.Name,
 			Label:      newExt.Label,
 			State:      state,
-			OldVersion: strPtr(old.Version),
-			NewVersion: strPtr(newExt.Version),
+			OldVersion: ptr.Of(old.Version),
+			NewVersion: ptr.Of(newExt.Version),
 			Active:     newExt.Active,
 		})
 	}
@@ -127,7 +128,7 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 			Name:       ne.Name,
 			Label:      ne.Label,
 			State:      "installed",
-			NewVersion: strPtr(ne.Version),
+			NewVersion: ptr.Of(ne.Version),
 			Active:     ne.Active,
 		})
 	}
@@ -219,8 +220,4 @@ func getFavicon(ctx context.Context, shopURL string) *string {
 	}
 
 	return nil
-}
-
-func strPtr(s string) *string {
-	return &s
 }

--- a/api/internal/ptr/ptr.go
+++ b/api/internal/ptr/ptr.go
@@ -1,0 +1,56 @@
+// Package ptr provides generic helpers for optional pointer values.
+package ptr
+
+import "time"
+
+// Of returns a pointer to v.
+func Of[T any](v T) *T {
+	return &v
+}
+
+// Deref returns the value pointed to by p, or the zero value of T when p is nil.
+func Deref[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}
+
+// DerefOr returns the value pointed to by p, or fallback when p is nil.
+func DerefOr[T any](p *T, fallback T) T {
+	if p == nil {
+		return fallback
+	}
+	return *p
+}
+
+// Map converts *T to *U with fn, preserving nil.
+func Map[T, U any](p *T, fn func(T) U) *U {
+	if p == nil {
+		return nil
+	}
+	v := fn(*p)
+	return &v
+}
+
+// Int converts a pointer to any integer type into *int, preserving nil.
+func Int[T ~int | ~int8 | ~int16 | ~int32 | ~int64 | ~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64](p *T) *int {
+	if p == nil {
+		return nil
+	}
+	v := int(*p)
+	return &v
+}
+
+// ParseTime parses *string with the given layout, returning nil when absent or invalid.
+func ParseTime(value *string, layout string) *time.Time {
+	if value == nil {
+		return nil
+	}
+	parsed, err := time.Parse(layout, *value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}

--- a/api/internal/ptr/ptr_test.go
+++ b/api/internal/ptr/ptr_test.go
@@ -1,0 +1,66 @@
+package ptr_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
+)
+
+func TestOf(t *testing.T) {
+	p := ptr.Of("hello")
+	if p == nil || *p != "hello" {
+		t.Fatalf("Of() = %v, want pointer to hello", p)
+	}
+}
+
+func TestDeref(t *testing.T) {
+	if got := ptr.Deref((*string)(nil)); got != "" {
+		t.Fatalf("Deref(nil) = %q, want empty", got)
+	}
+	if got := ptr.Deref(ptr.Of(42)); got != 42 {
+		t.Fatalf("Deref(42) = %d, want 42", got)
+	}
+}
+
+func TestDerefOr(t *testing.T) {
+	if got := ptr.DerefOr((*string)(nil), "fallback"); got != "fallback" {
+		t.Fatalf("DerefOr(nil) = %q, want fallback", got)
+	}
+	if got := ptr.DerefOr(ptr.Of("value"), "fallback"); got != "value" {
+		t.Fatalf("DerefOr(value) = %q, want value", got)
+	}
+}
+
+func TestMap(t *testing.T) {
+	if got := ptr.Map((*int32)(nil), func(v int32) int { return int(v) }); got != nil {
+		t.Fatalf("Map(nil) = %v, want nil", got)
+	}
+	got := ptr.Map(ptr.Of(int32(7)), func(v int32) int { return int(v) })
+	if got == nil || *got != 7 {
+		t.Fatalf("Map(7) = %v, want pointer to 7", got)
+	}
+}
+
+func TestInt(t *testing.T) {
+	if got := ptr.Int((*int32)(nil)); got != nil {
+		t.Fatalf("Int(nil) = %v, want nil", got)
+	}
+	got := ptr.Int(ptr.Of(int32(9)))
+	if got == nil || *got != 9 {
+		t.Fatalf("Int(9) = %v, want pointer to 9", got)
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	if got := ptr.ParseTime(nil, time.RFC3339); got != nil {
+		t.Fatalf("ParseTime(nil) = %v, want nil", got)
+	}
+	if got := ptr.ParseTime(ptr.Of("not-a-time"), time.RFC3339); got != nil {
+		t.Fatalf("ParseTime(invalid) = %v, want nil", got)
+	}
+	got := ptr.ParseTime(ptr.Of("2024-01-02T03:04:05Z"), time.RFC3339)
+	if got == nil || !got.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)) {
+		t.Fatalf("ParseTime(valid) = %v, want 2024-01-02T03:04:05Z", got)
+	}
+}

--- a/api/internal/readmodel/account/service.go
+++ b/api/internal/readmodel/account/service.go
@@ -11,9 +11,11 @@ import (
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
+	"github.com/friendsofshopware/shopmon/api/internal/shopware"
 	"github.com/friendsofshopware/shopmon/api/internal/version"
-	"github.com/jackc/pgx/v5/pgtype"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
@@ -36,7 +38,7 @@ func (s *Service) Profile(ctx context.Context, userID string) (api.UserProfile, 
 		Id:          dbUser.ID,
 		DisplayName: dbUser.Name,
 		Email:       openapi_types.Email(dbUser.Email),
-		CreatedAt:   pgtimeToTime(dbUser.CreatedAt),
+		CreatedAt:   database.Time(dbUser.CreatedAt),
 		Locale:      dbUser.Locale,
 	}, nil
 }
@@ -53,7 +55,7 @@ func (s *Service) UpdateLocale(ctx context.Context, userID, locale string) error
 }
 
 func (s *Service) Extensions(ctx context.Context, userID string, activeOrgID, requestedLanguage *string) ([]api.AccountExtension, error) {
-	language := resolveLanguage(requestedLanguage)
+	language := shopware.ContentLanguage(requestedLanguage)
 	if activeOrgID == nil {
 		return []api.AccountExtension{}, nil
 	}
@@ -86,8 +88,8 @@ func (s *Service) Extensions(ctx context.Context, userID string, activeOrgID, re
 	for _, r := range changelogRows {
 		changelogByExt[r.ExtensionName] = append(changelogByExt[r.ExtensionName], changelogVersion{
 			Version:    r.Version,
-			Text:       deref(r.Changelog),
-			ReleasedAt: deref(r.ReleasedAt),
+			Text:       ptr.Deref(r.Changelog),
+			ReleasedAt: ptr.Deref(r.ReleasedAt),
 		})
 	}
 
@@ -143,7 +145,7 @@ func (s *Service) Extensions(ctx context.Context, userID string, activeOrgID, re
 // queries rows for the requested extension, so the detail view does not transfer
 // the whole catalog.
 func (s *Service) Extension(ctx context.Context, userID string, activeOrgID *string, name string, requestedLanguage *string) (api.AccountExtension, error) {
-	language := resolveLanguage(requestedLanguage)
+	language := shopware.ContentLanguage(requestedLanguage)
 	if activeOrgID == nil {
 		return api.AccountExtension{}, ErrExtensionNotFound
 	}
@@ -179,8 +181,8 @@ func (s *Service) Extension(ctx context.Context, userID string, activeOrgID *str
 	for _, r := range changelogRows {
 		changelogByExt[r.ExtensionName] = append(changelogByExt[r.ExtensionName], changelogVersion{
 			Version:    r.Version,
-			Text:       deref(r.Changelog),
-			ReleasedAt: deref(r.ReleasedAt),
+			Text:       ptr.Deref(r.Changelog),
+			ReleasedAt: ptr.Deref(r.ReleasedAt),
 		})
 	}
 
@@ -277,13 +279,13 @@ func aggregateAccountExtensions(
 				Name:          row.Name,
 				Label:         row.Label,
 				Version:       row.Version,
-				LatestVersion: deref(row.LatestVersion),
+				LatestVersion: ptr.Deref(row.LatestVersion),
 				Active:        row.Active,
 				Installed:     row.Installed,
 				StoreLink:     row.StoreLink,
 				RatingAverage: ratingAvg,
 				Changelog:     changelog,
-				InstalledAt:   parseInstalledAt(row.InstalledAt),
+				InstalledAt:   ptr.ParseTime(row.InstalledAt, time.RFC3339),
 				Environments:  []api.AccountExtensionEnvironment{},
 			}
 			if row.isStore {
@@ -311,7 +313,7 @@ func aggregateAccountExtensions(
 			ShopId:                      int(row.EnvironmentShopID),
 			ShopName:                    row.EnvironmentShopName,
 			Version:                     row.Version,
-			LatestVersion:               deref(row.LatestVersion),
+			LatestVersion:               ptr.Deref(row.LatestVersion),
 			Active:                      row.Active,
 			Installed:                   row.Installed,
 		}
@@ -366,7 +368,7 @@ func (s *Service) Organizations(ctx context.Context, userID string) ([]api.Accou
 			Id:               row.ID,
 			Name:             row.Name,
 			Logo:             row.Logo,
-			CreatedAt:        pgtimeToTime(row.CreatedAt),
+			CreatedAt:        database.Time(row.CreatedAt),
 			EnvironmentCount: int(row.EnvironmentCount),
 			MemberCount:      int(row.MemberCount),
 		})
@@ -398,7 +400,7 @@ func (s *Service) Environments(ctx context.Context, userID string, activeOrgID *
 		result = append(result, api.AccountEnvironment{
 			Id: int(row.ID), Name: row.Name, Url: row.Url, Favicon: row.Favicon,
 			Status: row.Status, ShopwareVersion: row.ShopwareVersion,
-			LastScrapedAt: pgtimeToTimePtr(row.LastScrapedAt), LastScrapedError: row.LastScrapedError,
+			LastScrapedAt: database.TimePtr(row.LastScrapedAt), LastScrapedError: row.LastScrapedError,
 			OrganizationId: row.OrganizationID, OrganizationName: row.OrganizationName,
 			ShopId: shopId, ShopName: row.ShopName,
 		})
@@ -425,7 +427,7 @@ func (s *Service) Shops(ctx context.Context, userID string, activeOrgID *string)
 		result = append(result, api.AccountShop{
 			Id: int(row.ID), Name: row.Name, Description: row.Description,
 			GitUrl: row.GitUrl, OrganizationId: row.OrganizationID, OrganizationName: row.OrganizationName,
-			DefaultEnvironmentId: int32PtrToIntPtr(row.DefaultEnvironmentID),
+			DefaultEnvironmentId: ptr.Int(row.DefaultEnvironmentID),
 		})
 	}
 
@@ -471,7 +473,7 @@ func (s *Service) Changelogs(ctx context.Context, userID string, activeOrgID *st
 			Extensions:                  extensions,
 			OldShopwareVersion:          row.OldShopwareVersion,
 			NewShopwareVersion:          row.NewShopwareVersion,
-			Date:                        pgtimeToTime(row.Date),
+			Date:                        database.Time(row.Date),
 		})
 	}
 
@@ -539,48 +541,4 @@ func buildFullChangelog(versions []changelogVersion) *[]api.ExtensionChangelogEn
 		return version.Compare(entries[i].Version, entries[j].Version) > 0
 	})
 	return &entries
-}
-
-func resolveLanguage(language *string) string {
-	if language != nil && *language == "de" {
-		return "de"
-	}
-	return "en"
-}
-
-func parseInstalledAt(value *string) *time.Time {
-	if value == nil {
-		return nil
-	}
-	parsed, err := time.Parse(time.RFC3339, *value)
-	if err != nil {
-		return nil
-	}
-	return &parsed
-}
-
-func deref(value *string) string {
-	if value == nil {
-		return ""
-	}
-	return *value
-}
-
-func pgtimeToTime(value pgtype.Timestamp) time.Time {
-	return value.Time
-}
-
-func pgtimeToTimePtr(value pgtype.Timestamp) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	return &value.Time
-}
-
-func int32PtrToIntPtr(value *int32) *int {
-	if value == nil {
-		return nil
-	}
-	converted := int(*value)
-	return &converted
 }

--- a/api/internal/readmodel/admin/service.go
+++ b/api/internal/readmodel/admin/service.go
@@ -5,12 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
@@ -83,7 +82,7 @@ func (s *Service) Organizations(ctx context.Context, params api.AdminGetOrganiza
 			Id:               row.ID,
 			Name:             row.Name,
 			Logo:             row.Logo,
-			CreatedAt:        pgtimeToTime(row.CreatedAt),
+			CreatedAt:        database.Time(row.CreatedAt),
 			EnvironmentCount: int(row.EnvironmentCount),
 			MemberCount:      int(row.MemberCount),
 		})
@@ -134,7 +133,7 @@ func (s *Service) Environments(ctx context.Context, params api.AdminGetEnvironme
 			Url:              row.Url,
 			Status:           row.Status,
 			ShopwareVersion:  row.ShopwareVersion,
-			LastScrapedAt:    pgtimeToTimePtr(row.LastScrapedAt),
+			LastScrapedAt:    database.TimePtr(row.LastScrapedAt),
 			OrganizationId:   row.OrganizationID,
 			OrganizationName: row.OrganizationName,
 			ShopId:           &shopID,
@@ -248,7 +247,7 @@ func (s *Service) RecentActivity(ctx context.Context) (api.AdminRecentActivity, 
 			Id:          row.ID,
 			DisplayName: row.Name,
 			Email:       openapi_types.Email(row.Email),
-			CreatedAt:   pgtimeToTime(row.CreatedAt),
+			CreatedAt:   database.Time(row.CreatedAt),
 		})
 	}
 
@@ -310,7 +309,7 @@ func (s *Service) OrganizationDetail(ctx context.Context, orgID string) (api.Adm
 		Name:             org.Name,
 		Slug:             org.Slug,
 		Logo:             org.Logo,
-		CreatedAt:        pgtimeToTime(org.CreatedAt),
+		CreatedAt:        database.Time(org.CreatedAt),
 		MemberCount:      int(org.MemberCount),
 		EnvironmentCount: int(org.EnvironmentCount),
 		Members:          make([]api.AdminOrganizationMember, 0, len(members)),
@@ -327,7 +326,7 @@ func (s *Service) OrganizationDetail(ctx context.Context, orgID string) (api.Adm
 			Email:     m.Email,
 			Image:     m.Image,
 			Role:      m.Role,
-			CreatedAt: pgtimeToTime(m.CreatedAt),
+			CreatedAt: database.Time(m.CreatedAt),
 		})
 	}
 	for _, e := range environments {
@@ -337,7 +336,7 @@ func (s *Service) OrganizationDetail(ctx context.Context, orgID string) (api.Adm
 			Url:             e.Url,
 			Status:          e.Status,
 			ShopwareVersion: e.ShopwareVersion,
-			LastScrapedAt:   pgtimeToTimePtr(e.LastScrapedAt),
+			LastScrapedAt:   database.TimePtr(e.LastScrapedAt),
 			ShopId:          int(e.ShopID),
 			ShopName:        e.ShopName,
 		})
@@ -348,8 +347,8 @@ func (s *Service) OrganizationDetail(ctx context.Context, orgID string) (api.Adm
 			Email:        i.Email,
 			Role:         i.Role,
 			Status:       i.Status,
-			ExpiresAt:    pgtimeToTime(i.ExpiresAt),
-			CreatedAt:    pgtimeToTime(i.CreatedAt),
+			ExpiresAt:    database.Time(i.ExpiresAt),
+			CreatedAt:    database.Time(i.CreatedAt),
 			InviterName:  i.InviterName,
 			InviterEmail: i.InviterEmail,
 		})
@@ -367,7 +366,7 @@ func (s *Service) OrganizationDetail(ctx context.Context, orgID string) (api.Adm
 			Id:          int(s.ID),
 			Name:        s.Name,
 			Description: s.Description,
-			CreatedAt:   pgtimeToTime(s.CreatedAt),
+			CreatedAt:   database.Time(s.CreatedAt),
 		}
 		if s.DefaultEnvironmentID != nil {
 			id := int(*s.DefaultEnvironmentID)
@@ -409,8 +408,8 @@ func (s *Service) EnvironmentDetail(ctx context.Context, environmentID int) (api
 		Url:                  env.Url,
 		Status:               env.Status,
 		ShopwareVersion:      env.ShopwareVersion,
-		CreatedAt:            pgtimeToTime(env.CreatedAt),
-		LastScrapedAt:        pgtimeToTimePtr(env.LastScrapedAt),
+		CreatedAt:            database.Time(env.CreatedAt),
+		LastScrapedAt:        database.TimePtr(env.LastScrapedAt),
 		LastScrapedError:     env.LastScrapedError,
 		ConnectionIssueCount: int(env.ConnectionIssueCount),
 		OrganizationId:       env.OrganizationID,
@@ -465,7 +464,7 @@ func (s *Service) EnvironmentDetail(ctx context.Context, environmentID int) (api
 			ReturnCode:    int(dep.ReturnCode),
 			ExecutionTime: dep.ExecutionTime,
 			Reference:     dep.Reference,
-			CreatedAt:     pgtimeToTime(dep.CreatedAt),
+			CreatedAt:     database.Time(dep.CreatedAt),
 		}
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		return api.AdminEnvironmentDetail{}, fmt.Errorf("get environment last deployment: %w", err)
@@ -521,7 +520,7 @@ func (s *Service) AuditLog(ctx context.Context, params api.AdminGetAuditLogParam
 			TargetEmail:  a.TargetEmail,
 			Detail:       a.Detail,
 			IpAddress:    a.IpAddress,
-			CreatedAt:    pgtimeToTime(a.CreatedAt),
+			CreatedAt:    database.Time(a.CreatedAt),
 		})
 	}
 
@@ -529,15 +528,4 @@ func (s *Service) AuditLog(ctx context.Context, params api.AdminGetAuditLogParam
 		Entries: entries,
 		Total:   int(total),
 	}, nil
-}
-
-func pgtimeToTime(value pgtype.Timestamp) time.Time {
-	return value.Time
-}
-
-func pgtimeToTimePtr(value pgtype.Timestamp) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	return &value.Time
 }

--- a/api/internal/readmodel/environment/projection.go
+++ b/api/internal/readmodel/environment/projection.go
@@ -7,9 +7,10 @@ import (
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/version"
-	"github.com/jackc/pgx/v5/pgtype"
 )
 
 // toAccountEnvironment maps a single organization environment row to its API DTO.
@@ -26,7 +27,7 @@ func toAccountEnvironment(row queries.ListEnvironmentsByOrganizationRow) api.Acc
 		Favicon:          row.Favicon,
 		Status:           row.Status,
 		ShopwareVersion:  row.ShopwareVersion,
-		LastScrapedAt:    pgtimeToTimePtr(row.LastScrapedAt),
+		LastScrapedAt:    database.TimePtr(row.LastScrapedAt),
 		LastScrapedError: row.LastScrapedError,
 		OrganizationId:   row.OrganizationID,
 		OrganizationName: row.OrganizationName,
@@ -59,8 +60,8 @@ func mergeEnvironmentExtensions(
 	for _, r := range changelogRows {
 		changelogByExt[r.ExtensionName] = append(changelogByExt[r.ExtensionName], changelogVersion{
 			Version:    r.Version,
-			Text:       deref(r.Changelog),
-			ReleasedAt: deref(r.ReleasedAt),
+			Text:       ptr.Deref(r.Changelog),
+			ReleasedAt: ptr.Deref(r.ReleasedAt),
 		})
 	}
 
@@ -73,7 +74,7 @@ func mergeEnvironmentExtensions(
 			ratingAvg = &v
 		}
 
-		latestVersion := deref(row.LatestVersion)
+		latestVersion := ptr.Deref(row.LatestVersion)
 		changelog := buildCompatibleChangelog(changelogByExt[row.ExtensionName], row.Version, latestVersion)
 
 		extensions = append(extensions, api.EnvironmentExtension{
@@ -86,7 +87,7 @@ func mergeEnvironmentExtensions(
 			StoreLink:     row.StoreLink,
 			RatingAverage: ratingAvg,
 			Changelog:     changelog,
-			InstalledAt:   parseInstalledAt(row.InstalledAt),
+			InstalledAt:   ptr.ParseTime(row.InstalledAt, time.RFC3339),
 		})
 	}
 
@@ -95,10 +96,10 @@ func mergeEnvironmentExtensions(
 			Name:          row.Name,
 			Label:         row.Label,
 			Version:       row.Version,
-			LatestVersion: deref(row.LatestVersion),
+			LatestVersion: ptr.Deref(row.LatestVersion),
 			Active:        row.Active,
 			Installed:     row.Installed,
-			InstalledAt:   parseInstalledAt(row.InstalledAt),
+			InstalledAt:   ptr.ParseTime(row.InstalledAt, time.RFC3339),
 		})
 	}
 
@@ -146,36 +147,6 @@ func buildCompatibleChangelog(versions []changelogVersion, installedVersion, lat
 		return version.Compare(entries[i].Version, entries[j].Version) < 0
 	})
 	return &entries
-}
-
-// resolveLanguage normalizes an optional request language to a supported store
-// language code, defaulting to English. The query layer already falls back to
-// English for any field missing in the requested language, so an unsupported
-// value simply behaves like English.
-func resolveLanguage(lang *string) string {
-	if lang != nil && *lang == "de" {
-		return "de"
-	}
-	return "en"
-}
-
-// parseInstalledAt parses the RFC3339 installed-at timestamp, returning nil when
-// absent or unparseable.
-func parseInstalledAt(s *string) *time.Time {
-	if s == nil {
-		return nil
-	}
-	if t, err := time.Parse(time.RFC3339, *s); err == nil {
-		return &t
-	}
-	return nil
-}
-
-func deref(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
 }
 
 func mapEnvironmentScheduledTasks(rows []queries.EnvironmentScheduledTask) []api.ScheduledTask {
@@ -262,7 +233,7 @@ func mapEnvironmentChecks(rows []queries.EnvironmentCheck) []api.EnvironmentChec
 func mapEnvironmentSitespeeds(rows []queries.EnvironmentSitespeed) []api.Sitespeed {
 	sitespeeds := make([]api.Sitespeed, 0, len(rows))
 	for _, row := range rows {
-		createdAt := pgtimeToTime(row.CreatedAt)
+		createdAt := database.Time(row.CreatedAt)
 
 		var ttfb, fullyLoaded, largestContentfulPaint, firstContentfulPaint, transferSize *float32
 		var cumulativeLayoutShift *float32
@@ -340,20 +311,9 @@ func mapEnvironmentChangelogs(environment *queries.GetEnvironmentByIDRow, rows [
 			Extensions:                  extensions,
 			OldShopwareVersion:          row.OldShopwareVersion,
 			NewShopwareVersion:          row.NewShopwareVersion,
-			Date:                        pgtimeToTime(row.Date),
+			Date:                        database.Time(row.Date),
 		})
 	}
 
 	return changelogs, nil
-}
-
-func pgtimeToTime(value pgtype.Timestamp) time.Time {
-	return value.Time
-}
-
-func pgtimeToTimePtr(value pgtype.Timestamp) *time.Time {
-	if !value.Valid {
-		return nil
-	}
-	return &value.Time
 }

--- a/api/internal/readmodel/environment/service.go
+++ b/api/internal/readmodel/environment/service.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
+	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/shopware"
 	"github.com/jackc/pgx/v5"
 	"golang.org/x/sync/errgroup"
 )
@@ -89,7 +91,7 @@ func (s *Service) Detail(ctx context.Context, userID string, environmentID int32
 		return api.EnvironmentDetail{}, ErrNotAuthorized
 	}
 
-	aggregate, err := s.loadAggregate(ctx, environmentID, resolveLanguage(requestedLanguage))
+	aggregate, err := s.loadAggregate(ctx, environmentID, shopware.ContentLanguage(requestedLanguage))
 	if err != nil {
 		return api.EnvironmentDetail{}, err
 	}
@@ -253,7 +255,7 @@ func (s *Service) buildDetail(environment *queries.GetEnvironmentByIDRow, aggreg
 		Favicon:            environment.Favicon,
 		Status:             environment.Status,
 		ShopwareVersion:    environment.ShopwareVersion,
-		LastScrapedAt:      pgtimeToTimePtr(environment.LastScrapedAt),
+		LastScrapedAt:      database.TimePtr(environment.LastScrapedAt),
 		LastScrapedError:   environment.LastScrapedError,
 		OrganizationId:     environment.OrganizationID,
 		OrganizationName:   environment.OrganizationName,
@@ -263,7 +265,7 @@ func (s *Service) buildDetail(environment *queries.GetEnvironmentByIDRow, aggreg
 		EnvironmentImage:   environment.EnvironmentImage,
 		EnvironmentToken:   environment.EnvironmentToken,
 		Ignores:            ignores,
-		CreatedAt:          pgtimeToTime(environment.CreatedAt),
+		CreatedAt:          database.Time(environment.CreatedAt),
 		SitespeedEnabled:   environment.SitespeedEnabled,
 		SitespeedDetailUrl: sitespeedDetailURL(s.config, environment.ID, environment.SitespeedEnabled),
 		SitespeedUrls:      sitespeedURLs,
@@ -331,7 +333,7 @@ func (s *Service) StatusEvents(ctx context.Context, userID string, environmentID
 			OldStatus: row.OldStatus,
 			NewStatus: row.NewStatus,
 			Reasons:   reasons,
-			CreatedAt: pgtimeToTime(row.CreatedAt),
+			CreatedAt: database.Time(row.CreatedAt),
 		})
 	}
 	return events, nil

--- a/api/internal/shopware/checker/frosh_tools_test.go
+++ b/api/internal/shopware/checker/frosh_tools_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -24,8 +25,6 @@ func (m *mockHTTPClient) Get(_ context.Context, path string) ([]byte, error) {
 	}
 	return nil, errors.New("unexpected path: " + path)
 }
-
-func strPtr(s string) *string { return &s }
 
 func findCheck(checks []Check, id string) (Check, bool) {
 	for _, c := range checks {
@@ -89,7 +88,7 @@ func TestMapFroshChecks(t *testing.T) {
 		},
 		{
 			name:            "current and recommended carried as params",
-			check:           froshToolsCheck{Snippet: "phpOutdated", State: "STATE_WARNING", Current: strPtr("7.4"), Recommended: strPtr("8.2")},
+			check:           froshToolsCheck{Snippet: "phpOutdated", State: "STATE_WARNING", Current: ptr.Of("7.4"), Recommended: ptr.Of("8.2")},
 			wantEmitted:     true,
 			wantID:          "frosh.phpOutdated",
 			wantLevel:       StatusYellow,

--- a/api/internal/shopware/language.go
+++ b/api/internal/shopware/language.go
@@ -1,0 +1,13 @@
+package shopware
+
+import "github.com/friendsofshopware/shopmon/api/internal/ptr"
+
+// ContentLanguage normalizes an optional store language to a supported code.
+// Unsupported or missing values default to English; callers already fall back
+// to English for any field missing in the requested language.
+func ContentLanguage(language *string) string {
+	if ptr.Deref(language) == "de" {
+		return "de"
+	}
+	return "en"
+}


### PR DESCRIPTION
## Summary
- Add shared generic `ptr` helpers (`Of`, `Deref`, `Map`, `Int`, `ParseTime`) and remove local `strPtr`/`deref`/`int32PtrToIntPtr` copies
- Centralize `pgtype.Timestamp` conversion in `database.Time` / `database.TimePtr`
- Share Shopware content language normalization via `shopware.ContentLanguage`

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/ptr/... ./internal/readmodel/... ./internal/shopware/... ./internal/handler/... ./internal/monitoring/scrape/... ./internal/deployment/...`
- [ ] CI green on draft PR