### PR TITLE
fix: long shop names in sidebar

### DIFF
--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -63,7 +63,7 @@
                       class="size-4 rounded"
                     />
                     <icon-fa6-solid:folder v-else class="opacity-40" />
-                    <span>{{ shop.name }}</span>
+                    <span class="truncate pr-4">{{ shop.name }}</span>
                   </RouterLink>
                 </SidebarMenuButton>
                 <SidebarMenuBadge v-if="defaultEnvStatus(shop)"


### PR DESCRIPTION
This PR adds a truncate to the sidebar shop name. The problem was that they cut off if they to long without any sign that they were too long

<img width="254" height="44" alt="Bildschirmfoto 2026-07-20 um 08 53 39" src="https://github.com/user-attachments/assets/31d06d76-f40a-4b4a-b9f1-433af6a81f48" />
