### PR TITLE
fix(frontend): pass import payload synchronously to prevent Firefox race condition

### DIFF
--- a/frontend/src/components/modal/PluginConnectionModal.vue
+++ b/frontend/src/components/modal/PluginConnectionModal.vue
@@ -75,7 +75,7 @@
         <Button variant="ghost" @click="$emit('close')">
           {{ $t("common.cancel") }}
         </Button>
-        <Button @click="$emit('import')" :disabled="!pluginBase64Value.trim()">
+        <Button @click="handleImport" :disabled="!pluginBase64Value.trim()">
           <icon-fa6-solid:file-import class="mr-1.5 size-3" />
           {{ $t("pluginModal.importData") }}
         </Button>
@@ -110,7 +110,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const emit = defineEmits<{
   close: [];
-  import: [];
+  import: [value: string];
   "update:base64": [value: string];
 }>();
 
@@ -126,6 +126,11 @@ watch(
 watch(pluginBase64Value, (newValue) => {
   emit("update:base64", newValue);
 });
+
+function handleImport() {
+  emit("update:base64", pluginBase64Value.value);
+  emit("import", pluginBase64Value.value);
+}
 
 watch(
   () => props.show,

--- a/frontend/src/views/environment/AddEnvironment.vue
+++ b/frontend/src/views/environment/AddEnvironment.vue
@@ -329,10 +329,12 @@ const closePluginModal = () => {
   pluginError.value = "";
 };
 
-function processPluginData() {
+function processPluginData(rawInput?: string) {
   pluginError.value = "";
+  const inputToParse =
+    typeof rawInput === "string" && rawInput.trim() ? rawInput : pluginBase64.value;
   try {
-    const data = parsePluginData(pluginBase64.value);
+    const data = parsePluginData(inputToParse);
     setFieldValue("shopUrl", data.url);
     setFieldValue("clientId", data.clientId);
     setFieldValue("clientSecret", data.clientSecret);

--- a/frontend/src/views/environment/EditEnvironment.vue
+++ b/frontend/src/views/environment/EditEnvironment.vue
@@ -448,10 +448,12 @@ const closePluginModal = () => {
   pluginError.value = "";
 };
 
-function processPluginData() {
+function processPluginData(rawInput?: string) {
   pluginError.value = "";
+  const inputToParse =
+    typeof rawInput === "string" && rawInput.trim() ? rawInput : pluginBase64.value;
   try {
-    const data = parsePluginData(pluginBase64.value);
+    const data = parsePluginData(inputToParse);
     setFieldValue("shopUrl", data.url);
     setFieldValue("clientId", data.clientId);
     setFieldValue("clientSecret", data.clientSecret);

--- a/frontend/src/views/shop/AddShop.vue
+++ b/frontend/src/views/shop/AddShop.vue
@@ -333,10 +333,12 @@ function closePluginModal() {
   pluginError.value = "";
 }
 
-function processPluginData() {
+function processPluginData(rawInput?: string) {
   pluginError.value = "";
+  const inputToParse =
+    typeof rawInput === "string" && rawInput.trim() ? rawInput : pluginBase64.value;
   try {
-    const data = parsePluginData(pluginBase64.value);
+    const data = parsePluginData(inputToParse);
     setFieldValue("environmentUrl", data.url);
     setFieldValue("clientId", data.clientId);
     setFieldValue("clientSecret", data.clientSecret);


### PR DESCRIPTION
Fixes Firefox-specific event ordering issue where paste + import click evaluated empty state before Vue reactive watchers flushed across modal component boundaries.