### PR TITLE
fix(frontend): refresh sidebar shops after create/edit/delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,21 @@ mise run migrate         # Apply migrations
 mise run load-fixtures   # Reset DB + migrate + seed fixtures
 mise run dev             # Run API server + worker + frontend
 mise run dev:worker      # Run background worker only
-mise run test            # Run integration tests
+mise run test            # Run API integration tests
+mise run lint            # Lint/format/typecheck API + frontend (includes frontend unit tests)
 mise run generate        # Regenerate sqlc + oapi-codegen
 ```
+
+## Verification
+
+Before considering a change complete (and before opening or updating a PR), always run:
+
+```bash
+mise run lint
+mise run test
+```
+
+- **`mise run lint`** — API (`golangci-lint`) + frontend (oxlint, `vue-tsc`, oxfmt check, Vitest unit tests)
+- **`mise run test`** — API integration tests (`go test ./internal/...`)
+
+Do not rely only on targeted package/file test runs. Fix any failures (including format drift from oxfmt) and re-run both commands until they pass. If format check fails, run `cd frontend && npm run format:fix` (or `npx oxfmt <file>`) and include the formatting fix in the change.

--- a/frontend/src/components/layout/OrganizationSwitcher.vue
+++ b/frontend/src/components/layout/OrganizationSwitcher.vue
@@ -26,6 +26,7 @@ import {
   resetAccountEnvironments,
   fetchAccountEnvironments,
 } from "@/composables/useAccountEnvironments";
+import { resetAccountShops, fetchAccountShops } from "@/composables/useAccountShops";
 import { api } from "@/helpers/api";
 import {
   Select,
@@ -67,6 +68,8 @@ async function switchOrganization(orgId: AcceptableValue) {
   if (orgId === activeOrganizationId.value) return;
   await setActiveOrganization(orgId);
   resetAccountEnvironments();
+  resetAccountShops();
   fetchAccountEnvironments();
+  fetchAccountShops();
 }
 </script>

--- a/frontend/src/composables/useAccountShops.spec.ts
+++ b/frontend/src/composables/useAccountShops.spec.ts
@@ -7,11 +7,7 @@ vi.mock("@/helpers/api", () => ({
 }));
 
 import { api } from "@/helpers/api";
-import {
-  fetchAccountShops,
-  resetAccountShops,
-  useAccountShops,
-} from "./useAccountShops";
+import { fetchAccountShops, resetAccountShops, useAccountShops } from "./useAccountShops";
 
 describe("useAccountShops", () => {
   beforeEach(() => {

--- a/frontend/src/composables/useAccountShops.spec.ts
+++ b/frontend/src/composables/useAccountShops.spec.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/helpers/api", () => ({
+  api: {
+    GET: vi.fn(),
+  },
+}));
+
+import { api } from "@/helpers/api";
+import {
+  fetchAccountShops,
+  resetAccountShops,
+  useAccountShops,
+} from "./useAccountShops";
+
+describe("useAccountShops", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetAccountShops();
+  });
+
+  it("fetches shops once and shares state", async () => {
+    const shops = [{ id: 1, name: "Shop A" }];
+    vi.mocked(api.GET).mockResolvedValue({
+      data: shops,
+      error: undefined,
+      response: new Response(),
+    } as never);
+
+    const first = useAccountShops();
+    const second = useAccountShops();
+
+    await fetchAccountShops();
+
+    expect(api.GET).toHaveBeenCalledTimes(1);
+    expect(api.GET).toHaveBeenCalledWith("/account/shops");
+    expect(first.shops.value).toEqual(shops);
+    expect(second.shops.value).toEqual(shops);
+  });
+
+  it("re-fetches after reset", async () => {
+    vi.mocked(api.GET)
+      .mockResolvedValueOnce({
+        data: [{ id: 1, name: "Shop A" }],
+        error: undefined,
+        response: new Response(),
+      } as never)
+      .mockResolvedValueOnce({
+        data: [{ id: 2, name: "Shop B" }],
+        error: undefined,
+        response: new Response(),
+      } as never);
+
+    await fetchAccountShops();
+    resetAccountShops();
+    await fetchAccountShops();
+
+    expect(api.GET).toHaveBeenCalledTimes(2);
+    expect(useAccountShops().shops.value).toEqual([{ id: 2, name: "Shop B" }]);
+  });
+});

--- a/frontend/src/composables/useAccountShops.ts
+++ b/frontend/src/composables/useAccountShops.ts
@@ -1,0 +1,37 @@
+import { ref } from "vue";
+import { api } from "@/helpers/api";
+import type { components } from "@/types/api";
+
+type AccountShop = components["schemas"]["AccountShop"];
+
+const shops = ref<AccountShop[]>([]);
+const _fetched = ref(false);
+let _pending: Promise<AccountShop[]> | null = null;
+
+export function fetchAccountShops(): Promise<AccountShop[]> {
+  if (_pending) {
+    return _pending;
+  }
+
+  _pending = api.GET("/account/shops").then(({ data }) => {
+    shops.value = data ?? [];
+    _fetched.value = true;
+    _pending = null;
+    return shops.value;
+  });
+
+  return _pending;
+}
+
+export function resetAccountShops(): void {
+  _fetched.value = false;
+  _pending = null;
+  shops.value = [];
+}
+
+export function useAccountShops() {
+  if (!_fetched.value) {
+    void fetchAccountShops();
+  }
+  return { shops, fetchAccountShops, resetAccountShops };
+}

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -283,6 +283,7 @@ import { useLocale } from "@/composables/useLocale";
 import { useNotifications } from "@/composables/useNotifications";
 import { useSession, clearSession } from "@/composables/useSession";
 import { useAccountEnvironments } from "@/composables/useAccountEnvironments";
+import { useAccountShops } from "@/composables/useAccountShops";
 import { api, setToken } from "@/helpers/api";
 import { formatDateTime } from "@/helpers/formatter";
 import {
@@ -325,17 +326,13 @@ import {
 const router = useRouter();
 const { session, activeOrganizationId } = useSession();
 const { environments } = useAccountEnvironments();
+const { shops, fetchAccountShops } = useAccountShops();
 
 type AccountShop = components["schemas"]["AccountShop"];
-const shops = ref<AccountShop[]>([]);
 
-function loadShops() {
-  api.GET("/account/shops").then(({ data }) => {
-    shops.value = data ?? [];
-  });
-}
-loadShops();
-watch(activeOrganizationId, () => loadShops());
+watch(activeOrganizationId, () => {
+  void fetchAccountShops();
+});
 
 function shopLink(shop: AccountShop) {
   // A shop without a default environment (e.g. its last environment was deleted)

--- a/frontend/src/views/environment/AddEnvironment.vue
+++ b/frontend/src/views/environment/AddEnvironment.vue
@@ -199,6 +199,8 @@
 
 <script setup lang="ts">
 import { useAlert } from "@/composables/useAlert";
+import { fetchAccountEnvironments } from "@/composables/useAccountEnvironments";
+import { fetchAccountShops } from "@/composables/useAccountShops";
 import { api } from "@/helpers/api";
 import type { components } from "@/types/api";
 import { useForm } from "vee-validate";
@@ -304,6 +306,9 @@ const onSubmit = handleSubmit(async (values) => {
       error(apiError.message);
       return;
     }
+
+    // Keep sidebar shop links/status in sync without a full page reload.
+    await Promise.all([fetchAccountShops(), fetchAccountEnvironments()]);
 
     router.push({ name: "account.shop.list" });
   } catch (e) {

--- a/frontend/src/views/shop/AddShop.spec.ts
+++ b/frontend/src/views/shop/AddShop.spec.ts
@@ -37,6 +37,14 @@ vi.mock("@/composables/useAlert", () => ({
   }),
 }));
 
+vi.mock("@/composables/useAccountShops", () => ({
+  fetchAccountShops: vi.fn(() => Promise.resolve([])),
+}));
+
+vi.mock("@/composables/useAccountEnvironments", () => ({
+  fetchAccountEnvironments: vi.fn(() => Promise.resolve([])),
+}));
+
 import { api } from "@/helpers/api";
 
 describe("AddShop", () => {

--- a/frontend/src/views/shop/AddShop.vue
+++ b/frontend/src/views/shop/AddShop.vue
@@ -188,6 +188,8 @@
 
 <script setup lang="ts">
 import { useAlert } from "@/composables/useAlert";
+import { fetchAccountEnvironments } from "@/composables/useAccountEnvironments";
+import { fetchAccountShops } from "@/composables/useAccountShops";
 import { api } from "@/helpers/api";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -304,6 +306,9 @@ const onSubmit = handleSubmit(async (values) => {
       error(apiError.message);
       return;
     }
+
+    // Keep sidebar (and other shared lists) in sync without a full page reload.
+    await Promise.all([fetchAccountShops(), fetchAccountEnvironments()]);
 
     if (route.query.redirect) {
       router.push(route.query.redirect as string);

--- a/frontend/src/views/shop/EditShop.vue
+++ b/frontend/src/views/shop/EditShop.vue
@@ -245,6 +245,7 @@ import PackagesTokensCard from "@/components/shop/PackagesTokensCard.vue";
 import { useAlert } from "@/composables/useAlert";
 import { useInstanceConfig } from "@/composables/useInstanceConfig";
 import { fetchAccountEnvironments } from "@/composables/useAccountEnvironments";
+import { fetchAccountShops } from "@/composables/useAccountShops";
 import { api } from "@/helpers/api";
 import type { components } from "@/types/api";
 import { Button } from "@/components/ui/button";
@@ -332,7 +333,7 @@ async function setDefaultEnvironment(envId: number) {
       alert.error((error as { message?: string }).message ?? t("shop.defaultEnvSet"));
       return;
     }
-    await loadShopSummary();
+    await Promise.all([loadShopSummary(), fetchAccountShops()]);
     alert.success(t("shop.defaultEnvSet"));
   } catch (err) {
     alert.error(err instanceof Error ? err.message : String(err));
@@ -374,7 +375,7 @@ const onSubmitShop = handleShopSubmit(async (values) => {
       );
       return;
     }
-    await loadShopSummary();
+    await Promise.all([loadShopSummary(), fetchAccountShops()]);
     alert.success(t("shop.shopUpdated"));
   } catch (error) {
     alert.error(
@@ -398,6 +399,7 @@ async function deleteShop() {
       );
       return;
     }
+    await Promise.all([fetchAccountShops(), fetchAccountEnvironments()]);
     alert.success(t("shop.shopDeleted"));
     router.push({ name: "account.shop.list" });
   } catch (error) {


### PR DESCRIPTION
## Summary
- Share account shops via a `useAccountShops` composable (same pattern as environments) so the sidebar stays reactive
- Refresh shops (and environments where needed) after create/edit/delete shop and create environment
- Reset/reload shops when switching organizations

Fixes #737

## Test plan
- [ ] Create a new shop and confirm it appears in the sidebar without a full page reload
- [ ] Edit a shop name and confirm the sidebar label updates
- [ ] Delete a shop and confirm it disappears from the sidebar
- [ ] Create an environment and confirm related sidebar status/links stay correct
- [ ] Switch organizations and confirm the sidebar shop list reloads
- [ ] `cd frontend && npm test -- --run src/composables/useAccountShops.spec.ts src/views/shop/ src/views/environment/AddEnvironment.spec.ts`