### PR TITLE
fix: restore admin impersonate UI and session banner

### DIFF
--- a/api/internal/auth/admin_test.go
+++ b/api/internal/auth/admin_test.go
@@ -324,4 +324,9 @@ func TestAdminImpersonate(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&sessionResp))
 	user := sessionResp["user"].(map[string]interface{})
 	assert.Equal(t, "user@example.com", user["email"])
+
+	// Banner visibility depends on session.impersonatedBy being present
+	sessionInfo, ok := sessionResp["session"].(map[string]interface{})
+	require.True(t, ok)
+	assert.NotEmpty(t, sessionInfo["impersonatedBy"])
 }

--- a/api/internal/auth/credentials.go
+++ b/api/internal/auth/credentials.go
@@ -101,6 +101,7 @@ func (h *AuthHandler) GetSession(w http.ResponseWriter, r *http.Request) {
 		Session: currentSessionResponse{
 			ID: principal.Session.ID, UserID: principal.Session.UserID, ExpiresAt: principal.Session.ExpiresAt,
 			ActiveOrganizationID: principal.Session.ActiveOrganizationID,
+			ImpersonatedBy:       principal.Session.ImpersonatedBy,
 		},
 	})
 }

--- a/api/internal/auth/dto.go
+++ b/api/internal/auth/dto.go
@@ -123,6 +123,7 @@ type currentSessionResponse struct {
 	UserID               string    `json:"userId"`
 	ExpiresAt            time.Time `json:"expiresAt"`
 	ActiveOrganizationID *string   `json:"activeOrganizationId"`
+	ImpersonatedBy       *string   `json:"impersonatedBy,omitempty"`
 }
 
 type tokenUserResponse struct {

--- a/api/internal/authapi/server.gen.go
+++ b/api/internal/authapi/server.gen.go
@@ -231,7 +231,10 @@ type SessionInfo struct {
 	ActiveOrganizationId *string    `json:"activeOrganizationId,omitempty"`
 	ExpiresAt            *time.Time `json:"expiresAt,omitempty"`
 	Id                   *string    `json:"id,omitempty"`
-	UserId               *string    `json:"userId,omitempty"`
+
+	// ImpersonatedBy Admin user ID when this session is an impersonation
+	ImpersonatedBy *string `json:"impersonatedBy,omitempty"`
+	UserId         *string `json:"userId,omitempty"`
 }
 
 // NotFound defines model for NotFound.

--- a/api/openapi/spec.yaml
+++ b/api/openapi/spec.yaml
@@ -2192,6 +2192,22 @@ paths:
       responses:
         "200":
           description: Impersonation session created
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [token, session]
+                properties:
+                  token:
+                    type: string
+                  session:
+                    type: object
+                    required: [token, impersonatedBy]
+                    properties:
+                      token:
+                        type: string
+                      impersonatedBy:
+                        type: string
 
   # ──────────────────────────────────────────────
   # Auth – Additional Endpoints
@@ -4825,6 +4841,10 @@ components:
         activeOrganizationId:
           type: string
           nullable: true
+        impersonatedBy:
+          type: string
+          nullable: true
+          description: Admin user ID when this session is an impersonation
 
     InstanceConfig:
       type: object

--- a/frontend/src/components/ImpersonationBanner.vue
+++ b/frontend/src/components/ImpersonationBanner.vue
@@ -23,7 +23,7 @@
 import { useI18n } from "vue-i18n";
 import { useAlert } from "@/composables/useAlert";
 import { useSession } from "@/composables/useSession";
-import { api } from "@/helpers/api";
+import { api, restoreAdminToken, setToken } from "@/helpers/api";
 import { computed } from "vue";
 import { Button } from "@/components/ui/button";
 
@@ -44,7 +44,15 @@ async function stopImpersonating() {
       throw new Error("Failed to stop impersonating");
     }
 
-    window.location.reload();
+    const adminToken = restoreAdminToken();
+    if (!adminToken) {
+      // Impersonation session is gone; without a stashed admin token, log out.
+      setToken(null);
+      window.location.href = "/account/login";
+      return;
+    }
+
+    window.location.href = "/admin";
   } catch (error) {
     alert.error(
       t("impersonation.failedStop", {

--- a/frontend/src/helpers/api.ts
+++ b/frontend/src/helpers/api.ts
@@ -1,9 +1,14 @@
 import createClient from "openapi-fetch";
 import type { paths } from "../types/api";
 
+const TOKEN_KEY = "shopmon_token";
+// Saved while an admin is impersonating so stop-impersonating can restore the
+// original session after the short-lived impersonation token is deleted.
+const ADMIN_TOKEN_KEY = "shopmon_admin_token";
+
 export function getToken(): string | null {
   if (import.meta.env.SSR) return null;
-  return localStorage.getItem("shopmon_token");
+  return localStorage.getItem(TOKEN_KEY);
 }
 
 // The supported API content languages. Server-side localized store text resolves
@@ -21,10 +26,38 @@ export function apiLanguage(): ApiLanguage {
 export function setToken(token: string | null) {
   if (import.meta.env.SSR) return;
   if (token) {
-    localStorage.setItem("shopmon_token", token);
+    localStorage.setItem(TOKEN_KEY, token);
   } else {
-    localStorage.removeItem("shopmon_token");
+    localStorage.removeItem(TOKEN_KEY);
   }
+}
+
+/** Stash the current session token before switching to an impersonation token. */
+export function stashAdminToken(): void {
+  if (import.meta.env.SSR) return;
+  const token = getToken();
+  if (token) {
+    localStorage.setItem(ADMIN_TOKEN_KEY, token);
+  }
+}
+
+/**
+ * Restore the admin session after stop-impersonating.
+ * Returns the restored token, or null if none was stashed.
+ */
+export function restoreAdminToken(): string | null {
+  if (import.meta.env.SSR) return null;
+  const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+  localStorage.removeItem(ADMIN_TOKEN_KEY);
+  if (token) {
+    setToken(token);
+  }
+  return token;
+}
+
+export function clearAdminToken(): void {
+  if (import.meta.env.SSR) return;
+  localStorage.removeItem(ADMIN_TOKEN_KEY);
 }
 
 export const api = createClient<paths>({

--- a/frontend/src/layouts/AppLayout.vue
+++ b/frontend/src/layouts/AppLayout.vue
@@ -284,7 +284,7 @@ import { useNotifications } from "@/composables/useNotifications";
 import { useSession, clearSession } from "@/composables/useSession";
 import { useAccountEnvironments } from "@/composables/useAccountEnvironments";
 import { useAccountShops } from "@/composables/useAccountShops";
-import { api, setToken } from "@/helpers/api";
+import { api, clearAdminToken, setToken } from "@/helpers/api";
 import { formatDateTime } from "@/helpers/formatter";
 import {
   notificationReasons,
@@ -409,6 +409,7 @@ function isActive(item: { route: string; active?: string }, $route: RouteLocatio
 async function logout() {
   await api.POST("/auth/sign-out");
   setToken(null);
+  clearAdminToken();
   clearSession();
   router.push({ name: "home" });
 }

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -4,5490 +4,5490 @@
  */
 
 export interface paths {
-    "/health": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Health check */
-        get: operations["getHealth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/me": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get current user profile */
-        get: operations["getAccountMe"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Update current user preferences */
-        patch: operations["updateAccountMe"];
-        trace?: never;
-    };
-    "/account/extensions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get aggregated extensions across all environments */
-        get: operations["getAccountExtensions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/extensions/{name}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single aggregated extension by technical name */
-        get: operations["getAccountExtension"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/organizations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get organizations the user belongs to */
-        get: operations["getAccountOrganizations"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all environments accessible to the user */
-        get: operations["getAccountEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/shops": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all shops accessible to the user */
-        get: operations["getAccountShops"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/changelogs": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get changelogs across all environments */
-        get: operations["getAccountChangelogs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/subscribed-environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get environments the user is subscribed to for notifications */
-        get: operations["getAccountSubscribedEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/account/notification-preferences": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the current user's notification preferences */
-        get: operations["getNotificationPreferences"];
-        /** Create or update a single notification preference */
-        put: operations["setNotificationPreference"];
-        post?: never;
-        /** Delete a single notification preference (revert to inherited/default) */
-        delete: operations["deleteNotificationPreference"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all notifications for the current user */
-        get: operations["getNotifications"];
-        put?: never;
-        post?: never;
-        /** Delete all notifications */
-        delete: operations["deleteAllNotifications"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/event-types": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List the notifiable event types and their default channels */
-        get: operations["getNotificationEventTypes"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a single notification */
-        delete: operations["deleteNotification"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/notifications/mark-read": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Mark all notifications as read */
-        post: operations["markNotificationsRead"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all environments in an organization */
-        get: operations["getOrganizationEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a new environment */
-        post: operations["createEnvironment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get full environment details */
-        get: operations["getEnvironment"];
-        put?: never;
-        post?: never;
-        /** Delete an environment */
-        delete: operations["deleteEnvironment"];
-        options?: never;
-        head?: never;
-        /** Update an environment */
-        patch: operations["updateEnvironment"];
-        trace?: never;
-    };
-    "/environments/{environmentId}/refresh": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Refresh environment data from Shopware API */
-        post: operations["refreshEnvironment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/clear-cache": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Clear Shopware cache for the environment */
-        post: operations["clearEnvironmentCache"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/tasks/{taskId}/reschedule": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reschedule a scheduled task */
-        post: operations["rescheduleTask"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/subscribe": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Subscribe to environment notifications */
-        post: operations["subscribeToEnvironment"];
-        /** Unsubscribe from environment notifications */
-        delete: operations["unsubscribeFromEnvironment"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/status-events": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get the status change history for an environment */
-        get: operations["getEnvironmentStatusEvents"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/sitespeed-settings": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /** Update sitespeed settings for an environment */
-        put: operations["updateSitespeedSettings"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get all shops in an organization */
-        get: operations["getOrganizationShops"];
-        put?: never;
-        /** Create a new shop */
-        post: operations["createShop"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a shop */
-        delete: operations["deleteShop"];
-        options?: never;
-        head?: never;
-        /** Update a shop */
-        patch: operations["updateShop"];
-        trace?: never;
-    };
-    "/api-key-scopes": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get available API key scopes */
-        get: operations["getApiKeyScopes"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}/api-keys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List API keys for a shop */
-        get: operations["getApiKeys"];
-        put?: never;
-        /** Create a new API key */
-        post: operations["createApiKey"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}/api-keys/{keyId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete an API key */
-        delete: operations["deleteApiKey"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/packages-token/configuration": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get packages token configuration */
-        get: operations["getPackagesTokenConfiguration"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}/packages-tokens": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List packages tokens for a shop */
-        get: operations["getPackagesTokens"];
-        put?: never;
-        /** Create a new packages token */
-        post: operations["createPackagesToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete a packages token */
-        delete: operations["deletePackagesToken"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}/sync": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Sync a packages token */
-        post: operations["syncPackagesToken"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List deployments for an environment */
-        get: operations["getDeployments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/environments/{environmentId}/deployments/{deploymentId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get deployment details with output */
-        get: operations["getDeployment"];
-        put?: never;
-        post?: never;
-        /** Delete a deployment */
-        delete: operations["deleteDeployment"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/cli/deployments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create a deployment via CLI */
-        post: operations["createCliDeployment"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/sso-providers": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List SSO providers for an organization */
-        get: operations["getSsoProviders"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/sso/discover": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Discover OIDC configuration from an issuer URL */
-        get: operations["discoverSso"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/organizations/{orgId}/sso-providers/{providerId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        /** Update an SSO provider */
-        put: operations["updateSsoProvider"];
-        post?: never;
-        /** Delete an SSO provider */
-        delete: operations["deleteSsoProvider"];
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/organizations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List all organizations (admin only) */
-        get: operations["adminGetOrganizations"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/environments": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List all environments (admin only) */
-        get: operations["adminGetEnvironments"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/stats": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get admin dashboard statistics */
-        get: operations["adminGetStats"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/growth": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get growth data over time */
-        get: operations["adminGetGrowth"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/organizations/{orgId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an organization with detail (admin only) */
-        get: operations["adminGetOrganizationDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/environments/{envId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get an environment with detail (admin only) */
-        get: operations["adminGetEnvironmentDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/audit-log": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List audit log entries (admin only) */
-        get: operations["adminGetAuditLog"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/recent-activity": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get recent user and environment activity */
-        get: operations["adminGetRecentActivity"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/admin/shopware-versions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get Shopware version distribution across environments */
-        get: operations["adminGetShopwareVersions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/info/extension-compatibility": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Check extension compatibility between Shopware versions */
-        post: operations["checkExtensionCompatibility"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/info/shopware-versions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get known Shopware versions
-         * @description Returns all known Shopware versions, newest first. Served from a local cache that the worker refreshes hourly from the Shopware release changelog.
-         */
-        get: operations["getShopwareVersions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/info/config": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get instance feature configuration
-         * @description Returns which features are enabled on this instance, based on server configuration.
-         */
-        get: operations["getInstanceConfig"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/info/ecosystem": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get public ecosystem statistics
-         * @description Aggregate, non-identifying ecosystem statistics (user growth, environment growth and Shopware version distribution) visible to any authenticated user.
-         */
-        get: operations["getEcosystemStats"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sign-up/email": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Register with email and password */
-        post: operations["signUpEmail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sign-in/email": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Sign in with email and password */
-        post: operations["signInEmail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sign-out": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Sign out */
-        post: operations["signOut"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/session": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get current session */
-        get: operations["getSession"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/set-active-organization": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Set the active organization for the current session */
-        post: operations["setActiveOrganization"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/verify-email": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Verify email address */
-        get: operations["verifyEmail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/forget-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Request password reset email */
-        post: operations["forgetPassword"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/reset-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reset password with token */
-        post: operations["resetPassword"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sign-in/social": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Initiate OAuth sign-in (GitHub) */
-        post: operations["signInSocial"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sign-in/sso": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Initiate SSO sign-in */
-        post: operations["signInSSO"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sso/callback/{providerId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Handle SSO OIDC callback */
-        get: operations["ssoCallback"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/register-options": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Begin passkey registration */
-        post: operations["passkeyRegisterOptions"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/register": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Complete passkey registration */
-        post: operations["passkeyRegister"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/login-options": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Begin passkey login */
-        post: operations["passkeyLoginOptions"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/login": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Complete passkey login */
-        post: operations["passkeyLogin"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/organizations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Create an organization */
-        post: operations["createOrganization"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/organizations/{organizationId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Delete an organization */
-        delete: operations["deleteOrganization"];
-        options?: never;
-        head?: never;
-        /** Update an organization */
-        patch: operations["updateOrganization"];
-        trace?: never;
-    };
-    "/auth/organizations/{organizationId}/members": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List organization members */
-        get: operations["listOrganizationMembers"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/organizations/{organizationId}/members/{userId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        /** Remove a member from the organization */
-        delete: operations["removeMember"];
-        options?: never;
-        head?: never;
-        /** Change a member's role */
-        patch: operations["setMemberRole"];
-        trace?: never;
-    };
-    "/auth/organizations/{organizationId}/leave": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Leave an organization */
-        post: operations["leaveOrganization"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/organizations/{organizationId}/invitations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List pending invitations */
-        get: operations["listOrganizationInvitations"];
-        put?: never;
-        /** Invite a user to the organization */
-        post: operations["inviteMember"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/invitations/{invitationId}/accept": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Accept an invitation */
-        post: operations["acceptInvitation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/invitations/{invitationId}/reject": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Reject an invitation */
-        post: operations["rejectInvitation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/users": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List all users (admin only) */
-        get: operations["adminListUsers"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/users/{userId}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get a single user with detail (admin only) */
-        get: operations["adminGetUserDetail"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/users/{userId}/role": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        /** Set a user's role */
-        patch: operations["adminSetUserRole"];
-        trace?: never;
-    };
-    "/auth/admin/users/{userId}/ban": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Ban a user */
-        post: operations["adminBanUser"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/users/{userId}/unban": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Unban a user */
-        post: operations["adminUnbanUser"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/users/{userId}/impersonate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Impersonate a user */
-        post: operations["adminImpersonate"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/get-full-organization": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Get full organization details by ID */
-        get: operations["getFullOrganization"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/list-sessions": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List active sessions */
-        get: operations["listSessions"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/revoke-session": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Revoke a session */
-        post: operations["revokeSession"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/list-accounts": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List linked auth providers */
-        get: operations["listAccounts"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/unlink-account": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Unlink an auth provider */
-        post: operations["unlinkAccount"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/change-email": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Change email address */
-        post: operations["changeEmail"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/update-user": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Update user profile */
-        post: operations["updateUser"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/change-password": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Change password */
-        post: operations["changePassword"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/delete-user": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Delete user account */
-        post: operations["deleteUser"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/link-social": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Link a social provider */
-        post: operations["linkSocial"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/list-organizations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List user's organizations */
-        get: operations["listUserOrganizations"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/has-permission": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Check organization permission */
-        post: operations["hasPermission"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/cancel-invitation": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Cancel a pending invitation */
-        post: operations["cancelInvitation"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/list-user-passkeys": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** List user's passkeys */
-        get: operations["listUserPasskeys"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/passkey/delete-passkey": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Delete a passkey */
-        post: operations["deletePasskey"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/sso/register": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Register an SSO provider */
-        post: operations["registerSSOProvider"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/admin/stop-impersonating": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Stop impersonating a user */
-        post: operations["adminStopImpersonating"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/callback/github": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /** Handle GitHub OAuth callback */
-        get: operations["githubCallback"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/auth/exchange-code": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /** Exchange one-time authorization code for session token */
-        post: operations["exchangeCode"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+  "/health": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Health check */
+    get: operations["getHealth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/me": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get current user profile */
+    get: operations["getAccountMe"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Update current user preferences */
+    patch: operations["updateAccountMe"];
+    trace?: never;
+  };
+  "/account/extensions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get aggregated extensions across all environments */
+    get: operations["getAccountExtensions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/extensions/{name}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single aggregated extension by technical name */
+    get: operations["getAccountExtension"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/organizations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get organizations the user belongs to */
+    get: operations["getAccountOrganizations"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all environments accessible to the user */
+    get: operations["getAccountEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/shops": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all shops accessible to the user */
+    get: operations["getAccountShops"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/changelogs": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get changelogs across all environments */
+    get: operations["getAccountChangelogs"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/subscribed-environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get environments the user is subscribed to for notifications */
+    get: operations["getAccountSubscribedEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/account/notification-preferences": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the current user's notification preferences */
+    get: operations["getNotificationPreferences"];
+    /** Create or update a single notification preference */
+    put: operations["setNotificationPreference"];
+    post?: never;
+    /** Delete a single notification preference (revert to inherited/default) */
+    delete: operations["deleteNotificationPreference"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all notifications for the current user */
+    get: operations["getNotifications"];
+    put?: never;
+    post?: never;
+    /** Delete all notifications */
+    delete: operations["deleteAllNotifications"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/event-types": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List the notifiable event types and their default channels */
+    get: operations["getNotificationEventTypes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/{id}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a single notification */
+    delete: operations["deleteNotification"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/notifications/mark-read": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Mark all notifications as read */
+    post: operations["markNotificationsRead"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all environments in an organization */
+    get: operations["getOrganizationEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a new environment */
+    post: operations["createEnvironment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get full environment details */
+    get: operations["getEnvironment"];
+    put?: never;
+    post?: never;
+    /** Delete an environment */
+    delete: operations["deleteEnvironment"];
+    options?: never;
+    head?: never;
+    /** Update an environment */
+    patch: operations["updateEnvironment"];
+    trace?: never;
+  };
+  "/environments/{environmentId}/refresh": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Refresh environment data from Shopware API */
+    post: operations["refreshEnvironment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/clear-cache": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Clear Shopware cache for the environment */
+    post: operations["clearEnvironmentCache"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/tasks/{taskId}/reschedule": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reschedule a scheduled task */
+    post: operations["rescheduleTask"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/subscribe": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Subscribe to environment notifications */
+    post: operations["subscribeToEnvironment"];
+    /** Unsubscribe from environment notifications */
+    delete: operations["unsubscribeFromEnvironment"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/status-events": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get the status change history for an environment */
+    get: operations["getEnvironmentStatusEvents"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/sitespeed-settings": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** Update sitespeed settings for an environment */
+    put: operations["updateSitespeedSettings"];
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get all shops in an organization */
+    get: operations["getOrganizationShops"];
+    put?: never;
+    /** Create a new shop */
+    post: operations["createShop"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a shop */
+    delete: operations["deleteShop"];
+    options?: never;
+    head?: never;
+    /** Update a shop */
+    patch: operations["updateShop"];
+    trace?: never;
+  };
+  "/api-key-scopes": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get available API key scopes */
+    get: operations["getApiKeyScopes"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}/api-keys": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List API keys for a shop */
+    get: operations["getApiKeys"];
+    put?: never;
+    /** Create a new API key */
+    post: operations["createApiKey"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}/api-keys/{keyId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an API key */
+    delete: operations["deleteApiKey"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/packages-token/configuration": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get packages token configuration */
+    get: operations["getPackagesTokenConfiguration"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}/packages-tokens": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List packages tokens for a shop */
+    get: operations["getPackagesTokens"];
+    put?: never;
+    /** Create a new packages token */
+    post: operations["createPackagesToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete a packages token */
+    delete: operations["deletePackagesToken"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}/sync": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Sync a packages token */
+    post: operations["syncPackagesToken"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List deployments for an environment */
+    get: operations["getDeployments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/environments/{environmentId}/deployments/{deploymentId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get deployment details with output */
+    get: operations["getDeployment"];
+    put?: never;
+    post?: never;
+    /** Delete a deployment */
+    delete: operations["deleteDeployment"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/cli/deployments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create a deployment via CLI */
+    post: operations["createCliDeployment"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/sso-providers": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List SSO providers for an organization */
+    get: operations["getSsoProviders"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/sso/discover": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Discover OIDC configuration from an issuer URL */
+    get: operations["discoverSso"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/organizations/{orgId}/sso-providers/{providerId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    /** Update an SSO provider */
+    put: operations["updateSsoProvider"];
+    post?: never;
+    /** Delete an SSO provider */
+    delete: operations["deleteSsoProvider"];
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/organizations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List all organizations (admin only) */
+    get: operations["adminGetOrganizations"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/environments": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List all environments (admin only) */
+    get: operations["adminGetEnvironments"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/stats": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get admin dashboard statistics */
+    get: operations["adminGetStats"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/growth": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get growth data over time */
+    get: operations["adminGetGrowth"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/organizations/{orgId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get an organization with detail (admin only) */
+    get: operations["adminGetOrganizationDetail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/environments/{envId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get an environment with detail (admin only) */
+    get: operations["adminGetEnvironmentDetail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/audit-log": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List audit log entries (admin only) */
+    get: operations["adminGetAuditLog"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/recent-activity": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get recent user and environment activity */
+    get: operations["adminGetRecentActivity"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/admin/shopware-versions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Shopware version distribution across environments */
+    get: operations["adminGetShopwareVersions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/info/extension-compatibility": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Check extension compatibility between Shopware versions */
+    post: operations["checkExtensionCompatibility"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/info/shopware-versions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get known Shopware versions
+     * @description Returns all known Shopware versions, newest first. Served from a local cache that the worker refreshes hourly from the Shopware release changelog.
+     */
+    get: operations["getShopwareVersions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/info/config": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get instance feature configuration
+     * @description Returns which features are enabled on this instance, based on server configuration.
+     */
+    get: operations["getInstanceConfig"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/info/ecosystem": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get public ecosystem statistics
+     * @description Aggregate, non-identifying ecosystem statistics (user growth, environment growth and Shopware version distribution) visible to any authenticated user.
+     */
+    get: operations["getEcosystemStats"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sign-up/email": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Register with email and password */
+    post: operations["signUpEmail"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sign-in/email": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Sign in with email and password */
+    post: operations["signInEmail"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sign-out": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Sign out */
+    post: operations["signOut"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/session": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get current session */
+    get: operations["getSession"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/set-active-organization": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Set the active organization for the current session */
+    post: operations["setActiveOrganization"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/verify-email": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Verify email address */
+    get: operations["verifyEmail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/forget-password": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Request password reset email */
+    post: operations["forgetPassword"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/reset-password": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reset password with token */
+    post: operations["resetPassword"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sign-in/social": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Initiate OAuth sign-in (GitHub) */
+    post: operations["signInSocial"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sign-in/sso": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Initiate SSO sign-in */
+    post: operations["signInSSO"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sso/callback/{providerId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Handle SSO OIDC callback */
+    get: operations["ssoCallback"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/register-options": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Begin passkey registration */
+    post: operations["passkeyRegisterOptions"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/register": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Complete passkey registration */
+    post: operations["passkeyRegister"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/login-options": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Begin passkey login */
+    post: operations["passkeyLoginOptions"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/login": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Complete passkey login */
+    post: operations["passkeyLogin"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/organizations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create an organization */
+    post: operations["createOrganization"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/organizations/{organizationId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Delete an organization */
+    delete: operations["deleteOrganization"];
+    options?: never;
+    head?: never;
+    /** Update an organization */
+    patch: operations["updateOrganization"];
+    trace?: never;
+  };
+  "/auth/organizations/{organizationId}/members": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List organization members */
+    get: operations["listOrganizationMembers"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/organizations/{organizationId}/members/{userId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    /** Remove a member from the organization */
+    delete: operations["removeMember"];
+    options?: never;
+    head?: never;
+    /** Change a member's role */
+    patch: operations["setMemberRole"];
+    trace?: never;
+  };
+  "/auth/organizations/{organizationId}/leave": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Leave an organization */
+    post: operations["leaveOrganization"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/organizations/{organizationId}/invitations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List pending invitations */
+    get: operations["listOrganizationInvitations"];
+    put?: never;
+    /** Invite a user to the organization */
+    post: operations["inviteMember"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/invitations/{invitationId}/accept": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Accept an invitation */
+    post: operations["acceptInvitation"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/invitations/{invitationId}/reject": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Reject an invitation */
+    post: operations["rejectInvitation"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/users": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List all users (admin only) */
+    get: operations["adminListUsers"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/users/{userId}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get a single user with detail (admin only) */
+    get: operations["adminGetUserDetail"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/users/{userId}/role": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /** Set a user's role */
+    patch: operations["adminSetUserRole"];
+    trace?: never;
+  };
+  "/auth/admin/users/{userId}/ban": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Ban a user */
+    post: operations["adminBanUser"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/users/{userId}/unban": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Unban a user */
+    post: operations["adminUnbanUser"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/users/{userId}/impersonate": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Impersonate a user */
+    post: operations["adminImpersonate"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/get-full-organization": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get full organization details by ID */
+    get: operations["getFullOrganization"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/list-sessions": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List active sessions */
+    get: operations["listSessions"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/revoke-session": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Revoke a session */
+    post: operations["revokeSession"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/list-accounts": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List linked auth providers */
+    get: operations["listAccounts"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/unlink-account": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Unlink an auth provider */
+    post: operations["unlinkAccount"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/change-email": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Change email address */
+    post: operations["changeEmail"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/update-user": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Update user profile */
+    post: operations["updateUser"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/change-password": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Change password */
+    post: operations["changePassword"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/delete-user": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Delete user account */
+    post: operations["deleteUser"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/link-social": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Link a social provider */
+    post: operations["linkSocial"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/list-organizations": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List user's organizations */
+    get: operations["listUserOrganizations"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/has-permission": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Check organization permission */
+    post: operations["hasPermission"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/cancel-invitation": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Cancel a pending invitation */
+    post: operations["cancelInvitation"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/list-user-passkeys": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** List user's passkeys */
+    get: operations["listUserPasskeys"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/passkey/delete-passkey": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Delete a passkey */
+    post: operations["deletePasskey"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/sso/register": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Register an SSO provider */
+    post: operations["registerSSOProvider"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/admin/stop-impersonating": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Stop impersonating a user */
+    post: operations["adminStopImpersonating"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/callback/github": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Handle GitHub OAuth callback */
+    get: operations["githubCallback"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/auth/exchange-code": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Exchange one-time authorization code for session token */
+    post: operations["exchangeCode"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: {
-        ErrorResponse: {
-            message: string;
-        };
-        UserProfile: {
-            id: string;
-            displayName: string;
-            /** Format: email */
-            email: string;
-            /** Format: date-time */
-            createdAt: string;
-            /** @description The user's preferred language, used to localize notification emails. */
-            locale: string;
-        };
-        AccountExtension: {
-            name: string;
-            label: string;
-            version: string;
-            latestVersion: string;
-            active: boolean;
-            installed: boolean;
-            storeLink: string | null;
-            ratingAverage: number | null;
-            /** Format: date-time */
-            installedAt: string | null;
-            changelog: components["schemas"]["ExtensionChangelogEntry"][] | null;
-            /** @description URL of the extension's store icon, when known. */
-            iconUrl?: string | null;
-            producerName?: string | null;
-            producerWebsite?: string | null;
-            /** @description Release date of the latest store version (raw store value). */
-            releaseDate?: string | null;
-            /** @description Short store description in the requested language (falls back to English). */
-            shortDescription?: string | null;
-            /** @description Full store description (HTML) in the requested language (falls back to English). */
-            description?: string | null;
-            /** @description Installation manual (HTML) in the requested language (falls back to English). */
-            installationManual?: string | null;
-            screenshots?: components["schemas"]["ExtensionScreenshot"][] | null;
-            environments: components["schemas"]["AccountExtensionEnvironment"][];
-        };
-        ExtensionScreenshot: {
-            url: string;
-            /** @description Whether this image is the store's primary preview image. */
-            preview: boolean;
-        };
-        AccountExtensionEnvironment: {
-            environmentId: number;
-            environmentName: string;
-            environmentShopName: string;
-            environmentOrganizationName: string;
-            environmentOrganizationId: string;
-            environmentUrl: string;
-            /** @description ID of the shop this environment belongs to. */
-            shopId: number;
-            /** @description Name of the shop this environment belongs to (environments may share a name across shops). */
-            shopName: string;
-            active: boolean;
-            version: string;
-            latestVersion: string;
-            installed: boolean;
-        };
-        AccountOrganization: {
-            id: string;
-            name: string;
-            logo: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            environmentCount: number;
-            memberCount: number;
-        };
-        AccountEnvironment: {
-            id: number;
-            name: string;
-            url: string;
-            favicon: string | null;
-            status: string;
-            shopwareVersion: string;
-            /** Format: date-time */
-            lastScrapedAt: string | null;
-            lastScrapedError: string | null;
-            organizationId: string;
-            organizationName: string;
-            shopId: number | null;
-            shopName: string | null;
-        };
-        AccountShop: {
-            id: number;
-            name: string;
-            description: string | null;
-            gitUrl: string | null;
-            organizationId: string;
-            organizationName: string;
-            defaultEnvironmentId: number | null;
-        };
-        AccountChangelog: {
-            id: number;
-            environmentId: number;
-            /** @description JSON data describing extension changes */
-            extensions: components["schemas"]["ExtensionDiff"][];
-            oldShopwareVersion: string | null;
-            newShopwareVersion: string | null;
-            /** Format: date-time */
-            date: string;
-            environmentName: string;
-            environmentShopName: string;
-            environmentOrganizationName: string;
-            environmentOrganizationId: string;
-        };
-        ExtensionDiff: {
-            name: string;
-            label: string;
-            state: string;
-            oldVersion?: string | null;
-            newVersion?: string | null;
-            changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
-            active: boolean;
-        };
-        ExtensionChangelogEntry: {
-            version: string;
-            /** @description Changelog text. For store catalog endpoints this is already resolved to the requested language (English fallback). For stored environment-changelog history it holds the English (en_GB) text, with textDe carrying the German variant when available. */
-            text: string;
-            /** @description German (de_DE) changelog text for stored history entries, when available. */
-            textDe?: string | null;
-            /** Format: date-time */
-            creationDate: string;
-        };
-        SubscribedEnvironment: {
-            id: number;
-            name: string;
-            /** @description The shop this environment belongs to, if any. */
-            shopId?: number | null;
-            shopName?: string | null;
-        };
-        StatusReason: {
-            level: string;
-            messageKey: string;
-            params?: {
-                [key: string]: unknown;
-            };
-            source?: string;
-        };
-        StatusEvent: {
-            id: number;
-            oldStatus: string;
-            newStatus: string;
-            reasons: components["schemas"]["StatusReason"][];
-            /** Format: date-time */
-            createdAt: string;
-        };
-        NotificationEventType: {
-            /** @description Stable event type identifier (e.g. status_degraded). */
-            type: string;
-            /** @description Channels this event is delivered on by default. */
-            defaultChannels: string[];
-        };
-        NotificationPreference: {
-            /** @description Scope of the preference: global, organization, or environment. */
-            scopeType: string;
-            /** @description Empty for global; organization or environment id otherwise. */
-            scopeId: string;
-            /** @description Empty matches all event types; otherwise a specific event type. */
-            eventType: string;
-            /** @description Empty is a subscription marker; otherwise in_app or email. */
-            channel: string;
-            enabled: boolean;
-        };
-        NotificationPreferenceInput: {
-            scopeType: string;
-            scopeId?: string;
-            eventType?: string;
-            channel: string;
-            enabled: boolean;
-        };
-        Notification: {
-            id: number;
-            userId: string;
-            key: string;
-            level: string;
-            title: string;
-            message: string;
-            /** @description Translation key for the title; render with params client-side. Falls back to title. */
-            titleKey?: string | null;
-            /** @description Translation key for the message; render with params client-side. Falls back to message. */
-            messageKey?: string | null;
-            /** @description Structured params for interpolating titleKey/messageKey. */
-            params?: {
-                [key: string]: unknown;
-            };
-            link: components["schemas"]["NotificationLink"] | null;
-            read: boolean;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        NotificationLink: {
-            url: string;
-            label: string;
-        };
-        CreateEnvironmentRequest: {
-            name: string;
-            shopUrl: string;
-            clientId: string;
-            clientSecret: string;
-            shopId: number;
-            environmentToken?: string | null;
-        };
-        UpdateEnvironmentRequest: {
-            name?: string;
-            shopUrl?: string;
-            clientId?: string;
-            clientSecret?: string;
-            ignores?: string[];
-            shopId: number;
-        };
-        EnvironmentDetail: {
-            id: number;
-            organizationId: string;
-            organizationName: string;
-            shopId: number | null;
-            shopName: string | null;
-            shopDescription: string | null;
-            name: string;
-            status: string;
-            url: string;
-            favicon: string | null;
-            shopwareVersion: string;
-            /** Format: date-time */
-            lastScrapedAt: string | null;
-            lastScrapedError: string | null;
-            ignores: string[] | null;
-            environmentImage: string | null;
-            environmentToken: string;
-            lastChangelog: components["schemas"]["AccountChangelog"] | null;
-            sitespeedEnabled: boolean;
-            sitespeedUrls: string[] | null;
-            sitespeedDetailUrl: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            extensions: components["schemas"]["EnvironmentExtension"][];
-            scheduledTasks: components["schemas"]["ScheduledTask"][];
-            queues: components["schemas"]["Queue"][];
-            cache: components["schemas"]["CacheInfo"] | null;
-            checks: components["schemas"]["EnvironmentCheck"][];
-            sitespeeds: components["schemas"]["Sitespeed"][];
-            changelogs: components["schemas"]["AccountChangelog"][];
-            deploymentsCount: number;
-            subscribed: boolean;
-        };
-        EnvironmentExtension: {
-            name: string;
-            label: string;
-            version: string;
-            latestVersion: string;
-            active: boolean;
-            installed: boolean;
-            storeLink?: string | null;
-            ratingAverage?: number | null;
-            /** Format: date-time */
-            installedAt?: string | null;
-            changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
-        };
-        ScheduledTask: {
-            id: string;
-            name: string;
-            runInterval: number;
-            status: string;
-            /** Format: date-time */
-            lastExecutionTime?: string | null;
-            /** Format: date-time */
-            nextExecutionTime?: string | null;
-            overdue: boolean;
-        };
-        Queue: {
-            name: string;
-            size: number;
-        };
-        CacheInfo: {
-            id?: number;
-            environment?: string;
-            httpCache?: boolean;
-            cacheAdapter?: string;
-        };
-        EnvironmentCheck: {
-            id: string;
-            level: string;
-            message: string;
-            /** @description Translation key for the message; render with params client-side. Falls back to message. */
-            messageKey?: string | null;
-            /** @description Structured params for interpolating messageKey. */
-            params?: {
-                [key: string]: unknown;
-            };
-            link?: string | null;
-        };
-        Sitespeed: {
-            ttfb?: number | null;
-            fullyLoaded?: number | null;
-            largestContentfulPaint?: number | null;
-            firstContentfulPaint?: number | null;
-            cumulativeLayoutShift?: number | null;
-            transferSize?: number | null;
-            /** Format: date-time */
-            createdAt: string;
-            deployment?: components["schemas"]["SitespeedDeployment"] | null;
-        };
-        SitespeedDeployment: {
-            id: number;
-            name: string;
-        };
-        SitespeedSettingsRequest: {
-            enabled: boolean;
-            urls?: string[];
-        };
-        Shop: {
-            id: number;
-            name: string;
-            description: string | null;
-            gitUrl: string | null;
-            organizationId: string;
-            defaultEnvironmentId: number | null;
-        };
-        CreateShopRequest: {
-            name: string;
-            description?: string;
-            gitUrl?: string;
-            environmentName: string;
-            environmentUrl: string;
-            clientId: string;
-            clientSecret: string;
-        };
-        UpdateShopRequest: {
-            name?: string;
-            description?: string;
-            gitUrl?: string;
-            defaultEnvironmentId?: number;
-        };
-        ApiKeyScope: {
-            value: string;
-            label: string;
-            description: string;
-        };
-        ApiKey: {
-            id: string;
-            name: string;
-            scopes: string[];
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            lastUsedAt: string | null;
-        };
-        CreateApiKeyRequest: {
-            name: string;
-            scopes: string[];
-        };
-        CreateApiKeyResponse: {
-            id: string;
-            token: string;
-            name: string;
-            scopes: string[];
-        };
-        PackagesTokenConfiguration: {
-            configured: boolean;
-            composerUrl: string | null;
-        };
-        PackagesToken: {
-            id: number;
-            source: string;
-            /**
-             * Format: int64
-             * @description Unix timestamp in seconds of the last successful sync, or null if never synced.
-             */
-            lastSyncedAt: number | null;
-        };
-        CreatePackagesTokenRequest: {
-            token: string;
-        };
-        Deployment: {
-            id: number;
-            name: string | null;
-            command: string;
-            returnCode: number;
-            /** Format: date-time */
-            startDate: string;
-            /** Format: date-time */
-            endDate: string;
-            /** @description Execution time in seconds */
-            executionTime: number;
-            reference: string | null;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        DeploymentDetail: components["schemas"]["Deployment"] & {
-            output?: string | null;
-        };
-        CreateCliDeploymentRequest: {
-            environment_id: number;
-            command: string;
-            return_code: number;
-            /** Format: date-time */
-            start_date: string;
-            /** Format: date-time */
-            end_date: string;
-            execution_time: number;
-            composer?: string | null;
-            reference?: string | null;
-            name?: string | null;
-        };
-        CreateCliDeploymentResponse: {
-            success: boolean;
-            name: string;
-            deployment_id: number;
-            url: string;
-            upload_url: string;
-        };
-        SsoProvider: {
-            id: string;
-            domain: string;
-            issuer: string;
-            clientId: string;
-            authorizationEndpoint: string;
-            tokenEndpoint: string;
-            jwksEndpoint: string;
-        };
-        SsoDiscovery: {
-            issuer: string;
-            authorizationEndpoint: string;
-            tokenEndpoint: string;
-            jwksEndpoint: string;
-            userInfoEndpoint: string;
-            scopes: string[];
-        };
-        UpdateSsoProviderRequest: {
-            domain: string;
-            issuer: string;
-            clientId: string;
-            clientSecret?: string;
-            authorizationEndpoint: string;
-            tokenEndpoint: string;
-            jwksEndpoint: string;
-        };
-        AdminOrganizationsResponse: {
-            organizations: components["schemas"]["AccountOrganization"][];
-            total: number;
-        };
-        AdminEnvironmentsResponse: {
-            environments: components["schemas"]["AccountEnvironment"][];
-            total: number;
-        };
-        AdminUser: {
-            id: string;
-            name: string;
-            email: string;
-            emailVerified: boolean;
-            image?: string | null;
-            role: string;
-            banned?: boolean | null;
-            banReason?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminUsersResponse: {
-            users: components["schemas"]["AdminUser"][];
-            total: number;
-        };
-        AdminUserDetail: {
-            id: string;
-            name: string;
-            email: string;
-            emailVerified: boolean;
-            image?: string | null;
-            role: string;
-            banned: boolean;
-            banReason?: string | null;
-            /** Format: date-time */
-            banExpires?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            updatedAt: string;
-            authProviders: components["schemas"]["AdminUserAuthProvider"][];
-            sessions: components["schemas"]["AdminUserSession"][];
-            memberships: components["schemas"]["AdminUserMembership"][];
-            auditLog: components["schemas"]["AdminAuditLogEntry"][];
-        };
-        AdminUserAuthProvider: {
-            id: string;
-            providerId: string;
-            accountId?: string;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminUserSession: {
-            id: string;
-            ipAddress?: string | null;
-            userAgent?: string | null;
-            impersonated: boolean;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            expiresAt: string;
-        };
-        AdminUserMembership: {
-            organizationId: string;
-            organizationName: string;
-            organizationSlug: string;
-            role: string;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminOrganizationDetail: {
-            id: string;
-            name: string;
-            slug: string;
-            logo?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-            memberCount: number;
-            environmentCount: number;
-            members: components["schemas"]["AdminOrganizationMember"][];
-            environments: components["schemas"]["AdminOrganizationEnvironment"][];
-            invitations: components["schemas"]["AdminOrganizationInvitation"][];
-            ssoProviders: components["schemas"]["AdminOrganizationSSO"][];
-            shops: components["schemas"]["AdminOrganizationShop"][];
-        };
-        AdminOrganizationMember: {
-            userId: string;
-            name: string;
-            email: string;
-            image?: string | null;
-            role: string;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminOrganizationEnvironment: {
-            id: number;
-            name: string;
-            url: string;
-            status: string;
-            shopwareVersion: string;
-            shopId: number;
-            shopName: string;
-            /** Format: date-time */
-            lastScrapedAt?: string | null;
-        };
-        AdminOrganizationInvitation: {
-            id: string;
-            email: string;
-            role?: string | null;
-            status: string;
-            /** Format: date-time */
-            expiresAt: string;
-            /** Format: date-time */
-            createdAt: string;
-            inviterName: string;
-            inviterEmail: string;
-        };
-        AdminOrganizationSSO: {
-            id: string;
-            issuer: string;
-            providerId: string;
-            domain: string;
-        };
-        AdminOrganizationShop: {
-            id: number;
-            name: string;
-            description?: string | null;
-            defaultEnvironmentId?: number | null;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminEnvironmentDetail: {
-            id: number;
-            name: string;
-            url: string;
-            status: string;
-            shopwareVersion: string;
-            /** Format: date-time */
-            createdAt: string;
-            /** Format: date-time */
-            lastScrapedAt?: string | null;
-            lastScrapedError?: string | null;
-            connectionIssueCount: number;
-            organizationId: string;
-            organizationName: string;
-            shopId: number;
-            shopName: string;
-            checks: components["schemas"]["AdminEnvironmentCheck"][];
-            extensions: components["schemas"]["AdminEnvironmentExtension"][];
-            scheduledTasks: components["schemas"]["AdminEnvironmentTask"][];
-            lastDeployment?: components["schemas"]["AdminEnvironmentDeployment"];
-        };
-        AdminEnvironmentCheck: {
-            id: number;
-            checkId: string;
-            level: string;
-            message: string;
-            source: string;
-            link?: string | null;
-        };
-        AdminEnvironmentExtension: {
-            id: number;
-            name: string;
-            label: string;
-            active: boolean;
-            version: string;
-            latestVersion?: string | null;
-            installed: boolean;
-            storeLink?: string | null;
-        };
-        AdminEnvironmentTask: {
-            id: number;
-            taskId: string;
-            name: string;
-            status: string;
-            interval: number;
-            overdue: boolean;
-            lastExecutionTime?: string | null;
-            nextExecutionTime?: string | null;
-        };
-        AdminEnvironmentDeployment: {
-            id: number;
-            name: string;
-            command: string;
-            returnCode: number;
-            /** Format: float */
-            executionTime: number;
-            reference?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminAuditLogEntry: {
-            /** Format: int64 */
-            id: number;
-            actorUserId?: string | null;
-            actorName?: string | null;
-            actorEmail?: string | null;
-            action: string;
-            targetUserId?: string | null;
-            targetName?: string | null;
-            targetEmail?: string | null;
-            detail?: string | null;
-            ipAddress?: string | null;
-            /** Format: date-time */
-            createdAt: string;
-        };
-        AdminAuditLogResponse: {
-            entries: components["schemas"]["AdminAuditLogEntry"][];
-            total: number;
-        };
-        AdminStats: {
-            totalUsers: number;
-            totalOrganizations: number;
-            totalEnvironments: number;
-            environmentsByStatus: {
-                green: number;
-                yellow: number;
-                red: number;
-            };
-        };
-        AdminGrowth: {
-            users: components["schemas"]["GrowthDataPoint"][];
-            environments: components["schemas"]["GrowthDataPoint"][];
-        };
-        GrowthDataPoint: {
-            month: string;
-            count: number;
-        };
-        AdminRecentActivity: {
-            recentUsers: components["schemas"]["UserProfile"][];
-            recentEnvironments: components["schemas"]["AccountEnvironment"][];
-        };
-        ShopwareVersionCount: {
-            version: string;
-            count: number;
-        };
-        ShopwareVersion: {
-            name: string;
-        };
-        EcosystemStats: {
-            growth: components["schemas"]["AdminGrowth"];
-            shopwareVersions: components["schemas"]["ShopwareVersionCount"][];
-        };
-        ExtensionCompatibilityRequest: {
-            currentVersion: string;
-            futureVersion: string;
-            extensions: {
-                name: string;
-                version: string;
-            }[];
-        };
-        ExtensionCompatibilityResult: {
-            name: string;
-            label: string;
-            iconPath: string | null;
-            status: {
-                name: string;
-                label: string;
-                type: string;
-            };
-        };
-        AuthUser: {
-            id?: string;
-            name?: string;
-            /** Format: email */
-            email?: string;
-            emailVerified?: boolean;
-            image?: string | null;
-            role?: string;
-            notifications?: string[];
-        };
-        SessionInfo: {
-            id?: string;
-            userId?: string;
-            /** Format: date-time */
-            expiresAt?: string;
-            activeOrganizationId?: string | null;
-            /** @description Admin user ID when this session is an impersonation */
-            impersonatedBy?: string | null;
-        };
-        InstanceConfig: {
-            registrationEnabled: boolean;
-            githubAuthEnabled: boolean;
-            sitespeedEnabled: boolean;
-            packageMirrorEnabled: boolean;
-        };
+  schemas: {
+    ErrorResponse: {
+      message: string;
     };
-    responses: {
-        /** @description Authentication required */
-        Unauthorized: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ErrorResponse"];
-            };
-        };
-        /** @description Insufficient permissions */
-        Forbidden: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ErrorResponse"];
-            };
-        };
-        /** @description Resource not found */
-        NotFound: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ErrorResponse"];
-            };
-        };
-        /** @description Validation error */
-        ValidationError: {
-            headers: {
-                [name: string]: unknown;
-            };
-            content: {
-                "application/json": components["schemas"]["ErrorResponse"];
-            };
-        };
+    UserProfile: {
+      id: string;
+      displayName: string;
+      /** Format: email */
+      email: string;
+      /** Format: date-time */
+      createdAt: string;
+      /** @description The user's preferred language, used to localize notification emails. */
+      locale: string;
     };
-    parameters: {
-        /** @description Organization ID */
-        OrgId: string;
-        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-        LanguageParam: "en" | "de";
-        /** @description Environment ID */
-        EnvironmentId: number;
-        /** @description Shop ID */
-        ShopId: number;
-        /** @description Deployment ID */
-        DeploymentId: number;
-        /** @description API key ID */
-        KeyId: string;
-        /** @description Packages token ID */
-        TokenId: number;
-        /** @description Scheduled task ID */
-        TaskId: string;
-        /** @description SSO provider ID */
-        ProviderId: string;
-        /** @description Notification ID */
-        NotificationId: number;
+    AccountExtension: {
+      name: string;
+      label: string;
+      version: string;
+      latestVersion: string;
+      active: boolean;
+      installed: boolean;
+      storeLink: string | null;
+      ratingAverage: number | null;
+      /** Format: date-time */
+      installedAt: string | null;
+      changelog: components["schemas"]["ExtensionChangelogEntry"][] | null;
+      /** @description URL of the extension's store icon, when known. */
+      iconUrl?: string | null;
+      producerName?: string | null;
+      producerWebsite?: string | null;
+      /** @description Release date of the latest store version (raw store value). */
+      releaseDate?: string | null;
+      /** @description Short store description in the requested language (falls back to English). */
+      shortDescription?: string | null;
+      /** @description Full store description (HTML) in the requested language (falls back to English). */
+      description?: string | null;
+      /** @description Installation manual (HTML) in the requested language (falls back to English). */
+      installationManual?: string | null;
+      screenshots?: components["schemas"]["ExtensionScreenshot"][] | null;
+      environments: components["schemas"]["AccountExtensionEnvironment"][];
     };
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+    ExtensionScreenshot: {
+      url: string;
+      /** @description Whether this image is the store's primary preview image. */
+      preview: boolean;
+    };
+    AccountExtensionEnvironment: {
+      environmentId: number;
+      environmentName: string;
+      environmentShopName: string;
+      environmentOrganizationName: string;
+      environmentOrganizationId: string;
+      environmentUrl: string;
+      /** @description ID of the shop this environment belongs to. */
+      shopId: number;
+      /** @description Name of the shop this environment belongs to (environments may share a name across shops). */
+      shopName: string;
+      active: boolean;
+      version: string;
+      latestVersion: string;
+      installed: boolean;
+    };
+    AccountOrganization: {
+      id: string;
+      name: string;
+      logo: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      environmentCount: number;
+      memberCount: number;
+    };
+    AccountEnvironment: {
+      id: number;
+      name: string;
+      url: string;
+      favicon: string | null;
+      status: string;
+      shopwareVersion: string;
+      /** Format: date-time */
+      lastScrapedAt: string | null;
+      lastScrapedError: string | null;
+      organizationId: string;
+      organizationName: string;
+      shopId: number | null;
+      shopName: string | null;
+    };
+    AccountShop: {
+      id: number;
+      name: string;
+      description: string | null;
+      gitUrl: string | null;
+      organizationId: string;
+      organizationName: string;
+      defaultEnvironmentId: number | null;
+    };
+    AccountChangelog: {
+      id: number;
+      environmentId: number;
+      /** @description JSON data describing extension changes */
+      extensions: components["schemas"]["ExtensionDiff"][];
+      oldShopwareVersion: string | null;
+      newShopwareVersion: string | null;
+      /** Format: date-time */
+      date: string;
+      environmentName: string;
+      environmentShopName: string;
+      environmentOrganizationName: string;
+      environmentOrganizationId: string;
+    };
+    ExtensionDiff: {
+      name: string;
+      label: string;
+      state: string;
+      oldVersion?: string | null;
+      newVersion?: string | null;
+      changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
+      active: boolean;
+    };
+    ExtensionChangelogEntry: {
+      version: string;
+      /** @description Changelog text. For store catalog endpoints this is already resolved to the requested language (English fallback). For stored environment-changelog history it holds the English (en_GB) text, with textDe carrying the German variant when available. */
+      text: string;
+      /** @description German (de_DE) changelog text for stored history entries, when available. */
+      textDe?: string | null;
+      /** Format: date-time */
+      creationDate: string;
+    };
+    SubscribedEnvironment: {
+      id: number;
+      name: string;
+      /** @description The shop this environment belongs to, if any. */
+      shopId?: number | null;
+      shopName?: string | null;
+    };
+    StatusReason: {
+      level: string;
+      messageKey: string;
+      params?: {
+        [key: string]: unknown;
+      };
+      source?: string;
+    };
+    StatusEvent: {
+      id: number;
+      oldStatus: string;
+      newStatus: string;
+      reasons: components["schemas"]["StatusReason"][];
+      /** Format: date-time */
+      createdAt: string;
+    };
+    NotificationEventType: {
+      /** @description Stable event type identifier (e.g. status_degraded). */
+      type: string;
+      /** @description Channels this event is delivered on by default. */
+      defaultChannels: string[];
+    };
+    NotificationPreference: {
+      /** @description Scope of the preference: global, organization, or environment. */
+      scopeType: string;
+      /** @description Empty for global; organization or environment id otherwise. */
+      scopeId: string;
+      /** @description Empty matches all event types; otherwise a specific event type. */
+      eventType: string;
+      /** @description Empty is a subscription marker; otherwise in_app or email. */
+      channel: string;
+      enabled: boolean;
+    };
+    NotificationPreferenceInput: {
+      scopeType: string;
+      scopeId?: string;
+      eventType?: string;
+      channel: string;
+      enabled: boolean;
+    };
+    Notification: {
+      id: number;
+      userId: string;
+      key: string;
+      level: string;
+      title: string;
+      message: string;
+      /** @description Translation key for the title; render with params client-side. Falls back to title. */
+      titleKey?: string | null;
+      /** @description Translation key for the message; render with params client-side. Falls back to message. */
+      messageKey?: string | null;
+      /** @description Structured params for interpolating titleKey/messageKey. */
+      params?: {
+        [key: string]: unknown;
+      };
+      link: components["schemas"]["NotificationLink"] | null;
+      read: boolean;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    NotificationLink: {
+      url: string;
+      label: string;
+    };
+    CreateEnvironmentRequest: {
+      name: string;
+      shopUrl: string;
+      clientId: string;
+      clientSecret: string;
+      shopId: number;
+      environmentToken?: string | null;
+    };
+    UpdateEnvironmentRequest: {
+      name?: string;
+      shopUrl?: string;
+      clientId?: string;
+      clientSecret?: string;
+      ignores?: string[];
+      shopId: number;
+    };
+    EnvironmentDetail: {
+      id: number;
+      organizationId: string;
+      organizationName: string;
+      shopId: number | null;
+      shopName: string | null;
+      shopDescription: string | null;
+      name: string;
+      status: string;
+      url: string;
+      favicon: string | null;
+      shopwareVersion: string;
+      /** Format: date-time */
+      lastScrapedAt: string | null;
+      lastScrapedError: string | null;
+      ignores: string[] | null;
+      environmentImage: string | null;
+      environmentToken: string;
+      lastChangelog: components["schemas"]["AccountChangelog"] | null;
+      sitespeedEnabled: boolean;
+      sitespeedUrls: string[] | null;
+      sitespeedDetailUrl: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      extensions: components["schemas"]["EnvironmentExtension"][];
+      scheduledTasks: components["schemas"]["ScheduledTask"][];
+      queues: components["schemas"]["Queue"][];
+      cache: components["schemas"]["CacheInfo"] | null;
+      checks: components["schemas"]["EnvironmentCheck"][];
+      sitespeeds: components["schemas"]["Sitespeed"][];
+      changelogs: components["schemas"]["AccountChangelog"][];
+      deploymentsCount: number;
+      subscribed: boolean;
+    };
+    EnvironmentExtension: {
+      name: string;
+      label: string;
+      version: string;
+      latestVersion: string;
+      active: boolean;
+      installed: boolean;
+      storeLink?: string | null;
+      ratingAverage?: number | null;
+      /** Format: date-time */
+      installedAt?: string | null;
+      changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
+    };
+    ScheduledTask: {
+      id: string;
+      name: string;
+      runInterval: number;
+      status: string;
+      /** Format: date-time */
+      lastExecutionTime?: string | null;
+      /** Format: date-time */
+      nextExecutionTime?: string | null;
+      overdue: boolean;
+    };
+    Queue: {
+      name: string;
+      size: number;
+    };
+    CacheInfo: {
+      id?: number;
+      environment?: string;
+      httpCache?: boolean;
+      cacheAdapter?: string;
+    };
+    EnvironmentCheck: {
+      id: string;
+      level: string;
+      message: string;
+      /** @description Translation key for the message; render with params client-side. Falls back to message. */
+      messageKey?: string | null;
+      /** @description Structured params for interpolating messageKey. */
+      params?: {
+        [key: string]: unknown;
+      };
+      link?: string | null;
+    };
+    Sitespeed: {
+      ttfb?: number | null;
+      fullyLoaded?: number | null;
+      largestContentfulPaint?: number | null;
+      firstContentfulPaint?: number | null;
+      cumulativeLayoutShift?: number | null;
+      transferSize?: number | null;
+      /** Format: date-time */
+      createdAt: string;
+      deployment?: components["schemas"]["SitespeedDeployment"] | null;
+    };
+    SitespeedDeployment: {
+      id: number;
+      name: string;
+    };
+    SitespeedSettingsRequest: {
+      enabled: boolean;
+      urls?: string[];
+    };
+    Shop: {
+      id: number;
+      name: string;
+      description: string | null;
+      gitUrl: string | null;
+      organizationId: string;
+      defaultEnvironmentId: number | null;
+    };
+    CreateShopRequest: {
+      name: string;
+      description?: string;
+      gitUrl?: string;
+      environmentName: string;
+      environmentUrl: string;
+      clientId: string;
+      clientSecret: string;
+    };
+    UpdateShopRequest: {
+      name?: string;
+      description?: string;
+      gitUrl?: string;
+      defaultEnvironmentId?: number;
+    };
+    ApiKeyScope: {
+      value: string;
+      label: string;
+      description: string;
+    };
+    ApiKey: {
+      id: string;
+      name: string;
+      scopes: string[];
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      lastUsedAt: string | null;
+    };
+    CreateApiKeyRequest: {
+      name: string;
+      scopes: string[];
+    };
+    CreateApiKeyResponse: {
+      id: string;
+      token: string;
+      name: string;
+      scopes: string[];
+    };
+    PackagesTokenConfiguration: {
+      configured: boolean;
+      composerUrl: string | null;
+    };
+    PackagesToken: {
+      id: number;
+      source: string;
+      /**
+       * Format: int64
+       * @description Unix timestamp in seconds of the last successful sync, or null if never synced.
+       */
+      lastSyncedAt: number | null;
+    };
+    CreatePackagesTokenRequest: {
+      token: string;
+    };
+    Deployment: {
+      id: number;
+      name: string | null;
+      command: string;
+      returnCode: number;
+      /** Format: date-time */
+      startDate: string;
+      /** Format: date-time */
+      endDate: string;
+      /** @description Execution time in seconds */
+      executionTime: number;
+      reference: string | null;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    DeploymentDetail: components["schemas"]["Deployment"] & {
+      output?: string | null;
+    };
+    CreateCliDeploymentRequest: {
+      environment_id: number;
+      command: string;
+      return_code: number;
+      /** Format: date-time */
+      start_date: string;
+      /** Format: date-time */
+      end_date: string;
+      execution_time: number;
+      composer?: string | null;
+      reference?: string | null;
+      name?: string | null;
+    };
+    CreateCliDeploymentResponse: {
+      success: boolean;
+      name: string;
+      deployment_id: number;
+      url: string;
+      upload_url: string;
+    };
+    SsoProvider: {
+      id: string;
+      domain: string;
+      issuer: string;
+      clientId: string;
+      authorizationEndpoint: string;
+      tokenEndpoint: string;
+      jwksEndpoint: string;
+    };
+    SsoDiscovery: {
+      issuer: string;
+      authorizationEndpoint: string;
+      tokenEndpoint: string;
+      jwksEndpoint: string;
+      userInfoEndpoint: string;
+      scopes: string[];
+    };
+    UpdateSsoProviderRequest: {
+      domain: string;
+      issuer: string;
+      clientId: string;
+      clientSecret?: string;
+      authorizationEndpoint: string;
+      tokenEndpoint: string;
+      jwksEndpoint: string;
+    };
+    AdminOrganizationsResponse: {
+      organizations: components["schemas"]["AccountOrganization"][];
+      total: number;
+    };
+    AdminEnvironmentsResponse: {
+      environments: components["schemas"]["AccountEnvironment"][];
+      total: number;
+    };
+    AdminUser: {
+      id: string;
+      name: string;
+      email: string;
+      emailVerified: boolean;
+      image?: string | null;
+      role: string;
+      banned?: boolean | null;
+      banReason?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminUsersResponse: {
+      users: components["schemas"]["AdminUser"][];
+      total: number;
+    };
+    AdminUserDetail: {
+      id: string;
+      name: string;
+      email: string;
+      emailVerified: boolean;
+      image?: string | null;
+      role: string;
+      banned: boolean;
+      banReason?: string | null;
+      /** Format: date-time */
+      banExpires?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      authProviders: components["schemas"]["AdminUserAuthProvider"][];
+      sessions: components["schemas"]["AdminUserSession"][];
+      memberships: components["schemas"]["AdminUserMembership"][];
+      auditLog: components["schemas"]["AdminAuditLogEntry"][];
+    };
+    AdminUserAuthProvider: {
+      id: string;
+      providerId: string;
+      accountId?: string;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminUserSession: {
+      id: string;
+      ipAddress?: string | null;
+      userAgent?: string | null;
+      impersonated: boolean;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      expiresAt: string;
+    };
+    AdminUserMembership: {
+      organizationId: string;
+      organizationName: string;
+      organizationSlug: string;
+      role: string;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminOrganizationDetail: {
+      id: string;
+      name: string;
+      slug: string;
+      logo?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      memberCount: number;
+      environmentCount: number;
+      members: components["schemas"]["AdminOrganizationMember"][];
+      environments: components["schemas"]["AdminOrganizationEnvironment"][];
+      invitations: components["schemas"]["AdminOrganizationInvitation"][];
+      ssoProviders: components["schemas"]["AdminOrganizationSSO"][];
+      shops: components["schemas"]["AdminOrganizationShop"][];
+    };
+    AdminOrganizationMember: {
+      userId: string;
+      name: string;
+      email: string;
+      image?: string | null;
+      role: string;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminOrganizationEnvironment: {
+      id: number;
+      name: string;
+      url: string;
+      status: string;
+      shopwareVersion: string;
+      shopId: number;
+      shopName: string;
+      /** Format: date-time */
+      lastScrapedAt?: string | null;
+    };
+    AdminOrganizationInvitation: {
+      id: string;
+      email: string;
+      role?: string | null;
+      status: string;
+      /** Format: date-time */
+      expiresAt: string;
+      /** Format: date-time */
+      createdAt: string;
+      inviterName: string;
+      inviterEmail: string;
+    };
+    AdminOrganizationSSO: {
+      id: string;
+      issuer: string;
+      providerId: string;
+      domain: string;
+    };
+    AdminOrganizationShop: {
+      id: number;
+      name: string;
+      description?: string | null;
+      defaultEnvironmentId?: number | null;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminEnvironmentDetail: {
+      id: number;
+      name: string;
+      url: string;
+      status: string;
+      shopwareVersion: string;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      lastScrapedAt?: string | null;
+      lastScrapedError?: string | null;
+      connectionIssueCount: number;
+      organizationId: string;
+      organizationName: string;
+      shopId: number;
+      shopName: string;
+      checks: components["schemas"]["AdminEnvironmentCheck"][];
+      extensions: components["schemas"]["AdminEnvironmentExtension"][];
+      scheduledTasks: components["schemas"]["AdminEnvironmentTask"][];
+      lastDeployment?: components["schemas"]["AdminEnvironmentDeployment"];
+    };
+    AdminEnvironmentCheck: {
+      id: number;
+      checkId: string;
+      level: string;
+      message: string;
+      source: string;
+      link?: string | null;
+    };
+    AdminEnvironmentExtension: {
+      id: number;
+      name: string;
+      label: string;
+      active: boolean;
+      version: string;
+      latestVersion?: string | null;
+      installed: boolean;
+      storeLink?: string | null;
+    };
+    AdminEnvironmentTask: {
+      id: number;
+      taskId: string;
+      name: string;
+      status: string;
+      interval: number;
+      overdue: boolean;
+      lastExecutionTime?: string | null;
+      nextExecutionTime?: string | null;
+    };
+    AdminEnvironmentDeployment: {
+      id: number;
+      name: string;
+      command: string;
+      returnCode: number;
+      /** Format: float */
+      executionTime: number;
+      reference?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminAuditLogEntry: {
+      /** Format: int64 */
+      id: number;
+      actorUserId?: string | null;
+      actorName?: string | null;
+      actorEmail?: string | null;
+      action: string;
+      targetUserId?: string | null;
+      targetName?: string | null;
+      targetEmail?: string | null;
+      detail?: string | null;
+      ipAddress?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+    };
+    AdminAuditLogResponse: {
+      entries: components["schemas"]["AdminAuditLogEntry"][];
+      total: number;
+    };
+    AdminStats: {
+      totalUsers: number;
+      totalOrganizations: number;
+      totalEnvironments: number;
+      environmentsByStatus: {
+        green: number;
+        yellow: number;
+        red: number;
+      };
+    };
+    AdminGrowth: {
+      users: components["schemas"]["GrowthDataPoint"][];
+      environments: components["schemas"]["GrowthDataPoint"][];
+    };
+    GrowthDataPoint: {
+      month: string;
+      count: number;
+    };
+    AdminRecentActivity: {
+      recentUsers: components["schemas"]["UserProfile"][];
+      recentEnvironments: components["schemas"]["AccountEnvironment"][];
+    };
+    ShopwareVersionCount: {
+      version: string;
+      count: number;
+    };
+    ShopwareVersion: {
+      name: string;
+    };
+    EcosystemStats: {
+      growth: components["schemas"]["AdminGrowth"];
+      shopwareVersions: components["schemas"]["ShopwareVersionCount"][];
+    };
+    ExtensionCompatibilityRequest: {
+      currentVersion: string;
+      futureVersion: string;
+      extensions: {
+        name: string;
+        version: string;
+      }[];
+    };
+    ExtensionCompatibilityResult: {
+      name: string;
+      label: string;
+      iconPath: string | null;
+      status: {
+        name: string;
+        label: string;
+        type: string;
+      };
+    };
+    AuthUser: {
+      id?: string;
+      name?: string;
+      /** Format: email */
+      email?: string;
+      emailVerified?: boolean;
+      image?: string | null;
+      role?: string;
+      notifications?: string[];
+    };
+    SessionInfo: {
+      id?: string;
+      userId?: string;
+      /** Format: date-time */
+      expiresAt?: string;
+      activeOrganizationId?: string | null;
+      /** @description Admin user ID when this session is an impersonation */
+      impersonatedBy?: string | null;
+    };
+    InstanceConfig: {
+      registrationEnabled: boolean;
+      githubAuthEnabled: boolean;
+      sitespeedEnabled: boolean;
+      packageMirrorEnabled: boolean;
+    };
+  };
+  responses: {
+    /** @description Authentication required */
+    Unauthorized: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
+    /** @description Insufficient permissions */
+    Forbidden: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
+    /** @description Resource not found */
+    NotFound: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
+    /** @description Validation error */
+    ValidationError: {
+      headers: {
+        [name: string]: unknown;
+      };
+      content: {
+        "application/json": components["schemas"]["ErrorResponse"];
+      };
+    };
+  };
+  parameters: {
+    /** @description Organization ID */
+    OrgId: string;
+    /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+    LanguageParam: "en" | "de";
+    /** @description Environment ID */
+    EnvironmentId: number;
+    /** @description Shop ID */
+    ShopId: number;
+    /** @description Deployment ID */
+    DeploymentId: number;
+    /** @description API key ID */
+    KeyId: string;
+    /** @description Packages token ID */
+    TokenId: number;
+    /** @description Scheduled task ID */
+    TaskId: string;
+    /** @description SSO provider ID */
+    ProviderId: string;
+    /** @description Notification ID */
+    NotificationId: number;
+  };
+  requestBodies: never;
+  headers: never;
+  pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getHealth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Service is healthy */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "text/plain": "ok";
-                };
-            };
-        };
-    };
-    getAccountMe: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Current user profile */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UserProfile"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    updateAccountMe: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @description Preferred language (e.g. "en", "de"). */
-                    locale?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Updated user profile */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["UserProfile"];
-                };
-            };
-            400: components["responses"]["ValidationError"];
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountExtensions: {
-        parameters: {
-            query?: {
-                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-                language?: components["parameters"]["LanguageParam"];
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of extensions */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountExtension"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountExtension: {
-        parameters: {
-            query?: {
-                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-                language?: components["parameters"]["LanguageParam"];
-            };
-            header?: never;
-            path: {
-                /** @description Technical name of the extension */
-                name: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description The extension */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountExtension"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    getAccountOrganizations: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of organizations */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountOrganization"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountEnvironments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountEnvironment"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountShops: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of shops */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountShop"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountChangelogs: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of changelogs */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountChangelog"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getAccountSubscribedEnvironments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of subscribed environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SubscribedEnvironment"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getNotificationPreferences: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of notification preferences */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationPreference"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    setNotificationPreference: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["NotificationPreferenceInput"];
-            };
-        };
-        responses: {
-            /** @description Preference saved */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            400: components["responses"]["ValidationError"];
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    deleteNotificationPreference: {
-        parameters: {
-            query: {
-                scopeType: string;
-                scopeId?: string;
-                eventType?: string;
-                channel: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Preference deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            400: components["responses"]["ValidationError"];
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getNotifications: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of notifications */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Notification"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    deleteAllNotifications: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All notifications deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getNotificationEventTypes: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of event types */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["NotificationEventType"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    deleteNotification: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Notification ID */
-                id: components["parameters"]["NotificationId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Notification deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    markNotificationsRead: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description All notifications marked as read */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getOrganizationEnvironments: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AccountEnvironment"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    createEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateEnvironmentRequest"];
-            };
-        };
-        responses: {
-            /** @description Environment created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    getEnvironment: {
-        parameters: {
-            query?: {
-                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-                language?: components["parameters"]["LanguageParam"];
-            };
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Environment details */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EnvironmentDetail"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    deleteEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Environment deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    updateEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateEnvironmentRequest"];
-            };
-        };
-        responses: {
-            /** @description Environment updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    refreshEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    /** @description Also run sitespeed check */
-                    sitespeed?: boolean;
-                };
-            };
-        };
-        responses: {
-            /** @description Environment refresh triggered */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    clearEnvironmentCache: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Cache cleared */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    rescheduleTask: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-                /** @description Scheduled task ID */
-                taskId: components["parameters"]["TaskId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Task rescheduled */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    subscribeToEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Subscribed */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    unsubscribeFromEnvironment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Unsubscribed */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    getEnvironmentStatusEvents: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of status events (most recent first) */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["StatusEvent"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    updateSitespeedSettings: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["SitespeedSettingsRequest"];
-            };
-        };
-        responses: {
-            /** @description Sitespeed settings updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    getOrganizationShops: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of shops */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Shop"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    createShop: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateShopRequest"];
-            };
-        };
-        responses: {
-            /** @description Shop created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    deleteShop: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Shop deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    updateShop: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateShopRequest"];
-            };
-        };
-        responses: {
-            /** @description Shop updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    getApiKeyScopes: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of available scopes */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ApiKeyScope"][];
-                };
-            };
-        };
-    };
-    getApiKeys: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of API keys */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ApiKey"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    createApiKey: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateApiKeyRequest"];
-            };
-        };
-        responses: {
-            /** @description API key created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CreateApiKeyResponse"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    deleteApiKey: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-                /** @description API key ID */
-                keyId: components["parameters"]["KeyId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description API key deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    getPackagesTokenConfiguration: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Packages token configuration */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PackagesTokenConfiguration"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    getPackagesTokens: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of packages tokens */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PackagesToken"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    createPackagesToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreatePackagesTokenRequest"];
-            };
-        };
-        responses: {
-            /** @description Packages token created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    deletePackagesToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-                /** @description Packages token ID */
-                tokenId: components["parameters"]["TokenId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Packages token deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    syncPackagesToken: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description Shop ID */
-                shopId: components["parameters"]["ShopId"];
-                /** @description Packages token ID */
-                tokenId: components["parameters"]["TokenId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Sync triggered */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    getDeployments: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-            };
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of deployments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Deployment"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    getDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-                /** @description Deployment ID */
-                deploymentId: components["parameters"]["DeploymentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment details with output */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["DeploymentDetail"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    deleteDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Environment ID */
-                environmentId: components["parameters"]["EnvironmentId"];
-                /** @description Deployment ID */
-                deploymentId: components["parameters"]["DeploymentId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deployment deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    createCliDeployment: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["CreateCliDeploymentRequest"];
-            };
-        };
-        responses: {
-            /** @description Deployment created */
-            201: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CreateCliDeploymentResponse"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    getSsoProviders: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of SSO providers */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SsoProvider"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    discoverSso: {
-        parameters: {
-            query: {
-                issuer: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Discovered OIDC configuration */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["SsoDiscovery"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    updateSsoProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description SSO provider ID */
-                providerId: components["parameters"]["ProviderId"];
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["UpdateSsoProviderRequest"];
-            };
-        };
-        responses: {
-            /** @description SSO provider updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    deleteSsoProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Organization ID */
-                orgId: components["parameters"]["OrgId"];
-                /** @description SSO provider ID */
-                providerId: components["parameters"]["ProviderId"];
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description SSO provider deleted */
-            204: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    adminGetOrganizations: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                sortBy?: "name" | "createdAt" | "shopCount" | "memberCount";
-                sortDirection?: "asc" | "desc";
-                searchField?: string;
-                searchOperator?: string;
-                searchValue?: string;
-                filterField?: string;
-                filterOperator?: string;
-                filterValue?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Paginated list of organizations */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminOrganizationsResponse"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetEnvironments: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                sortBy?: string;
-                sortDirection?: "asc" | "desc";
-                searchField?: string;
-                searchOperator?: string;
-                searchValue?: string;
-                filterField?: string;
-                filterOperator?: string;
-                filterValue?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Paginated list of environments */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminEnvironmentsResponse"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetStats: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Admin statistics */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminStats"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetGrowth: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Growth data */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminGrowth"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetOrganizationDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                orgId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Organization detail */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminOrganizationDetail"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    adminGetEnvironmentDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                envId: number;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Environment detail */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminEnvironmentDetail"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-            404: components["responses"]["NotFound"];
-        };
-    };
-    adminGetAuditLog: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                action?: string;
-                actorUserId?: string;
-                targetUserId?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Paginated audit log */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminAuditLogResponse"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetRecentActivity: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Recent activity */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminRecentActivity"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    adminGetShopwareVersions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Version distribution */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShopwareVersionCount"][];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            403: components["responses"]["Forbidden"];
-        };
-    };
-    checkExtensionCompatibility: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExtensionCompatibilityRequest"];
-            };
-        };
-        responses: {
-            /** @description Compatibility results */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExtensionCompatibilityResult"][];
-                };
-            };
-            422: components["responses"]["ValidationError"];
-        };
-    };
-    getShopwareVersions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Known Shopware versions, newest first */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ShopwareVersion"][];
-                };
-            };
-        };
-    };
-    getInstanceConfig: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Instance configuration */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["InstanceConfig"];
-                };
-            };
-        };
-    };
-    getEcosystemStats: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Ecosystem statistics */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EcosystemStats"];
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    signUpEmail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    email: string;
-                    password: string;
-                    name: string;
-                };
-            };
-        };
-        responses: {
-            /** @description User created successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        user?: components["schemas"]["AuthUser"];
-                    };
-                };
-            };
-            400: components["responses"]["ValidationError"];
-            /** @description Email already exists */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorResponse"];
-                };
-            };
-        };
-    };
-    signInEmail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    email: string;
-                    password: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Signed in successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        user?: components["schemas"]["AuthUser"];
-                    };
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-            /** @description Account is banned */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    signOut: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Signed out */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    getSession: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Current session */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        user?: components["schemas"]["AuthUser"];
-                        session?: components["schemas"]["SessionInfo"];
-                    };
-                };
-            };
-            401: components["responses"]["Unauthorized"];
-        };
-    };
-    setActiveOrganization: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    organizationId: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Active organization updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Not a member of the specified organization */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    verifyEmail: {
-        parameters: {
-            query: {
-                token: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Email verified */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid or expired token */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    forgetPassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    email: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Reset email sent (always returns success) */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    resetPassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    token: string;
-                    newPassword: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Password reset */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid token or weak password */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    signInSocial: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @enum {string} */
-                    provider: "github";
-                    callbackURL?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Authorization URL */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        url?: string;
-                    };
-                };
-            };
-        };
-    };
-    signInSSO: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    email: string;
-                    callbackURL?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Authorization URL */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        url?: string;
-                    };
-                };
-            };
-            /** @description No SSO provider for this domain */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    ssoCallback: {
-        parameters: {
-            query: {
-                code: string;
-                state: string;
-            };
-            header?: never;
-            path: {
-                providerId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description One-time authorization code */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        code?: string;
-                    };
-                };
-            };
-            /** @description Missing or invalid parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    passkeyRegisterOptions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Registration options and challenge key */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        options?: Record<string, never>;
-                        challengeKey?: string;
-                    };
-                };
-            };
-        };
-    };
-    passkeyRegister: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    challengeKey: string;
-                    name?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Passkey registered */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Invalid or expired challenge */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    passkeyLoginOptions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Login options and challenge key */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    passkeyLogin: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    challengeKey: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Logged in */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Authentication failed */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    createOrganization: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    name: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Organization created */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id?: string;
-                        name?: string;
-                    };
-                };
-            };
-        };
-    };
-    deleteOrganization: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Only owners can delete */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    updateOrganization: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    name?: string;
-                    logo?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    listOrganizationMembers: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of members */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id?: string;
-                        userId?: string;
-                        role?: string;
-                        name?: string;
-                        email?: string;
-                        image?: string | null;
-                    }[];
-                };
-            };
-        };
-    };
-    removeMember: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Member removed */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    setMemberRole: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    role: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Role updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    leaveOrganization: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Left organization */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Cannot leave as only owner */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    listOrganizationInvitations: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of pending invitations */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    inviteMember: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                organizationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    email: string;
-                    /** @default member */
-                    role?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Invitation sent */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    acceptInvitation: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                invitationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Invitation accepted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    rejectInvitation: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                invitationId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Invitation rejected */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    adminListUsers: {
-        parameters: {
-            query?: {
-                limit?: number;
-                offset?: number;
-                /** @description Filter users by email or name (case-insensitive substring) */
-                search?: string;
-                /** @description Filter users by role */
-                role?: "user" | "admin";
-                /** @description Filter users by account status */
-                status?: "active" | "banned" | "unverified";
-                sortBy?: "createdAt" | "name" | "email";
-                sortDirection?: "asc" | "desc";
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Paginated list of users */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminUsersResponse"];
-                };
-            };
-        };
-    };
-    adminGetUserDetail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description User detail */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AdminUserDetail"];
-                };
-            };
-            404: components["responses"]["NotFound"];
-        };
-    };
-    adminSetUserRole: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** @enum {string} */
-                    role: "user" | "admin";
-                };
-            };
-        };
-        responses: {
-            /** @description Role updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    adminBanUser: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    banReason?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description User banned */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    adminUnbanUser: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description User unbanned */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    adminImpersonate: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                userId: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Impersonation session created */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        token: string;
-                        session: {
-                            token: string;
-                            impersonatedBy: string;
-                        };
-                    };
-                };
-            };
-        };
-    };
-    getFullOrganization: {
-        parameters: {
-            query: {
-                organizationId: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Full organization details */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id?: string;
-                        name?: string;
-                        members?: {
-                            id?: string;
-                            userId?: string;
-                            role?: string;
-                            name?: string;
-                            email?: string;
-                        }[];
-                        invitations?: {
-                            id?: string;
-                            email?: string;
-                            role?: string;
-                            status?: string;
-                        }[];
-                    };
-                };
-            };
-        };
-    };
-    listSessions: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of sessions */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        /** Format: date-time */
-                        expiresAt: string;
-                        /** Format: date-time */
-                        createdAt: string;
-                        ipAddress?: string | null;
-                        userAgent?: string | null;
-                        impersonatedBy?: string | null;
-                    }[];
-                };
-            };
-        };
-    };
-    revokeSession: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    sessionId: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Session revoked */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    listAccounts: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of linked accounts */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        provider: string;
-                        accountId: string;
-                        /** Format: date-time */
-                        createdAt: string;
-                    }[];
-                };
-            };
-        };
-    };
-    unlinkAccount: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    providerId: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Account unlinked */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    changeEmail: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    /** Format: email */
-                    newEmail: string;
-                    currentPassword: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Email changed */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    updateUser: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: {
-            content: {
-                "application/json": {
-                    name?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description User updated */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    changePassword: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    currentPassword: string;
-                    newPassword: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Password changed */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-            /** @description Current password incorrect */
-            401: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    deleteUser: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description User deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    linkSocial: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    provider: string;
-                    callbackURL?: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Authorization URL */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        url?: string;
-                    };
-                };
-            };
-        };
-    };
-    listUserOrganizations: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of organizations */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string;
-                        logo?: string | null;
-                        /** Format: date-time */
-                        createdAt?: string;
-                        role?: string;
-                    }[];
-                };
-            };
-        };
-    };
-    hasPermission: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    organizationId: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Permission check result */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        success?: boolean;
-                    };
-                };
-            };
-        };
-    };
-    cancelInvitation: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    invitationId: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Invitation cancelled */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    listUserPasskeys: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description List of passkeys */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        id: string;
-                        name: string | null;
-                        deviceType?: string;
-                        backedUp?: boolean;
-                        /** Format: date-time */
-                        createdAt: string;
-                    }[];
-                };
-            };
-        };
-    };
-    deletePasskey: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    id: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Passkey deleted */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    registerSSOProvider: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    organizationId: string;
-                    domain: string;
-                    issuer: string;
-                    clientId: string;
-                    clientSecret: string;
-                    authorizationEndpoint: string;
-                    tokenEndpoint: string;
-                    jwksEndpoint: string;
-                };
-            };
-        };
-        responses: {
-            /** @description SSO provider registered */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    adminStopImpersonating: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Impersonation ended */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    githubCallback: {
-        parameters: {
-            query: {
-                code: string;
-                state: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description One-time authorization code */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        code?: string;
-                    };
-                };
-            };
-            /** @description Missing or invalid parameters */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
-    exchangeCode: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": {
-                    code: string;
-                };
-            };
-        };
-        responses: {
-            /** @description Session token */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        token?: string;
-                    };
-                };
-            };
-            /** @description Invalid or expired code */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content?: never;
-            };
-        };
-    };
+  getHealth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Service is healthy */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "text/plain": "ok";
+        };
+      };
+    };
+  };
+  getAccountMe: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Current user profile */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserProfile"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  updateAccountMe: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @description Preferred language (e.g. "en", "de"). */
+          locale?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Updated user profile */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["UserProfile"];
+        };
+      };
+      400: components["responses"]["ValidationError"];
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountExtensions: {
+    parameters: {
+      query?: {
+        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+        language?: components["parameters"]["LanguageParam"];
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of extensions */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountExtension"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountExtension: {
+    parameters: {
+      query?: {
+        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+        language?: components["parameters"]["LanguageParam"];
+      };
+      header?: never;
+      path: {
+        /** @description Technical name of the extension */
+        name: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The extension */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountExtension"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  getAccountOrganizations: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of organizations */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountOrganization"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountEnvironments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountEnvironment"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountShops: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of shops */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountShop"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountChangelogs: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of changelogs */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountChangelog"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getAccountSubscribedEnvironments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of subscribed environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SubscribedEnvironment"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getNotificationPreferences: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of notification preferences */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotificationPreference"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  setNotificationPreference: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["NotificationPreferenceInput"];
+      };
+    };
+    responses: {
+      /** @description Preference saved */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      400: components["responses"]["ValidationError"];
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  deleteNotificationPreference: {
+    parameters: {
+      query: {
+        scopeType: string;
+        scopeId?: string;
+        eventType?: string;
+        channel: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Preference deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      400: components["responses"]["ValidationError"];
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getNotifications: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of notifications */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Notification"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  deleteAllNotifications: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All notifications deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getNotificationEventTypes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of event types */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NotificationEventType"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  deleteNotification: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Notification ID */
+        id: components["parameters"]["NotificationId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Notification deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  markNotificationsRead: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description All notifications marked as read */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getOrganizationEnvironments: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AccountEnvironment"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  createEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateEnvironmentRequest"];
+      };
+    };
+    responses: {
+      /** @description Environment created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  getEnvironment: {
+    parameters: {
+      query?: {
+        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+        language?: components["parameters"]["LanguageParam"];
+      };
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["EnvironmentDetail"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  deleteEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  updateEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateEnvironmentRequest"];
+      };
+    };
+    responses: {
+      /** @description Environment updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  refreshEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          /** @description Also run sitespeed check */
+          sitespeed?: boolean;
+        };
+      };
+    };
+    responses: {
+      /** @description Environment refresh triggered */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  clearEnvironmentCache: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Cache cleared */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  rescheduleTask: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+        /** @description Scheduled task ID */
+        taskId: components["parameters"]["TaskId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Task rescheduled */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  subscribeToEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Subscribed */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  unsubscribeFromEnvironment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Unsubscribed */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  getEnvironmentStatusEvents: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of status events (most recent first) */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["StatusEvent"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  updateSitespeedSettings: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SitespeedSettingsRequest"];
+      };
+    };
+    responses: {
+      /** @description Sitespeed settings updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  getOrganizationShops: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of shops */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Shop"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  createShop: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateShopRequest"];
+      };
+    };
+    responses: {
+      /** @description Shop created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  deleteShop: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Shop deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  updateShop: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateShopRequest"];
+      };
+    };
+    responses: {
+      /** @description Shop updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  getApiKeyScopes: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of available scopes */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ApiKeyScope"][];
+        };
+      };
+    };
+  };
+  getApiKeys: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of API keys */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ApiKey"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  createApiKey: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateApiKeyRequest"];
+      };
+    };
+    responses: {
+      /** @description API key created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateApiKeyResponse"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  deleteApiKey: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+        /** @description API key ID */
+        keyId: components["parameters"]["KeyId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description API key deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  getPackagesTokenConfiguration: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Packages token configuration */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["PackagesTokenConfiguration"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  getPackagesTokens: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of packages tokens */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["PackagesToken"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  createPackagesToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreatePackagesTokenRequest"];
+      };
+    };
+    responses: {
+      /** @description Packages token created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  deletePackagesToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+        /** @description Packages token ID */
+        tokenId: components["parameters"]["TokenId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Packages token deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  syncPackagesToken: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description Shop ID */
+        shopId: components["parameters"]["ShopId"];
+        /** @description Packages token ID */
+        tokenId: components["parameters"]["TokenId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Sync triggered */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  getDeployments: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+      };
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of deployments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["Deployment"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  getDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+        /** @description Deployment ID */
+        deploymentId: components["parameters"]["DeploymentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Deployment details with output */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["DeploymentDetail"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  deleteDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Environment ID */
+        environmentId: components["parameters"]["EnvironmentId"];
+        /** @description Deployment ID */
+        deploymentId: components["parameters"]["DeploymentId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Deployment deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  createCliDeployment: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["CreateCliDeploymentRequest"];
+      };
+    };
+    responses: {
+      /** @description Deployment created */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["CreateCliDeploymentResponse"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  getSsoProviders: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of SSO providers */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SsoProvider"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  discoverSso: {
+    parameters: {
+      query: {
+        issuer: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Discovered OIDC configuration */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["SsoDiscovery"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  updateSsoProvider: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description SSO provider ID */
+        providerId: components["parameters"]["ProviderId"];
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["UpdateSsoProviderRequest"];
+      };
+    };
+    responses: {
+      /** @description SSO provider updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  deleteSsoProvider: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description Organization ID */
+        orgId: components["parameters"]["OrgId"];
+        /** @description SSO provider ID */
+        providerId: components["parameters"]["ProviderId"];
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description SSO provider deleted */
+      204: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  adminGetOrganizations: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+        sortBy?: "name" | "createdAt" | "shopCount" | "memberCount";
+        sortDirection?: "asc" | "desc";
+        searchField?: string;
+        searchOperator?: string;
+        searchValue?: string;
+        filterField?: string;
+        filterOperator?: string;
+        filterValue?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated list of organizations */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminOrganizationsResponse"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetEnvironments: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+        sortBy?: string;
+        sortDirection?: "asc" | "desc";
+        searchField?: string;
+        searchOperator?: string;
+        searchValue?: string;
+        filterField?: string;
+        filterOperator?: string;
+        filterValue?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated list of environments */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminEnvironmentsResponse"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetStats: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Admin statistics */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminStats"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetGrowth: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Growth data */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminGrowth"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetOrganizationDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        orgId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Organization detail */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminOrganizationDetail"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  adminGetEnvironmentDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        envId: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Environment detail */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminEnvironmentDetail"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+      404: components["responses"]["NotFound"];
+    };
+  };
+  adminGetAuditLog: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+        action?: string;
+        actorUserId?: string;
+        targetUserId?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated audit log */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminAuditLogResponse"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetRecentActivity: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Recent activity */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminRecentActivity"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  adminGetShopwareVersions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Version distribution */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShopwareVersionCount"][];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      403: components["responses"]["Forbidden"];
+    };
+  };
+  checkExtensionCompatibility: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["ExtensionCompatibilityRequest"];
+      };
+    };
+    responses: {
+      /** @description Compatibility results */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ExtensionCompatibilityResult"][];
+        };
+      };
+      422: components["responses"]["ValidationError"];
+    };
+  };
+  getShopwareVersions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Known Shopware versions, newest first */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ShopwareVersion"][];
+        };
+      };
+    };
+  };
+  getInstanceConfig: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Instance configuration */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["InstanceConfig"];
+        };
+      };
+    };
+  };
+  getEcosystemStats: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Ecosystem statistics */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["EcosystemStats"];
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  signUpEmail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          email: string;
+          password: string;
+          name: string;
+        };
+      };
+    };
+    responses: {
+      /** @description User created successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            user?: components["schemas"]["AuthUser"];
+          };
+        };
+      };
+      400: components["responses"]["ValidationError"];
+      /** @description Email already exists */
+      409: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["ErrorResponse"];
+        };
+      };
+    };
+  };
+  signInEmail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          email: string;
+          password: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Signed in successfully */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            user?: components["schemas"]["AuthUser"];
+          };
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+      /** @description Account is banned */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  signOut: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Signed out */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  getSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Current session */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            user?: components["schemas"]["AuthUser"];
+            session?: components["schemas"]["SessionInfo"];
+          };
+        };
+      };
+      401: components["responses"]["Unauthorized"];
+    };
+  };
+  setActiveOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          organizationId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Active organization updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Not a member of the specified organization */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  verifyEmail: {
+    parameters: {
+      query: {
+        token: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Email verified */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Invalid or expired token */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  forgetPassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          email: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Reset email sent (always returns success) */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  resetPassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          token: string;
+          newPassword: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Password reset */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Invalid token or weak password */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  signInSocial: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          provider: "github";
+          callbackURL?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Authorization URL */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            url?: string;
+          };
+        };
+      };
+    };
+  };
+  signInSSO: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          email: string;
+          callbackURL?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Authorization URL */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            url?: string;
+          };
+        };
+      };
+      /** @description No SSO provider for this domain */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  ssoCallback: {
+    parameters: {
+      query: {
+        code: string;
+        state: string;
+      };
+      header?: never;
+      path: {
+        providerId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description One-time authorization code */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+          };
+        };
+      };
+      /** @description Missing or invalid parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  passkeyRegisterOptions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Registration options and challenge key */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            options?: Record<string, never>;
+            challengeKey?: string;
+          };
+        };
+      };
+    };
+  };
+  passkeyRegister: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          challengeKey: string;
+          name?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Passkey registered */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Invalid or expired challenge */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  passkeyLoginOptions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Login options and challenge key */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  passkeyLogin: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          challengeKey: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Logged in */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Authentication failed */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  createOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          name: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Organization created */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id?: string;
+            name?: string;
+          };
+        };
+      };
+    };
+  };
+  deleteOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Only owners can delete */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          name?: string;
+          logo?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listOrganizationMembers: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of members */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id?: string;
+            userId?: string;
+            role?: string;
+            name?: string;
+            email?: string;
+            image?: string | null;
+          }[];
+        };
+      };
+    };
+  };
+  removeMember: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Member removed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  setMemberRole: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          role: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Role updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  leaveOrganization: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Left organization */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Cannot leave as only owner */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listOrganizationInvitations: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of pending invitations */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  inviteMember: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        organizationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          email: string;
+          /** @default member */
+          role?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Invitation sent */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  acceptInvitation: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        invitationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Invitation accepted */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  rejectInvitation: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        invitationId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Invitation rejected */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminListUsers: {
+    parameters: {
+      query?: {
+        limit?: number;
+        offset?: number;
+        /** @description Filter users by email or name (case-insensitive substring) */
+        search?: string;
+        /** @description Filter users by role */
+        role?: "user" | "admin";
+        /** @description Filter users by account status */
+        status?: "active" | "banned" | "unverified";
+        sortBy?: "createdAt" | "name" | "email";
+        sortDirection?: "asc" | "desc";
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Paginated list of users */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminUsersResponse"];
+        };
+      };
+    };
+  };
+  adminGetUserDetail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description User detail */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["AdminUserDetail"];
+        };
+      };
+      404: components["responses"]["NotFound"];
+    };
+  };
+  adminSetUserRole: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** @enum {string} */
+          role: "user" | "admin";
+        };
+      };
+    };
+    responses: {
+      /** @description Role updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminBanUser: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          banReason?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description User banned */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminUnbanUser: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description User unbanned */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminImpersonate: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        userId: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Impersonation session created */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            token: string;
+            session: {
+              token: string;
+              impersonatedBy: string;
+            };
+          };
+        };
+      };
+    };
+  };
+  getFullOrganization: {
+    parameters: {
+      query: {
+        organizationId: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Full organization details */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id?: string;
+            name?: string;
+            members?: {
+              id?: string;
+              userId?: string;
+              role?: string;
+              name?: string;
+              email?: string;
+            }[];
+            invitations?: {
+              id?: string;
+              email?: string;
+              role?: string;
+              status?: string;
+            }[];
+          };
+        };
+      };
+    };
+  };
+  listSessions: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of sessions */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            /** Format: date-time */
+            expiresAt: string;
+            /** Format: date-time */
+            createdAt: string;
+            ipAddress?: string | null;
+            userAgent?: string | null;
+            impersonatedBy?: string | null;
+          }[];
+        };
+      };
+    };
+  };
+  revokeSession: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          sessionId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Session revoked */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listAccounts: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of linked accounts */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            provider: string;
+            accountId: string;
+            /** Format: date-time */
+            createdAt: string;
+          }[];
+        };
+      };
+    };
+  };
+  unlinkAccount: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          providerId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Account unlinked */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  changeEmail: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          /** Format: email */
+          newEmail: string;
+          currentPassword: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Email changed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  updateUser: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        "application/json": {
+          name?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description User updated */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  changePassword: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          currentPassword: string;
+          newPassword: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Password changed */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Current password incorrect */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  deleteUser: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description User deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  linkSocial: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          provider: string;
+          callbackURL?: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Authorization URL */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            url?: string;
+          };
+        };
+      };
+    };
+  };
+  listUserOrganizations: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of organizations */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string;
+            logo?: string | null;
+            /** Format: date-time */
+            createdAt?: string;
+            role?: string;
+          }[];
+        };
+      };
+    };
+  };
+  hasPermission: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          organizationId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Permission check result */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            success?: boolean;
+          };
+        };
+      };
+    };
+  };
+  cancelInvitation: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          invitationId: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Invitation cancelled */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  listUserPasskeys: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description List of passkeys */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            id: string;
+            name: string | null;
+            deviceType?: string;
+            backedUp?: boolean;
+            /** Format: date-time */
+            createdAt: string;
+          }[];
+        };
+      };
+    };
+  };
+  deletePasskey: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          id: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Passkey deleted */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  registerSSOProvider: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          organizationId: string;
+          domain: string;
+          issuer: string;
+          clientId: string;
+          clientSecret: string;
+          authorizationEndpoint: string;
+          tokenEndpoint: string;
+          jwksEndpoint: string;
+        };
+      };
+    };
+    responses: {
+      /** @description SSO provider registered */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  adminStopImpersonating: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Impersonation ended */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  githubCallback: {
+    parameters: {
+      query: {
+        code: string;
+        state: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description One-time authorization code */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            code?: string;
+          };
+        };
+      };
+      /** @description Missing or invalid parameters */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  exchangeCode: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        "application/json": {
+          code: string;
+        };
+      };
+    };
+    responses: {
+      /** @description Session token */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": {
+            token?: string;
+          };
+        };
+      };
+      /** @description Invalid or expired code */
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
 }

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -4,5480 +4,5490 @@
  */
 
 export interface paths {
-  "/health": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Health check */
-    get: operations["getHealth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/me": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get current user profile */
-    get: operations["getAccountMe"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Update current user preferences */
-    patch: operations["updateAccountMe"];
-    trace?: never;
-  };
-  "/account/extensions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get aggregated extensions across all environments */
-    get: operations["getAccountExtensions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/extensions/{name}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get a single aggregated extension by technical name */
-    get: operations["getAccountExtension"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/organizations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get organizations the user belongs to */
-    get: operations["getAccountOrganizations"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get all environments accessible to the user */
-    get: operations["getAccountEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/shops": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get all shops accessible to the user */
-    get: operations["getAccountShops"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/changelogs": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get changelogs across all environments */
-    get: operations["getAccountChangelogs"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/subscribed-environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get environments the user is subscribed to for notifications */
-    get: operations["getAccountSubscribedEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/account/notification-preferences": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get the current user's notification preferences */
-    get: operations["getNotificationPreferences"];
-    /** Create or update a single notification preference */
-    put: operations["setNotificationPreference"];
-    post?: never;
-    /** Delete a single notification preference (revert to inherited/default) */
-    delete: operations["deleteNotificationPreference"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/notifications": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get all notifications for the current user */
-    get: operations["getNotifications"];
-    put?: never;
-    post?: never;
-    /** Delete all notifications */
-    delete: operations["deleteAllNotifications"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/notifications/event-types": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List the notifiable event types and their default channels */
-    get: operations["getNotificationEventTypes"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/notifications/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a single notification */
-    delete: operations["deleteNotification"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/notifications/mark-read": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Mark all notifications as read */
-    post: operations["markNotificationsRead"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get all environments in an organization */
-    get: operations["getOrganizationEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Create a new environment */
-    post: operations["createEnvironment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get full environment details */
-    get: operations["getEnvironment"];
-    put?: never;
-    post?: never;
-    /** Delete an environment */
-    delete: operations["deleteEnvironment"];
-    options?: never;
-    head?: never;
-    /** Update an environment */
-    patch: operations["updateEnvironment"];
-    trace?: never;
-  };
-  "/environments/{environmentId}/refresh": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Refresh environment data from Shopware API */
-    post: operations["refreshEnvironment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/clear-cache": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Clear Shopware cache for the environment */
-    post: operations["clearEnvironmentCache"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/tasks/{taskId}/reschedule": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Reschedule a scheduled task */
-    post: operations["rescheduleTask"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/subscribe": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Subscribe to environment notifications */
-    post: operations["subscribeToEnvironment"];
-    /** Unsubscribe from environment notifications */
-    delete: operations["unsubscribeFromEnvironment"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/status-events": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get the status change history for an environment */
-    get: operations["getEnvironmentStatusEvents"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/sitespeed-settings": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /** Update sitespeed settings for an environment */
-    put: operations["updateSitespeedSettings"];
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get all shops in an organization */
-    get: operations["getOrganizationShops"];
-    put?: never;
-    /** Create a new shop */
-    post: operations["createShop"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a shop */
-    delete: operations["deleteShop"];
-    options?: never;
-    head?: never;
-    /** Update a shop */
-    patch: operations["updateShop"];
-    trace?: never;
-  };
-  "/api-key-scopes": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get available API key scopes */
-    get: operations["getApiKeyScopes"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}/api-keys": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List API keys for a shop */
-    get: operations["getApiKeys"];
-    put?: never;
-    /** Create a new API key */
-    post: operations["createApiKey"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}/api-keys/{keyId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete an API key */
-    delete: operations["deleteApiKey"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/packages-token/configuration": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get packages token configuration */
-    get: operations["getPackagesTokenConfiguration"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}/packages-tokens": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List packages tokens for a shop */
-    get: operations["getPackagesTokens"];
-    put?: never;
-    /** Create a new packages token */
-    post: operations["createPackagesToken"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete a packages token */
-    delete: operations["deletePackagesToken"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}/sync": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Sync a packages token */
-    post: operations["syncPackagesToken"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List deployments for an environment */
-    get: operations["getDeployments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/environments/{environmentId}/deployments/{deploymentId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get deployment details with output */
-    get: operations["getDeployment"];
-    put?: never;
-    post?: never;
-    /** Delete a deployment */
-    delete: operations["deleteDeployment"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/cli/deployments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Create a deployment via CLI */
-    post: operations["createCliDeployment"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/sso-providers": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List SSO providers for an organization */
-    get: operations["getSsoProviders"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/sso/discover": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Discover OIDC configuration from an issuer URL */
-    get: operations["discoverSso"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/organizations/{orgId}/sso-providers/{providerId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    /** Update an SSO provider */
-    put: operations["updateSsoProvider"];
-    post?: never;
-    /** Delete an SSO provider */
-    delete: operations["deleteSsoProvider"];
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/organizations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List all organizations (admin only) */
-    get: operations["adminGetOrganizations"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/environments": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List all environments (admin only) */
-    get: operations["adminGetEnvironments"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/stats": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get admin dashboard statistics */
-    get: operations["adminGetStats"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/growth": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get growth data over time */
-    get: operations["adminGetGrowth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/organizations/{orgId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get an organization with detail (admin only) */
-    get: operations["adminGetOrganizationDetail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/environments/{envId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get an environment with detail (admin only) */
-    get: operations["adminGetEnvironmentDetail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/audit-log": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List audit log entries (admin only) */
-    get: operations["adminGetAuditLog"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/recent-activity": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get recent user and environment activity */
-    get: operations["adminGetRecentActivity"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/admin/shopware-versions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get Shopware version distribution across environments */
-    get: operations["adminGetShopwareVersions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/info/extension-compatibility": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Check extension compatibility between Shopware versions */
-    post: operations["checkExtensionCompatibility"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/info/shopware-versions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get known Shopware versions
-     * @description Returns all known Shopware versions, newest first. Served from a local cache that the worker refreshes hourly from the Shopware release changelog.
-     */
-    get: operations["getShopwareVersions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/info/config": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get instance feature configuration
-     * @description Returns which features are enabled on this instance, based on server configuration.
-     */
-    get: operations["getInstanceConfig"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/info/ecosystem": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * Get public ecosystem statistics
-     * @description Aggregate, non-identifying ecosystem statistics (user growth, environment growth and Shopware version distribution) visible to any authenticated user.
-     */
-    get: operations["getEcosystemStats"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sign-up/email": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Register with email and password */
-    post: operations["signUpEmail"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sign-in/email": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Sign in with email and password */
-    post: operations["signInEmail"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sign-out": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Sign out */
-    post: operations["signOut"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/session": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get current session */
-    get: operations["getSession"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/set-active-organization": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Set the active organization for the current session */
-    post: operations["setActiveOrganization"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/verify-email": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Verify email address */
-    get: operations["verifyEmail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/forget-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Request password reset email */
-    post: operations["forgetPassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/reset-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Reset password with token */
-    post: operations["resetPassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sign-in/social": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Initiate OAuth sign-in (GitHub) */
-    post: operations["signInSocial"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sign-in/sso": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Initiate SSO sign-in */
-    post: operations["signInSSO"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sso/callback/{providerId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Handle SSO OIDC callback */
-    get: operations["ssoCallback"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/register-options": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Begin passkey registration */
-    post: operations["passkeyRegisterOptions"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/register": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Complete passkey registration */
-    post: operations["passkeyRegister"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/login-options": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Begin passkey login */
-    post: operations["passkeyLoginOptions"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Complete passkey login */
-    post: operations["passkeyLogin"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/organizations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Create an organization */
-    post: operations["createOrganization"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/organizations/{organizationId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Delete an organization */
-    delete: operations["deleteOrganization"];
-    options?: never;
-    head?: never;
-    /** Update an organization */
-    patch: operations["updateOrganization"];
-    trace?: never;
-  };
-  "/auth/organizations/{organizationId}/members": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List organization members */
-    get: operations["listOrganizationMembers"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/organizations/{organizationId}/members/{userId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    /** Remove a member from the organization */
-    delete: operations["removeMember"];
-    options?: never;
-    head?: never;
-    /** Change a member's role */
-    patch: operations["setMemberRole"];
-    trace?: never;
-  };
-  "/auth/organizations/{organizationId}/leave": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Leave an organization */
-    post: operations["leaveOrganization"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/organizations/{organizationId}/invitations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List pending invitations */
-    get: operations["listOrganizationInvitations"];
-    put?: never;
-    /** Invite a user to the organization */
-    post: operations["inviteMember"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/invitations/{invitationId}/accept": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Accept an invitation */
-    post: operations["acceptInvitation"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/invitations/{invitationId}/reject": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Reject an invitation */
-    post: operations["rejectInvitation"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/users": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List all users (admin only) */
-    get: operations["adminListUsers"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/users/{userId}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get a single user with detail (admin only) */
-    get: operations["adminGetUserDetail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/users/{userId}/role": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /** Set a user's role */
-    patch: operations["adminSetUserRole"];
-    trace?: never;
-  };
-  "/auth/admin/users/{userId}/ban": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Ban a user */
-    post: operations["adminBanUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/users/{userId}/unban": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Unban a user */
-    post: operations["adminUnbanUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/users/{userId}/impersonate": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Impersonate a user */
-    post: operations["adminImpersonate"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/get-full-organization": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get full organization details by ID */
-    get: operations["getFullOrganization"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/list-sessions": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List active sessions */
-    get: operations["listSessions"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/revoke-session": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Revoke a session */
-    post: operations["revokeSession"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/list-accounts": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List linked auth providers */
-    get: operations["listAccounts"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/unlink-account": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Unlink an auth provider */
-    post: operations["unlinkAccount"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/change-email": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Change email address */
-    post: operations["changeEmail"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/update-user": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Update user profile */
-    post: operations["updateUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/change-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Change password */
-    post: operations["changePassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/delete-user": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Delete user account */
-    post: operations["deleteUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/link-social": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Link a social provider */
-    post: operations["linkSocial"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/list-organizations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List user's organizations */
-    get: operations["listUserOrganizations"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/has-permission": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Check organization permission */
-    post: operations["hasPermission"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/cancel-invitation": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Cancel a pending invitation */
-    post: operations["cancelInvitation"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/list-user-passkeys": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** List user's passkeys */
-    get: operations["listUserPasskeys"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/passkey/delete-passkey": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Delete a passkey */
-    post: operations["deletePasskey"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/sso/register": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Register an SSO provider */
-    post: operations["registerSSOProvider"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/admin/stop-impersonating": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Stop impersonating a user */
-    post: operations["adminStopImpersonating"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/callback/github": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Handle GitHub OAuth callback */
-    get: operations["githubCallback"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/exchange-code": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Exchange one-time authorization code for session token */
-    post: operations["exchangeCode"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/health": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Health check */
+        get: operations["getHealth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current user profile */
+        get: operations["getAccountMe"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Update current user preferences */
+        patch: operations["updateAccountMe"];
+        trace?: never;
+    };
+    "/account/extensions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get aggregated extensions across all environments */
+        get: operations["getAccountExtensions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/extensions/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single aggregated extension by technical name */
+        get: operations["getAccountExtension"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get organizations the user belongs to */
+        get: operations["getAccountOrganizations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all environments accessible to the user */
+        get: operations["getAccountEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/shops": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all shops accessible to the user */
+        get: operations["getAccountShops"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/changelogs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get changelogs across all environments */
+        get: operations["getAccountChangelogs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/subscribed-environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get environments the user is subscribed to for notifications */
+        get: operations["getAccountSubscribedEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/account/notification-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the current user's notification preferences */
+        get: operations["getNotificationPreferences"];
+        /** Create or update a single notification preference */
+        put: operations["setNotificationPreference"];
+        post?: never;
+        /** Delete a single notification preference (revert to inherited/default) */
+        delete: operations["deleteNotificationPreference"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all notifications for the current user */
+        get: operations["getNotifications"];
+        put?: never;
+        post?: never;
+        /** Delete all notifications */
+        delete: operations["deleteAllNotifications"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/event-types": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List the notifiable event types and their default channels */
+        get: operations["getNotificationEventTypes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a single notification */
+        delete: operations["deleteNotification"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/notifications/mark-read": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Mark all notifications as read */
+        post: operations["markNotificationsRead"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all environments in an organization */
+        get: operations["getOrganizationEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a new environment */
+        post: operations["createEnvironment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get full environment details */
+        get: operations["getEnvironment"];
+        put?: never;
+        post?: never;
+        /** Delete an environment */
+        delete: operations["deleteEnvironment"];
+        options?: never;
+        head?: never;
+        /** Update an environment */
+        patch: operations["updateEnvironment"];
+        trace?: never;
+    };
+    "/environments/{environmentId}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Refresh environment data from Shopware API */
+        post: operations["refreshEnvironment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/clear-cache": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Clear Shopware cache for the environment */
+        post: operations["clearEnvironmentCache"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/tasks/{taskId}/reschedule": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reschedule a scheduled task */
+        post: operations["rescheduleTask"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/subscribe": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Subscribe to environment notifications */
+        post: operations["subscribeToEnvironment"];
+        /** Unsubscribe from environment notifications */
+        delete: operations["unsubscribeFromEnvironment"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/status-events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the status change history for an environment */
+        get: operations["getEnvironmentStatusEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/sitespeed-settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update sitespeed settings for an environment */
+        put: operations["updateSitespeedSettings"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get all shops in an organization */
+        get: operations["getOrganizationShops"];
+        put?: never;
+        /** Create a new shop */
+        post: operations["createShop"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a shop */
+        delete: operations["deleteShop"];
+        options?: never;
+        head?: never;
+        /** Update a shop */
+        patch: operations["updateShop"];
+        trace?: never;
+    };
+    "/api-key-scopes": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get available API key scopes */
+        get: operations["getApiKeyScopes"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}/api-keys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List API keys for a shop */
+        get: operations["getApiKeys"];
+        put?: never;
+        /** Create a new API key */
+        post: operations["createApiKey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}/api-keys/{keyId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete an API key */
+        delete: operations["deleteApiKey"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/packages-token/configuration": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get packages token configuration */
+        get: operations["getPackagesTokenConfiguration"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}/packages-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List packages tokens for a shop */
+        get: operations["getPackagesTokens"];
+        put?: never;
+        /** Create a new packages token */
+        post: operations["createPackagesToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete a packages token */
+        delete: operations["deletePackagesToken"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/shops/{shopId}/packages-tokens/{tokenId}/sync": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sync a packages token */
+        post: operations["syncPackagesToken"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List deployments for an environment */
+        get: operations["getDeployments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/environments/{environmentId}/deployments/{deploymentId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get deployment details with output */
+        get: operations["getDeployment"];
+        put?: never;
+        post?: never;
+        /** Delete a deployment */
+        delete: operations["deleteDeployment"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/cli/deployments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create a deployment via CLI */
+        post: operations["createCliDeployment"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/sso-providers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List SSO providers for an organization */
+        get: operations["getSsoProviders"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/sso/discover": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Discover OIDC configuration from an issuer URL */
+        get: operations["discoverSso"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/organizations/{orgId}/sso-providers/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Update an SSO provider */
+        put: operations["updateSsoProvider"];
+        post?: never;
+        /** Delete an SSO provider */
+        delete: operations["deleteSsoProvider"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all organizations (admin only) */
+        get: operations["adminGetOrganizations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/environments": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all environments (admin only) */
+        get: operations["adminGetEnvironments"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/stats": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get admin dashboard statistics */
+        get: operations["adminGetStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/growth": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get growth data over time */
+        get: operations["adminGetGrowth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/organizations/{orgId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an organization with detail (admin only) */
+        get: operations["adminGetOrganizationDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/environments/{envId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get an environment with detail (admin only) */
+        get: operations["adminGetEnvironmentDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/audit-log": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List audit log entries (admin only) */
+        get: operations["adminGetAuditLog"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/recent-activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get recent user and environment activity */
+        get: operations["adminGetRecentActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/admin/shopware-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Shopware version distribution across environments */
+        get: operations["adminGetShopwareVersions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info/extension-compatibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Check extension compatibility between Shopware versions */
+        post: operations["checkExtensionCompatibility"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info/shopware-versions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get known Shopware versions
+         * @description Returns all known Shopware versions, newest first. Served from a local cache that the worker refreshes hourly from the Shopware release changelog.
+         */
+        get: operations["getShopwareVersions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info/config": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get instance feature configuration
+         * @description Returns which features are enabled on this instance, based on server configuration.
+         */
+        get: operations["getInstanceConfig"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/info/ecosystem": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get public ecosystem statistics
+         * @description Aggregate, non-identifying ecosystem statistics (user growth, environment growth and Shopware version distribution) visible to any authenticated user.
+         */
+        get: operations["getEcosystemStats"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sign-up/email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register with email and password */
+        post: operations["signUpEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sign-in/email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sign in with email and password */
+        post: operations["signInEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sign-out": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sign out */
+        post: operations["signOut"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get current session */
+        get: operations["getSession"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/set-active-organization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Set the active organization for the current session */
+        post: operations["setActiveOrganization"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/verify-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Verify email address */
+        get: operations["verifyEmail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/forget-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request password reset email */
+        post: operations["forgetPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/reset-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reset password with token */
+        post: operations["resetPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sign-in/social": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Initiate OAuth sign-in (GitHub) */
+        post: operations["signInSocial"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sign-in/sso": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Initiate SSO sign-in */
+        post: operations["signInSSO"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/callback/{providerId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Handle SSO OIDC callback */
+        get: operations["ssoCallback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/register-options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Begin passkey registration */
+        post: operations["passkeyRegisterOptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete passkey registration */
+        post: operations["passkeyRegister"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/login-options": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Begin passkey login */
+        post: operations["passkeyLoginOptions"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Complete passkey login */
+        post: operations["passkeyLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Create an organization */
+        post: operations["createOrganization"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/organizations/{organizationId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete an organization */
+        delete: operations["deleteOrganization"];
+        options?: never;
+        head?: never;
+        /** Update an organization */
+        patch: operations["updateOrganization"];
+        trace?: never;
+    };
+    "/auth/organizations/{organizationId}/members": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List organization members */
+        get: operations["listOrganizationMembers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/organizations/{organizationId}/members/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Remove a member from the organization */
+        delete: operations["removeMember"];
+        options?: never;
+        head?: never;
+        /** Change a member's role */
+        patch: operations["setMemberRole"];
+        trace?: never;
+    };
+    "/auth/organizations/{organizationId}/leave": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Leave an organization */
+        post: operations["leaveOrganization"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/organizations/{organizationId}/invitations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List pending invitations */
+        get: operations["listOrganizationInvitations"];
+        put?: never;
+        /** Invite a user to the organization */
+        post: operations["inviteMember"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/invitations/{invitationId}/accept": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Accept an invitation */
+        post: operations["acceptInvitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/invitations/{invitationId}/reject": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reject an invitation */
+        post: operations["rejectInvitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all users (admin only) */
+        get: operations["adminListUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/users/{userId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get a single user with detail (admin only) */
+        get: operations["adminGetUserDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/users/{userId}/role": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** Set a user's role */
+        patch: operations["adminSetUserRole"];
+        trace?: never;
+    };
+    "/auth/admin/users/{userId}/ban": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Ban a user */
+        post: operations["adminBanUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/users/{userId}/unban": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unban a user */
+        post: operations["adminUnbanUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/users/{userId}/impersonate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Impersonate a user */
+        post: operations["adminImpersonate"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/get-full-organization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get full organization details by ID */
+        get: operations["getFullOrganization"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/list-sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List active sessions */
+        get: operations["listSessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/revoke-session": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Revoke a session */
+        post: operations["revokeSession"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/list-accounts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List linked auth providers */
+        get: operations["listAccounts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/unlink-account": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Unlink an auth provider */
+        post: operations["unlinkAccount"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/change-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Change email address */
+        post: operations["changeEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/update-user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Update user profile */
+        post: operations["updateUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/change-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Change password */
+        post: operations["changePassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/delete-user": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Delete user account */
+        post: operations["deleteUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/link-social": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Link a social provider */
+        post: operations["linkSocial"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/list-organizations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List user's organizations */
+        get: operations["listUserOrganizations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/has-permission": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Check organization permission */
+        post: operations["hasPermission"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/cancel-invitation": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Cancel a pending invitation */
+        post: operations["cancelInvitation"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/list-user-passkeys": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List user's passkeys */
+        get: operations["listUserPasskeys"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/passkey/delete-passkey": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Delete a passkey */
+        post: operations["deletePasskey"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sso/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register an SSO provider */
+        post: operations["registerSSOProvider"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/admin/stop-impersonating": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Stop impersonating a user */
+        post: operations["adminStopImpersonating"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/callback/github": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Handle GitHub OAuth callback */
+        get: operations["githubCallback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/exchange-code": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Exchange one-time authorization code for session token */
+        post: operations["exchangeCode"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    ErrorResponse: {
-      message: string;
-    };
-    UserProfile: {
-      id: string;
-      displayName: string;
-      /** Format: email */
-      email: string;
-      /** Format: date-time */
-      createdAt: string;
-      /** @description The user's preferred language, used to localize notification emails. */
-      locale: string;
-    };
-    AccountExtension: {
-      name: string;
-      label: string;
-      version: string;
-      latestVersion: string;
-      active: boolean;
-      installed: boolean;
-      storeLink: string | null;
-      ratingAverage: number | null;
-      /** Format: date-time */
-      installedAt: string | null;
-      changelog: components["schemas"]["ExtensionChangelogEntry"][] | null;
-      /** @description URL of the extension's store icon, when known. */
-      iconUrl?: string | null;
-      producerName?: string | null;
-      producerWebsite?: string | null;
-      /** @description Release date of the latest store version (raw store value). */
-      releaseDate?: string | null;
-      /** @description Short store description in the requested language (falls back to English). */
-      shortDescription?: string | null;
-      /** @description Full store description (HTML) in the requested language (falls back to English). */
-      description?: string | null;
-      /** @description Installation manual (HTML) in the requested language (falls back to English). */
-      installationManual?: string | null;
-      screenshots?: components["schemas"]["ExtensionScreenshot"][] | null;
-      environments: components["schemas"]["AccountExtensionEnvironment"][];
-    };
-    ExtensionScreenshot: {
-      url: string;
-      /** @description Whether this image is the store's primary preview image. */
-      preview: boolean;
-    };
-    AccountExtensionEnvironment: {
-      environmentId: number;
-      environmentName: string;
-      environmentShopName: string;
-      environmentOrganizationName: string;
-      environmentOrganizationId: string;
-      environmentUrl: string;
-      /** @description ID of the shop this environment belongs to. */
-      shopId: number;
-      /** @description Name of the shop this environment belongs to (environments may share a name across shops). */
-      shopName: string;
-      active: boolean;
-      version: string;
-      latestVersion: string;
-      installed: boolean;
-    };
-    AccountOrganization: {
-      id: string;
-      name: string;
-      logo: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      environmentCount: number;
-      memberCount: number;
-    };
-    AccountEnvironment: {
-      id: number;
-      name: string;
-      url: string;
-      favicon: string | null;
-      status: string;
-      shopwareVersion: string;
-      /** Format: date-time */
-      lastScrapedAt: string | null;
-      lastScrapedError: string | null;
-      organizationId: string;
-      organizationName: string;
-      shopId: number | null;
-      shopName: string | null;
-    };
-    AccountShop: {
-      id: number;
-      name: string;
-      description: string | null;
-      gitUrl: string | null;
-      organizationId: string;
-      organizationName: string;
-      defaultEnvironmentId: number | null;
-    };
-    AccountChangelog: {
-      id: number;
-      environmentId: number;
-      /** @description JSON data describing extension changes */
-      extensions: components["schemas"]["ExtensionDiff"][];
-      oldShopwareVersion: string | null;
-      newShopwareVersion: string | null;
-      /** Format: date-time */
-      date: string;
-      environmentName: string;
-      environmentShopName: string;
-      environmentOrganizationName: string;
-      environmentOrganizationId: string;
-    };
-    ExtensionDiff: {
-      name: string;
-      label: string;
-      state: string;
-      oldVersion?: string | null;
-      newVersion?: string | null;
-      changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
-      active: boolean;
-    };
-    ExtensionChangelogEntry: {
-      version: string;
-      /** @description Changelog text. For store catalog endpoints this is already resolved to the requested language (English fallback). For stored environment-changelog history it holds the English (en_GB) text, with textDe carrying the German variant when available. */
-      text: string;
-      /** @description German (de_DE) changelog text for stored history entries, when available. */
-      textDe?: string | null;
-      /** Format: date-time */
-      creationDate: string;
-    };
-    SubscribedEnvironment: {
-      id: number;
-      name: string;
-      /** @description The shop this environment belongs to, if any. */
-      shopId?: number | null;
-      shopName?: string | null;
-    };
-    StatusReason: {
-      level: string;
-      messageKey: string;
-      params?: {
-        [key: string]: unknown;
-      };
-      source?: string;
-    };
-    StatusEvent: {
-      id: number;
-      oldStatus: string;
-      newStatus: string;
-      reasons: components["schemas"]["StatusReason"][];
-      /** Format: date-time */
-      createdAt: string;
-    };
-    NotificationEventType: {
-      /** @description Stable event type identifier (e.g. status_degraded). */
-      type: string;
-      /** @description Channels this event is delivered on by default. */
-      defaultChannels: string[];
-    };
-    NotificationPreference: {
-      /** @description Scope of the preference: global, organization, or environment. */
-      scopeType: string;
-      /** @description Empty for global; organization or environment id otherwise. */
-      scopeId: string;
-      /** @description Empty matches all event types; otherwise a specific event type. */
-      eventType: string;
-      /** @description Empty is a subscription marker; otherwise in_app or email. */
-      channel: string;
-      enabled: boolean;
-    };
-    NotificationPreferenceInput: {
-      scopeType: string;
-      scopeId?: string;
-      eventType?: string;
-      channel: string;
-      enabled: boolean;
-    };
-    Notification: {
-      id: number;
-      userId: string;
-      key: string;
-      level: string;
-      title: string;
-      message: string;
-      /** @description Translation key for the title; render with params client-side. Falls back to title. */
-      titleKey?: string | null;
-      /** @description Translation key for the message; render with params client-side. Falls back to message. */
-      messageKey?: string | null;
-      /** @description Structured params for interpolating titleKey/messageKey. */
-      params?: {
-        [key: string]: unknown;
-      };
-      link: components["schemas"]["NotificationLink"] | null;
-      read: boolean;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    NotificationLink: {
-      url: string;
-      label: string;
-    };
-    CreateEnvironmentRequest: {
-      name: string;
-      shopUrl: string;
-      clientId: string;
-      clientSecret: string;
-      shopId: number;
-      environmentToken?: string | null;
-    };
-    UpdateEnvironmentRequest: {
-      name?: string;
-      shopUrl?: string;
-      clientId?: string;
-      clientSecret?: string;
-      ignores?: string[];
-      shopId: number;
-    };
-    EnvironmentDetail: {
-      id: number;
-      organizationId: string;
-      organizationName: string;
-      shopId: number | null;
-      shopName: string | null;
-      shopDescription: string | null;
-      name: string;
-      status: string;
-      url: string;
-      favicon: string | null;
-      shopwareVersion: string;
-      /** Format: date-time */
-      lastScrapedAt: string | null;
-      lastScrapedError: string | null;
-      ignores: string[] | null;
-      environmentImage: string | null;
-      environmentToken: string;
-      lastChangelog: components["schemas"]["AccountChangelog"] | null;
-      sitespeedEnabled: boolean;
-      sitespeedUrls: string[] | null;
-      sitespeedDetailUrl: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      extensions: components["schemas"]["EnvironmentExtension"][];
-      scheduledTasks: components["schemas"]["ScheduledTask"][];
-      queues: components["schemas"]["Queue"][];
-      cache: components["schemas"]["CacheInfo"] | null;
-      checks: components["schemas"]["EnvironmentCheck"][];
-      sitespeeds: components["schemas"]["Sitespeed"][];
-      changelogs: components["schemas"]["AccountChangelog"][];
-      deploymentsCount: number;
-      subscribed: boolean;
-    };
-    EnvironmentExtension: {
-      name: string;
-      label: string;
-      version: string;
-      latestVersion: string;
-      active: boolean;
-      installed: boolean;
-      storeLink?: string | null;
-      ratingAverage?: number | null;
-      /** Format: date-time */
-      installedAt?: string | null;
-      changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
-    };
-    ScheduledTask: {
-      id: string;
-      name: string;
-      runInterval: number;
-      status: string;
-      /** Format: date-time */
-      lastExecutionTime?: string | null;
-      /** Format: date-time */
-      nextExecutionTime?: string | null;
-      overdue: boolean;
-    };
-    Queue: {
-      name: string;
-      size: number;
-    };
-    CacheInfo: {
-      id?: number;
-      environment?: string;
-      httpCache?: boolean;
-      cacheAdapter?: string;
-    };
-    EnvironmentCheck: {
-      id: string;
-      level: string;
-      message: string;
-      /** @description Translation key for the message; render with params client-side. Falls back to message. */
-      messageKey?: string | null;
-      /** @description Structured params for interpolating messageKey. */
-      params?: {
-        [key: string]: unknown;
-      };
-      link?: string | null;
-    };
-    Sitespeed: {
-      ttfb?: number | null;
-      fullyLoaded?: number | null;
-      largestContentfulPaint?: number | null;
-      firstContentfulPaint?: number | null;
-      cumulativeLayoutShift?: number | null;
-      transferSize?: number | null;
-      /** Format: date-time */
-      createdAt: string;
-      deployment?: components["schemas"]["SitespeedDeployment"] | null;
-    };
-    SitespeedDeployment: {
-      id: number;
-      name: string;
-    };
-    SitespeedSettingsRequest: {
-      enabled: boolean;
-      urls?: string[];
-    };
-    Shop: {
-      id: number;
-      name: string;
-      description: string | null;
-      gitUrl: string | null;
-      organizationId: string;
-      defaultEnvironmentId: number | null;
-    };
-    CreateShopRequest: {
-      name: string;
-      description?: string;
-      gitUrl?: string;
-      environmentName: string;
-      environmentUrl: string;
-      clientId: string;
-      clientSecret: string;
-    };
-    UpdateShopRequest: {
-      name?: string;
-      description?: string;
-      gitUrl?: string;
-      defaultEnvironmentId?: number;
-    };
-    ApiKeyScope: {
-      value: string;
-      label: string;
-      description: string;
-    };
-    ApiKey: {
-      id: string;
-      name: string;
-      scopes: string[];
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      lastUsedAt: string | null;
-    };
-    CreateApiKeyRequest: {
-      name: string;
-      scopes: string[];
-    };
-    CreateApiKeyResponse: {
-      id: string;
-      token: string;
-      name: string;
-      scopes: string[];
-    };
-    PackagesTokenConfiguration: {
-      configured: boolean;
-      composerUrl: string | null;
-    };
-    PackagesToken: {
-      id: number;
-      source: string;
-      /**
-       * Format: int64
-       * @description Unix timestamp in seconds of the last successful sync, or null if never synced.
-       */
-      lastSyncedAt: number | null;
-    };
-    CreatePackagesTokenRequest: {
-      token: string;
-    };
-    Deployment: {
-      id: number;
-      name: string | null;
-      command: string;
-      returnCode: number;
-      /** Format: date-time */
-      startDate: string;
-      /** Format: date-time */
-      endDate: string;
-      /** @description Execution time in seconds */
-      executionTime: number;
-      reference: string | null;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    DeploymentDetail: components["schemas"]["Deployment"] & {
-      output?: string | null;
-    };
-    CreateCliDeploymentRequest: {
-      environment_id: number;
-      command: string;
-      return_code: number;
-      /** Format: date-time */
-      start_date: string;
-      /** Format: date-time */
-      end_date: string;
-      execution_time: number;
-      composer?: string | null;
-      reference?: string | null;
-      name?: string | null;
-    };
-    CreateCliDeploymentResponse: {
-      success: boolean;
-      name: string;
-      deployment_id: number;
-      url: string;
-      upload_url: string;
-    };
-    SsoProvider: {
-      id: string;
-      domain: string;
-      issuer: string;
-      clientId: string;
-      authorizationEndpoint: string;
-      tokenEndpoint: string;
-      jwksEndpoint: string;
-    };
-    SsoDiscovery: {
-      issuer: string;
-      authorizationEndpoint: string;
-      tokenEndpoint: string;
-      jwksEndpoint: string;
-      userInfoEndpoint: string;
-      scopes: string[];
-    };
-    UpdateSsoProviderRequest: {
-      domain: string;
-      issuer: string;
-      clientId: string;
-      clientSecret?: string;
-      authorizationEndpoint: string;
-      tokenEndpoint: string;
-      jwksEndpoint: string;
-    };
-    AdminOrganizationsResponse: {
-      organizations: components["schemas"]["AccountOrganization"][];
-      total: number;
-    };
-    AdminEnvironmentsResponse: {
-      environments: components["schemas"]["AccountEnvironment"][];
-      total: number;
-    };
-    AdminUser: {
-      id: string;
-      name: string;
-      email: string;
-      emailVerified: boolean;
-      image?: string | null;
-      role: string;
-      banned?: boolean | null;
-      banReason?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminUsersResponse: {
-      users: components["schemas"]["AdminUser"][];
-      total: number;
-    };
-    AdminUserDetail: {
-      id: string;
-      name: string;
-      email: string;
-      emailVerified: boolean;
-      image?: string | null;
-      role: string;
-      banned: boolean;
-      banReason?: string | null;
-      /** Format: date-time */
-      banExpires?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      updatedAt: string;
-      authProviders: components["schemas"]["AdminUserAuthProvider"][];
-      sessions: components["schemas"]["AdminUserSession"][];
-      memberships: components["schemas"]["AdminUserMembership"][];
-      auditLog: components["schemas"]["AdminAuditLogEntry"][];
-    };
-    AdminUserAuthProvider: {
-      id: string;
-      providerId: string;
-      accountId?: string;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminUserSession: {
-      id: string;
-      ipAddress?: string | null;
-      userAgent?: string | null;
-      impersonated: boolean;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      expiresAt: string;
-    };
-    AdminUserMembership: {
-      organizationId: string;
-      organizationName: string;
-      organizationSlug: string;
-      role: string;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminOrganizationDetail: {
-      id: string;
-      name: string;
-      slug: string;
-      logo?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-      memberCount: number;
-      environmentCount: number;
-      members: components["schemas"]["AdminOrganizationMember"][];
-      environments: components["schemas"]["AdminOrganizationEnvironment"][];
-      invitations: components["schemas"]["AdminOrganizationInvitation"][];
-      ssoProviders: components["schemas"]["AdminOrganizationSSO"][];
-      shops: components["schemas"]["AdminOrganizationShop"][];
-    };
-    AdminOrganizationMember: {
-      userId: string;
-      name: string;
-      email: string;
-      image?: string | null;
-      role: string;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminOrganizationEnvironment: {
-      id: number;
-      name: string;
-      url: string;
-      status: string;
-      shopwareVersion: string;
-      shopId: number;
-      shopName: string;
-      /** Format: date-time */
-      lastScrapedAt?: string | null;
-    };
-    AdminOrganizationInvitation: {
-      id: string;
-      email: string;
-      role?: string | null;
-      status: string;
-      /** Format: date-time */
-      expiresAt: string;
-      /** Format: date-time */
-      createdAt: string;
-      inviterName: string;
-      inviterEmail: string;
-    };
-    AdminOrganizationSSO: {
-      id: string;
-      issuer: string;
-      providerId: string;
-      domain: string;
-    };
-    AdminOrganizationShop: {
-      id: number;
-      name: string;
-      description?: string | null;
-      defaultEnvironmentId?: number | null;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminEnvironmentDetail: {
-      id: number;
-      name: string;
-      url: string;
-      status: string;
-      shopwareVersion: string;
-      /** Format: date-time */
-      createdAt: string;
-      /** Format: date-time */
-      lastScrapedAt?: string | null;
-      lastScrapedError?: string | null;
-      connectionIssueCount: number;
-      organizationId: string;
-      organizationName: string;
-      shopId: number;
-      shopName: string;
-      checks: components["schemas"]["AdminEnvironmentCheck"][];
-      extensions: components["schemas"]["AdminEnvironmentExtension"][];
-      scheduledTasks: components["schemas"]["AdminEnvironmentTask"][];
-      lastDeployment?: components["schemas"]["AdminEnvironmentDeployment"];
-    };
-    AdminEnvironmentCheck: {
-      id: number;
-      checkId: string;
-      level: string;
-      message: string;
-      source: string;
-      link?: string | null;
-    };
-    AdminEnvironmentExtension: {
-      id: number;
-      name: string;
-      label: string;
-      active: boolean;
-      version: string;
-      latestVersion?: string | null;
-      installed: boolean;
-      storeLink?: string | null;
-    };
-    AdminEnvironmentTask: {
-      id: number;
-      taskId: string;
-      name: string;
-      status: string;
-      interval: number;
-      overdue: boolean;
-      lastExecutionTime?: string | null;
-      nextExecutionTime?: string | null;
-    };
-    AdminEnvironmentDeployment: {
-      id: number;
-      name: string;
-      command: string;
-      returnCode: number;
-      /** Format: float */
-      executionTime: number;
-      reference?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminAuditLogEntry: {
-      /** Format: int64 */
-      id: number;
-      actorUserId?: string | null;
-      actorName?: string | null;
-      actorEmail?: string | null;
-      action: string;
-      targetUserId?: string | null;
-      targetName?: string | null;
-      targetEmail?: string | null;
-      detail?: string | null;
-      ipAddress?: string | null;
-      /** Format: date-time */
-      createdAt: string;
-    };
-    AdminAuditLogResponse: {
-      entries: components["schemas"]["AdminAuditLogEntry"][];
-      total: number;
-    };
-    AdminStats: {
-      totalUsers: number;
-      totalOrganizations: number;
-      totalEnvironments: number;
-      environmentsByStatus: {
-        green: number;
-        yellow: number;
-        red: number;
-      };
-    };
-    AdminGrowth: {
-      users: components["schemas"]["GrowthDataPoint"][];
-      environments: components["schemas"]["GrowthDataPoint"][];
-    };
-    GrowthDataPoint: {
-      month: string;
-      count: number;
-    };
-    AdminRecentActivity: {
-      recentUsers: components["schemas"]["UserProfile"][];
-      recentEnvironments: components["schemas"]["AccountEnvironment"][];
-    };
-    ShopwareVersionCount: {
-      version: string;
-      count: number;
-    };
-    ShopwareVersion: {
-      name: string;
-    };
-    EcosystemStats: {
-      growth: components["schemas"]["AdminGrowth"];
-      shopwareVersions: components["schemas"]["ShopwareVersionCount"][];
-    };
-    ExtensionCompatibilityRequest: {
-      currentVersion: string;
-      futureVersion: string;
-      extensions: {
-        name: string;
-        version: string;
-      }[];
-    };
-    ExtensionCompatibilityResult: {
-      name: string;
-      label: string;
-      iconPath: string | null;
-      status: {
-        name: string;
-        label: string;
-        type: string;
-      };
-    };
-    AuthUser: {
-      id?: string;
-      name?: string;
-      /** Format: email */
-      email?: string;
-      emailVerified?: boolean;
-      image?: string | null;
-      role?: string;
-      notifications?: string[];
-    };
-    SessionInfo: {
-      id?: string;
-      userId?: string;
-      /** Format: date-time */
-      expiresAt?: string;
-      activeOrganizationId?: string | null;
-    };
-    InstanceConfig: {
-      registrationEnabled: boolean;
-      githubAuthEnabled: boolean;
-      sitespeedEnabled: boolean;
-      packageMirrorEnabled: boolean;
-    };
-  };
-  responses: {
-    /** @description Authentication required */
-    Unauthorized: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": components["schemas"]["ErrorResponse"];
-      };
-    };
-    /** @description Insufficient permissions */
-    Forbidden: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": components["schemas"]["ErrorResponse"];
-      };
-    };
-    /** @description Resource not found */
-    NotFound: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": components["schemas"]["ErrorResponse"];
-      };
-    };
-    /** @description Validation error */
-    ValidationError: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": components["schemas"]["ErrorResponse"];
-      };
-    };
-  };
-  parameters: {
-    /** @description Organization ID */
-    OrgId: string;
-    /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-    LanguageParam: "en" | "de";
-    /** @description Environment ID */
-    EnvironmentId: number;
-    /** @description Shop ID */
-    ShopId: number;
-    /** @description Deployment ID */
-    DeploymentId: number;
-    /** @description API key ID */
-    KeyId: string;
-    /** @description Packages token ID */
-    TokenId: number;
-    /** @description Scheduled task ID */
-    TaskId: string;
-    /** @description SSO provider ID */
-    ProviderId: string;
-    /** @description Notification ID */
-    NotificationId: number;
-  };
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
-}
-export type $defs = Record<string, never>;
-export interface operations {
-  getHealth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "text/plain": "ok";
-        };
-      };
-    };
-  };
-  getAccountMe: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Current user profile */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UserProfile"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  updateAccountMe: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description Preferred language (e.g. "en", "de"). */
-          locale?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Updated user profile */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["UserProfile"];
-        };
-      };
-      400: components["responses"]["ValidationError"];
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountExtensions: {
-    parameters: {
-      query?: {
-        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-        language?: components["parameters"]["LanguageParam"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of extensions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountExtension"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountExtension: {
-    parameters: {
-      query?: {
-        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-        language?: components["parameters"]["LanguageParam"];
-      };
-      header?: never;
-      path: {
-        /** @description Technical name of the extension */
-        name: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description The extension */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountExtension"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  getAccountOrganizations: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of organizations */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountOrganization"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountEnvironments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountEnvironment"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountShops: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of shops */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountShop"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountChangelogs: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of changelogs */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountChangelog"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getAccountSubscribedEnvironments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of subscribed environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SubscribedEnvironment"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getNotificationPreferences: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of notification preferences */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["NotificationPreference"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  setNotificationPreference: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["NotificationPreferenceInput"];
-      };
-    };
-    responses: {
-      /** @description Preference saved */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      400: components["responses"]["ValidationError"];
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  deleteNotificationPreference: {
-    parameters: {
-      query: {
-        scopeType: string;
-        scopeId?: string;
-        eventType?: string;
-        channel: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Preference deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      400: components["responses"]["ValidationError"];
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getNotifications: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of notifications */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Notification"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  deleteAllNotifications: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All notifications deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getNotificationEventTypes: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of event types */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["NotificationEventType"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  deleteNotification: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Notification ID */
-        id: components["parameters"]["NotificationId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Notification deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  markNotificationsRead: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description All notifications marked as read */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getOrganizationEnvironments: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AccountEnvironment"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  createEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateEnvironmentRequest"];
-      };
-    };
-    responses: {
-      /** @description Environment created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  getEnvironment: {
-    parameters: {
-      query?: {
-        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
-        language?: components["parameters"]["LanguageParam"];
-      };
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment details */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["EnvironmentDetail"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  deleteEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  updateEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateEnvironmentRequest"];
-      };
-    };
-    responses: {
-      /** @description Environment updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  refreshEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          /** @description Also run sitespeed check */
-          sitespeed?: boolean;
-        };
-      };
-    };
-    responses: {
-      /** @description Environment refresh triggered */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  clearEnvironmentCache: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Cache cleared */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  rescheduleTask: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-        /** @description Scheduled task ID */
-        taskId: components["parameters"]["TaskId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Task rescheduled */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  subscribeToEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Subscribed */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  unsubscribeFromEnvironment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Unsubscribed */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  getEnvironmentStatusEvents: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of status events (most recent first) */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["StatusEvent"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  updateSitespeedSettings: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["SitespeedSettingsRequest"];
-      };
-    };
-    responses: {
-      /** @description Sitespeed settings updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  getOrganizationShops: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of shops */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Shop"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  createShop: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateShopRequest"];
-      };
-    };
-    responses: {
-      /** @description Shop created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  deleteShop: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Shop deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  updateShop: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateShopRequest"];
-      };
-    };
-    responses: {
-      /** @description Shop updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  getApiKeyScopes: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of available scopes */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ApiKeyScope"][];
-        };
-      };
-    };
-  };
-  getApiKeys: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of API keys */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ApiKey"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  createApiKey: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateApiKeyRequest"];
-      };
-    };
-    responses: {
-      /** @description API key created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["CreateApiKeyResponse"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  deleteApiKey: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-        /** @description API key ID */
-        keyId: components["parameters"]["KeyId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description API key deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  getPackagesTokenConfiguration: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Packages token configuration */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["PackagesTokenConfiguration"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  getPackagesTokens: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of packages tokens */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["PackagesToken"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  createPackagesToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreatePackagesTokenRequest"];
-      };
-    };
-    responses: {
-      /** @description Packages token created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  deletePackagesToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-        /** @description Packages token ID */
-        tokenId: components["parameters"]["TokenId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Packages token deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  syncPackagesToken: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description Shop ID */
-        shopId: components["parameters"]["ShopId"];
-        /** @description Packages token ID */
-        tokenId: components["parameters"]["TokenId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Sync triggered */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  getDeployments: {
-    parameters: {
-      query?: {
-        limit?: number;
-        offset?: number;
-      };
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of deployments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["Deployment"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  getDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-        /** @description Deployment ID */
-        deploymentId: components["parameters"]["DeploymentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment details with output */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["DeploymentDetail"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  deleteDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Environment ID */
-        environmentId: components["parameters"]["EnvironmentId"];
-        /** @description Deployment ID */
-        deploymentId: components["parameters"]["DeploymentId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deployment deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  createCliDeployment: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateCliDeploymentRequest"];
-      };
-    };
-    responses: {
-      /** @description Deployment created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["CreateCliDeploymentResponse"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  getSsoProviders: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of SSO providers */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SsoProvider"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  discoverSso: {
-    parameters: {
-      query: {
-        issuer: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Discovered OIDC configuration */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["SsoDiscovery"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  updateSsoProvider: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description SSO provider ID */
-        providerId: components["parameters"]["ProviderId"];
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UpdateSsoProviderRequest"];
-      };
-    };
-    responses: {
-      /** @description SSO provider updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  deleteSsoProvider: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Organization ID */
-        orgId: components["parameters"]["OrgId"];
-        /** @description SSO provider ID */
-        providerId: components["parameters"]["ProviderId"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description SSO provider deleted */
-      204: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  adminGetOrganizations: {
-    parameters: {
-      query?: {
-        limit?: number;
-        offset?: number;
-        sortBy?: "name" | "createdAt" | "shopCount" | "memberCount";
-        sortDirection?: "asc" | "desc";
-        searchField?: string;
-        searchOperator?: string;
-        searchValue?: string;
-        filterField?: string;
-        filterOperator?: string;
-        filterValue?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Paginated list of organizations */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminOrganizationsResponse"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetEnvironments: {
-    parameters: {
-      query?: {
-        limit?: number;
-        offset?: number;
-        sortBy?: string;
-        sortDirection?: "asc" | "desc";
-        searchField?: string;
-        searchOperator?: string;
-        searchValue?: string;
-        filterField?: string;
-        filterOperator?: string;
-        filterValue?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Paginated list of environments */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminEnvironmentsResponse"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetStats: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Admin statistics */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminStats"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetGrowth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Growth data */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminGrowth"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetOrganizationDetail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        orgId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Organization detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminOrganizationDetail"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  adminGetEnvironmentDetail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        envId: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Environment detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminEnvironmentDetail"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-      404: components["responses"]["NotFound"];
-    };
-  };
-  adminGetAuditLog: {
-    parameters: {
-      query?: {
-        limit?: number;
-        offset?: number;
-        action?: string;
-        actorUserId?: string;
-        targetUserId?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Paginated audit log */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminAuditLogResponse"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetRecentActivity: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Recent activity */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminRecentActivity"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  adminGetShopwareVersions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Version distribution */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShopwareVersionCount"][];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      403: components["responses"]["Forbidden"];
-    };
-  };
-  checkExtensionCompatibility: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ExtensionCompatibilityRequest"];
-      };
-    };
-    responses: {
-      /** @description Compatibility results */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ExtensionCompatibilityResult"][];
-        };
-      };
-      422: components["responses"]["ValidationError"];
-    };
-  };
-  getShopwareVersions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Known Shopware versions, newest first */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ShopwareVersion"][];
-        };
-      };
-    };
-  };
-  getInstanceConfig: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Instance configuration */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["InstanceConfig"];
-        };
-      };
-    };
-  };
-  getEcosystemStats: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Ecosystem statistics */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["EcosystemStats"];
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  signUpEmail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          password: string;
-          name: string;
-        };
-      };
-    };
-    responses: {
-      /** @description User created successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            user?: components["schemas"]["AuthUser"];
-          };
-        };
-      };
-      400: components["responses"]["ValidationError"];
-      /** @description Email already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["ErrorResponse"];
-        };
-      };
-    };
-  };
-  signInEmail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          password: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Signed in successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            user?: components["schemas"]["AuthUser"];
-          };
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-      /** @description Account is banned */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  signOut: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Signed out */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getSession: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Current session */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            user?: components["schemas"]["AuthUser"];
-            session?: components["schemas"]["SessionInfo"];
-          };
-        };
-      };
-      401: components["responses"]["Unauthorized"];
-    };
-  };
-  setActiveOrganization: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          organizationId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Active organization updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Not a member of the specified organization */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  verifyEmail: {
-    parameters: {
-      query: {
-        token: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Email verified */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Invalid or expired token */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  forgetPassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Reset email sent (always returns success) */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  resetPassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          token: string;
-          newPassword: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Password reset */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Invalid token or weak password */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  signInSocial: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @enum {string} */
-          provider: "github";
-          callbackURL?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Authorization URL */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            url?: string;
-          };
-        };
-      };
-    };
-  };
-  signInSSO: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          callbackURL?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Authorization URL */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            url?: string;
-          };
-        };
-      };
-      /** @description No SSO provider for this domain */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  ssoCallback: {
-    parameters: {
-      query: {
-        code: string;
-        state: string;
-      };
-      header?: never;
-      path: {
-        providerId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description One-time authorization code */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            code?: string;
-          };
-        };
-      };
-      /** @description Missing or invalid parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  passkeyRegisterOptions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Registration options and challenge key */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            options?: Record<string, never>;
-            challengeKey?: string;
-          };
-        };
-      };
-    };
-  };
-  passkeyRegister: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          challengeKey: string;
-          name?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Passkey registered */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Invalid or expired challenge */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  passkeyLoginOptions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Login options and challenge key */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  passkeyLogin: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          challengeKey: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Logged in */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Authentication failed */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  createOrganization: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          name: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Organization created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id?: string;
-            name?: string;
-          };
-        };
-      };
-    };
-  };
-  deleteOrganization: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Only owners can delete */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  updateOrganization: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          name?: string;
-          logo?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listOrganizationMembers: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of members */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id?: string;
-            userId?: string;
-            role?: string;
-            name?: string;
-            email?: string;
-            image?: string | null;
-          }[];
-        };
-      };
-    };
-  };
-  removeMember: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Member removed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  setMemberRole: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          role: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Role updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  leaveOrganization: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Left organization */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Cannot leave as only owner */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listOrganizationInvitations: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of pending invitations */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  inviteMember: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        organizationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          /** @default member */
-          role?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Invitation sent */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  acceptInvitation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        invitationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Invitation accepted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  rejectInvitation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        invitationId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Invitation rejected */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  adminListUsers: {
-    parameters: {
-      query?: {
-        limit?: number;
-        offset?: number;
-        /** @description Filter users by email or name (case-insensitive substring) */
-        search?: string;
-        /** @description Filter users by role */
-        role?: "user" | "admin";
-        /** @description Filter users by account status */
-        status?: "active" | "banned" | "unverified";
-        sortBy?: "createdAt" | "name" | "email";
-        sortDirection?: "asc" | "desc";
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Paginated list of users */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminUsersResponse"];
-        };
-      };
-    };
-  };
-  adminGetUserDetail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["AdminUserDetail"];
-        };
-      };
-      404: components["responses"]["NotFound"];
-    };
-  };
-  adminSetUserRole: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @enum {string} */
-          role: "user" | "admin";
-        };
-      };
-    };
-    responses: {
-      /** @description Role updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  adminBanUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          banReason?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description User banned */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  adminUnbanUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User unbanned */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  adminImpersonate: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        userId: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Impersonation session created */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  getFullOrganization: {
-    parameters: {
-      query: {
-        organizationId: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Full organization details */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id?: string;
-            name?: string;
-            members?: {
-              id?: string;
-              userId?: string;
-              role?: string;
-              name?: string;
-              email?: string;
-            }[];
-            invitations?: {
-              id?: string;
-              email?: string;
-              role?: string;
-              status?: string;
-            }[];
-          };
-        };
-      };
-    };
-  };
-  listSessions: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of sessions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+    schemas: {
+        ErrorResponse: {
+            message: string;
+        };
+        UserProfile: {
             id: string;
+            displayName: string;
+            /** Format: email */
+            email: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** @description The user's preferred language, used to localize notification emails. */
+            locale: string;
+        };
+        AccountExtension: {
+            name: string;
+            label: string;
+            version: string;
+            latestVersion: string;
+            active: boolean;
+            installed: boolean;
+            storeLink: string | null;
+            ratingAverage: number | null;
+            /** Format: date-time */
+            installedAt: string | null;
+            changelog: components["schemas"]["ExtensionChangelogEntry"][] | null;
+            /** @description URL of the extension's store icon, when known. */
+            iconUrl?: string | null;
+            producerName?: string | null;
+            producerWebsite?: string | null;
+            /** @description Release date of the latest store version (raw store value). */
+            releaseDate?: string | null;
+            /** @description Short store description in the requested language (falls back to English). */
+            shortDescription?: string | null;
+            /** @description Full store description (HTML) in the requested language (falls back to English). */
+            description?: string | null;
+            /** @description Installation manual (HTML) in the requested language (falls back to English). */
+            installationManual?: string | null;
+            screenshots?: components["schemas"]["ExtensionScreenshot"][] | null;
+            environments: components["schemas"]["AccountExtensionEnvironment"][];
+        };
+        ExtensionScreenshot: {
+            url: string;
+            /** @description Whether this image is the store's primary preview image. */
+            preview: boolean;
+        };
+        AccountExtensionEnvironment: {
+            environmentId: number;
+            environmentName: string;
+            environmentShopName: string;
+            environmentOrganizationName: string;
+            environmentOrganizationId: string;
+            environmentUrl: string;
+            /** @description ID of the shop this environment belongs to. */
+            shopId: number;
+            /** @description Name of the shop this environment belongs to (environments may share a name across shops). */
+            shopName: string;
+            active: boolean;
+            version: string;
+            latestVersion: string;
+            installed: boolean;
+        };
+        AccountOrganization: {
+            id: string;
+            name: string;
+            logo: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            environmentCount: number;
+            memberCount: number;
+        };
+        AccountEnvironment: {
+            id: number;
+            name: string;
+            url: string;
+            favicon: string | null;
+            status: string;
+            shopwareVersion: string;
+            /** Format: date-time */
+            lastScrapedAt: string | null;
+            lastScrapedError: string | null;
+            organizationId: string;
+            organizationName: string;
+            shopId: number | null;
+            shopName: string | null;
+        };
+        AccountShop: {
+            id: number;
+            name: string;
+            description: string | null;
+            gitUrl: string | null;
+            organizationId: string;
+            organizationName: string;
+            defaultEnvironmentId: number | null;
+        };
+        AccountChangelog: {
+            id: number;
+            environmentId: number;
+            /** @description JSON data describing extension changes */
+            extensions: components["schemas"]["ExtensionDiff"][];
+            oldShopwareVersion: string | null;
+            newShopwareVersion: string | null;
+            /** Format: date-time */
+            date: string;
+            environmentName: string;
+            environmentShopName: string;
+            environmentOrganizationName: string;
+            environmentOrganizationId: string;
+        };
+        ExtensionDiff: {
+            name: string;
+            label: string;
+            state: string;
+            oldVersion?: string | null;
+            newVersion?: string | null;
+            changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
+            active: boolean;
+        };
+        ExtensionChangelogEntry: {
+            version: string;
+            /** @description Changelog text. For store catalog endpoints this is already resolved to the requested language (English fallback). For stored environment-changelog history it holds the English (en_GB) text, with textDe carrying the German variant when available. */
+            text: string;
+            /** @description German (de_DE) changelog text for stored history entries, when available. */
+            textDe?: string | null;
+            /** Format: date-time */
+            creationDate: string;
+        };
+        SubscribedEnvironment: {
+            id: number;
+            name: string;
+            /** @description The shop this environment belongs to, if any. */
+            shopId?: number | null;
+            shopName?: string | null;
+        };
+        StatusReason: {
+            level: string;
+            messageKey: string;
+            params?: {
+                [key: string]: unknown;
+            };
+            source?: string;
+        };
+        StatusEvent: {
+            id: number;
+            oldStatus: string;
+            newStatus: string;
+            reasons: components["schemas"]["StatusReason"][];
+            /** Format: date-time */
+            createdAt: string;
+        };
+        NotificationEventType: {
+            /** @description Stable event type identifier (e.g. status_degraded). */
+            type: string;
+            /** @description Channels this event is delivered on by default. */
+            defaultChannels: string[];
+        };
+        NotificationPreference: {
+            /** @description Scope of the preference: global, organization, or environment. */
+            scopeType: string;
+            /** @description Empty for global; organization or environment id otherwise. */
+            scopeId: string;
+            /** @description Empty matches all event types; otherwise a specific event type. */
+            eventType: string;
+            /** @description Empty is a subscription marker; otherwise in_app or email. */
+            channel: string;
+            enabled: boolean;
+        };
+        NotificationPreferenceInput: {
+            scopeType: string;
+            scopeId?: string;
+            eventType?: string;
+            channel: string;
+            enabled: boolean;
+        };
+        Notification: {
+            id: number;
+            userId: string;
+            key: string;
+            level: string;
+            title: string;
+            message: string;
+            /** @description Translation key for the title; render with params client-side. Falls back to title. */
+            titleKey?: string | null;
+            /** @description Translation key for the message; render with params client-side. Falls back to message. */
+            messageKey?: string | null;
+            /** @description Structured params for interpolating titleKey/messageKey. */
+            params?: {
+                [key: string]: unknown;
+            };
+            link: components["schemas"]["NotificationLink"] | null;
+            read: boolean;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        NotificationLink: {
+            url: string;
+            label: string;
+        };
+        CreateEnvironmentRequest: {
+            name: string;
+            shopUrl: string;
+            clientId: string;
+            clientSecret: string;
+            shopId: number;
+            environmentToken?: string | null;
+        };
+        UpdateEnvironmentRequest: {
+            name?: string;
+            shopUrl?: string;
+            clientId?: string;
+            clientSecret?: string;
+            ignores?: string[];
+            shopId: number;
+        };
+        EnvironmentDetail: {
+            id: number;
+            organizationId: string;
+            organizationName: string;
+            shopId: number | null;
+            shopName: string | null;
+            shopDescription: string | null;
+            name: string;
+            status: string;
+            url: string;
+            favicon: string | null;
+            shopwareVersion: string;
+            /** Format: date-time */
+            lastScrapedAt: string | null;
+            lastScrapedError: string | null;
+            ignores: string[] | null;
+            environmentImage: string | null;
+            environmentToken: string;
+            lastChangelog: components["schemas"]["AccountChangelog"] | null;
+            sitespeedEnabled: boolean;
+            sitespeedUrls: string[] | null;
+            sitespeedDetailUrl: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            extensions: components["schemas"]["EnvironmentExtension"][];
+            scheduledTasks: components["schemas"]["ScheduledTask"][];
+            queues: components["schemas"]["Queue"][];
+            cache: components["schemas"]["CacheInfo"] | null;
+            checks: components["schemas"]["EnvironmentCheck"][];
+            sitespeeds: components["schemas"]["Sitespeed"][];
+            changelogs: components["schemas"]["AccountChangelog"][];
+            deploymentsCount: number;
+            subscribed: boolean;
+        };
+        EnvironmentExtension: {
+            name: string;
+            label: string;
+            version: string;
+            latestVersion: string;
+            active: boolean;
+            installed: boolean;
+            storeLink?: string | null;
+            ratingAverage?: number | null;
+            /** Format: date-time */
+            installedAt?: string | null;
+            changelog?: components["schemas"]["ExtensionChangelogEntry"][] | null;
+        };
+        ScheduledTask: {
+            id: string;
+            name: string;
+            runInterval: number;
+            status: string;
+            /** Format: date-time */
+            lastExecutionTime?: string | null;
+            /** Format: date-time */
+            nextExecutionTime?: string | null;
+            overdue: boolean;
+        };
+        Queue: {
+            name: string;
+            size: number;
+        };
+        CacheInfo: {
+            id?: number;
+            environment?: string;
+            httpCache?: boolean;
+            cacheAdapter?: string;
+        };
+        EnvironmentCheck: {
+            id: string;
+            level: string;
+            message: string;
+            /** @description Translation key for the message; render with params client-side. Falls back to message. */
+            messageKey?: string | null;
+            /** @description Structured params for interpolating messageKey. */
+            params?: {
+                [key: string]: unknown;
+            };
+            link?: string | null;
+        };
+        Sitespeed: {
+            ttfb?: number | null;
+            fullyLoaded?: number | null;
+            largestContentfulPaint?: number | null;
+            firstContentfulPaint?: number | null;
+            cumulativeLayoutShift?: number | null;
+            transferSize?: number | null;
+            /** Format: date-time */
+            createdAt: string;
+            deployment?: components["schemas"]["SitespeedDeployment"] | null;
+        };
+        SitespeedDeployment: {
+            id: number;
+            name: string;
+        };
+        SitespeedSettingsRequest: {
+            enabled: boolean;
+            urls?: string[];
+        };
+        Shop: {
+            id: number;
+            name: string;
+            description: string | null;
+            gitUrl: string | null;
+            organizationId: string;
+            defaultEnvironmentId: number | null;
+        };
+        CreateShopRequest: {
+            name: string;
+            description?: string;
+            gitUrl?: string;
+            environmentName: string;
+            environmentUrl: string;
+            clientId: string;
+            clientSecret: string;
+        };
+        UpdateShopRequest: {
+            name?: string;
+            description?: string;
+            gitUrl?: string;
+            defaultEnvironmentId?: number;
+        };
+        ApiKeyScope: {
+            value: string;
+            label: string;
+            description: string;
+        };
+        ApiKey: {
+            id: string;
+            name: string;
+            scopes: string[];
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            lastUsedAt: string | null;
+        };
+        CreateApiKeyRequest: {
+            name: string;
+            scopes: string[];
+        };
+        CreateApiKeyResponse: {
+            id: string;
+            token: string;
+            name: string;
+            scopes: string[];
+        };
+        PackagesTokenConfiguration: {
+            configured: boolean;
+            composerUrl: string | null;
+        };
+        PackagesToken: {
+            id: number;
+            source: string;
+            /**
+             * Format: int64
+             * @description Unix timestamp in seconds of the last successful sync, or null if never synced.
+             */
+            lastSyncedAt: number | null;
+        };
+        CreatePackagesTokenRequest: {
+            token: string;
+        };
+        Deployment: {
+            id: number;
+            name: string | null;
+            command: string;
+            returnCode: number;
+            /** Format: date-time */
+            startDate: string;
+            /** Format: date-time */
+            endDate: string;
+            /** @description Execution time in seconds */
+            executionTime: number;
+            reference: string | null;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        DeploymentDetail: components["schemas"]["Deployment"] & {
+            output?: string | null;
+        };
+        CreateCliDeploymentRequest: {
+            environment_id: number;
+            command: string;
+            return_code: number;
+            /** Format: date-time */
+            start_date: string;
+            /** Format: date-time */
+            end_date: string;
+            execution_time: number;
+            composer?: string | null;
+            reference?: string | null;
+            name?: string | null;
+        };
+        CreateCliDeploymentResponse: {
+            success: boolean;
+            name: string;
+            deployment_id: number;
+            url: string;
+            upload_url: string;
+        };
+        SsoProvider: {
+            id: string;
+            domain: string;
+            issuer: string;
+            clientId: string;
+            authorizationEndpoint: string;
+            tokenEndpoint: string;
+            jwksEndpoint: string;
+        };
+        SsoDiscovery: {
+            issuer: string;
+            authorizationEndpoint: string;
+            tokenEndpoint: string;
+            jwksEndpoint: string;
+            userInfoEndpoint: string;
+            scopes: string[];
+        };
+        UpdateSsoProviderRequest: {
+            domain: string;
+            issuer: string;
+            clientId: string;
+            clientSecret?: string;
+            authorizationEndpoint: string;
+            tokenEndpoint: string;
+            jwksEndpoint: string;
+        };
+        AdminOrganizationsResponse: {
+            organizations: components["schemas"]["AccountOrganization"][];
+            total: number;
+        };
+        AdminEnvironmentsResponse: {
+            environments: components["schemas"]["AccountEnvironment"][];
+            total: number;
+        };
+        AdminUser: {
+            id: string;
+            name: string;
+            email: string;
+            emailVerified: boolean;
+            image?: string | null;
+            role: string;
+            banned?: boolean | null;
+            banReason?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminUsersResponse: {
+            users: components["schemas"]["AdminUser"][];
+            total: number;
+        };
+        AdminUserDetail: {
+            id: string;
+            name: string;
+            email: string;
+            emailVerified: boolean;
+            image?: string | null;
+            role: string;
+            banned: boolean;
+            banReason?: string | null;
+            /** Format: date-time */
+            banExpires?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            updatedAt: string;
+            authProviders: components["schemas"]["AdminUserAuthProvider"][];
+            sessions: components["schemas"]["AdminUserSession"][];
+            memberships: components["schemas"]["AdminUserMembership"][];
+            auditLog: components["schemas"]["AdminAuditLogEntry"][];
+        };
+        AdminUserAuthProvider: {
+            id: string;
+            providerId: string;
+            accountId?: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminUserSession: {
+            id: string;
+            ipAddress?: string | null;
+            userAgent?: string | null;
+            impersonated: boolean;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            expiresAt: string;
+        };
+        AdminUserMembership: {
+            organizationId: string;
+            organizationName: string;
+            organizationSlug: string;
+            role: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminOrganizationDetail: {
+            id: string;
+            name: string;
+            slug: string;
+            logo?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+            memberCount: number;
+            environmentCount: number;
+            members: components["schemas"]["AdminOrganizationMember"][];
+            environments: components["schemas"]["AdminOrganizationEnvironment"][];
+            invitations: components["schemas"]["AdminOrganizationInvitation"][];
+            ssoProviders: components["schemas"]["AdminOrganizationSSO"][];
+            shops: components["schemas"]["AdminOrganizationShop"][];
+        };
+        AdminOrganizationMember: {
+            userId: string;
+            name: string;
+            email: string;
+            image?: string | null;
+            role: string;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminOrganizationEnvironment: {
+            id: number;
+            name: string;
+            url: string;
+            status: string;
+            shopwareVersion: string;
+            shopId: number;
+            shopName: string;
+            /** Format: date-time */
+            lastScrapedAt?: string | null;
+        };
+        AdminOrganizationInvitation: {
+            id: string;
+            email: string;
+            role?: string | null;
+            status: string;
             /** Format: date-time */
             expiresAt: string;
             /** Format: date-time */
             createdAt: string;
-            ipAddress?: string | null;
-            userAgent?: string | null;
-            impersonatedBy?: string | null;
-          }[];
+            inviterName: string;
+            inviterEmail: string;
         };
-      };
-    };
-  };
-  revokeSession: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          sessionId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Session revoked */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listAccounts: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of linked accounts */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
+        AdminOrganizationSSO: {
             id: string;
-            provider: string;
-            accountId: string;
-            /** Format: date-time */
-            createdAt: string;
-          }[];
+            issuer: string;
+            providerId: string;
+            domain: string;
         };
-      };
-    };
-  };
-  unlinkAccount: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          providerId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Account unlinked */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  changeEmail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          newEmail: string;
-          currentPassword: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Email changed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  updateUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": {
-          name?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description User updated */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  changePassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          currentPassword: string;
-          newPassword: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Password changed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-      /** @description Current password incorrect */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  deleteUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  linkSocial: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          provider: string;
-          callbackURL?: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Authorization URL */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            url?: string;
-          };
-        };
-      };
-    };
-  };
-  listUserOrganizations: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of organizations */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
+        AdminOrganizationShop: {
+            id: number;
             name: string;
-            logo?: string | null;
-            /** Format: date-time */
-            createdAt?: string;
-            role?: string;
-          }[];
-        };
-      };
-    };
-  };
-  hasPermission: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          organizationId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Permission check result */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            success?: boolean;
-          };
-        };
-      };
-    };
-  };
-  cancelInvitation: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          invitationId: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Invitation cancelled */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
-  listUserPasskeys: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description List of passkeys */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            id: string;
-            name: string | null;
-            deviceType?: string;
-            backedUp?: boolean;
+            description?: string | null;
+            defaultEnvironmentId?: number | null;
             /** Format: date-time */
             createdAt: string;
-          }[];
         };
-      };
-    };
-  };
-  deletePasskey: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          id: string;
+        AdminEnvironmentDetail: {
+            id: number;
+            name: string;
+            url: string;
+            status: string;
+            shopwareVersion: string;
+            /** Format: date-time */
+            createdAt: string;
+            /** Format: date-time */
+            lastScrapedAt?: string | null;
+            lastScrapedError?: string | null;
+            connectionIssueCount: number;
+            organizationId: string;
+            organizationName: string;
+            shopId: number;
+            shopName: string;
+            checks: components["schemas"]["AdminEnvironmentCheck"][];
+            extensions: components["schemas"]["AdminEnvironmentExtension"][];
+            scheduledTasks: components["schemas"]["AdminEnvironmentTask"][];
+            lastDeployment?: components["schemas"]["AdminEnvironmentDeployment"];
         };
-      };
+        AdminEnvironmentCheck: {
+            id: number;
+            checkId: string;
+            level: string;
+            message: string;
+            source: string;
+            link?: string | null;
+        };
+        AdminEnvironmentExtension: {
+            id: number;
+            name: string;
+            label: string;
+            active: boolean;
+            version: string;
+            latestVersion?: string | null;
+            installed: boolean;
+            storeLink?: string | null;
+        };
+        AdminEnvironmentTask: {
+            id: number;
+            taskId: string;
+            name: string;
+            status: string;
+            interval: number;
+            overdue: boolean;
+            lastExecutionTime?: string | null;
+            nextExecutionTime?: string | null;
+        };
+        AdminEnvironmentDeployment: {
+            id: number;
+            name: string;
+            command: string;
+            returnCode: number;
+            /** Format: float */
+            executionTime: number;
+            reference?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminAuditLogEntry: {
+            /** Format: int64 */
+            id: number;
+            actorUserId?: string | null;
+            actorName?: string | null;
+            actorEmail?: string | null;
+            action: string;
+            targetUserId?: string | null;
+            targetName?: string | null;
+            targetEmail?: string | null;
+            detail?: string | null;
+            ipAddress?: string | null;
+            /** Format: date-time */
+            createdAt: string;
+        };
+        AdminAuditLogResponse: {
+            entries: components["schemas"]["AdminAuditLogEntry"][];
+            total: number;
+        };
+        AdminStats: {
+            totalUsers: number;
+            totalOrganizations: number;
+            totalEnvironments: number;
+            environmentsByStatus: {
+                green: number;
+                yellow: number;
+                red: number;
+            };
+        };
+        AdminGrowth: {
+            users: components["schemas"]["GrowthDataPoint"][];
+            environments: components["schemas"]["GrowthDataPoint"][];
+        };
+        GrowthDataPoint: {
+            month: string;
+            count: number;
+        };
+        AdminRecentActivity: {
+            recentUsers: components["schemas"]["UserProfile"][];
+            recentEnvironments: components["schemas"]["AccountEnvironment"][];
+        };
+        ShopwareVersionCount: {
+            version: string;
+            count: number;
+        };
+        ShopwareVersion: {
+            name: string;
+        };
+        EcosystemStats: {
+            growth: components["schemas"]["AdminGrowth"];
+            shopwareVersions: components["schemas"]["ShopwareVersionCount"][];
+        };
+        ExtensionCompatibilityRequest: {
+            currentVersion: string;
+            futureVersion: string;
+            extensions: {
+                name: string;
+                version: string;
+            }[];
+        };
+        ExtensionCompatibilityResult: {
+            name: string;
+            label: string;
+            iconPath: string | null;
+            status: {
+                name: string;
+                label: string;
+                type: string;
+            };
+        };
+        AuthUser: {
+            id?: string;
+            name?: string;
+            /** Format: email */
+            email?: string;
+            emailVerified?: boolean;
+            image?: string | null;
+            role?: string;
+            notifications?: string[];
+        };
+        SessionInfo: {
+            id?: string;
+            userId?: string;
+            /** Format: date-time */
+            expiresAt?: string;
+            activeOrganizationId?: string | null;
+            /** @description Admin user ID when this session is an impersonation */
+            impersonatedBy?: string | null;
+        };
+        InstanceConfig: {
+            registrationEnabled: boolean;
+            githubAuthEnabled: boolean;
+            sitespeedEnabled: boolean;
+            packageMirrorEnabled: boolean;
+        };
     };
     responses: {
-      /** @description Passkey deleted */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        /** @description Authentication required */
+        Unauthorized: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
         };
-        content?: never;
-      };
+        /** @description Insufficient permissions */
+        Forbidden: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+        /** @description Resource not found */
+        NotFound: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
+        /** @description Validation error */
+        ValidationError: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["ErrorResponse"];
+            };
+        };
     };
-  };
-  registerSSOProvider: {
     parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+        /** @description Organization ID */
+        OrgId: string;
+        /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+        LanguageParam: "en" | "de";
+        /** @description Environment ID */
+        EnvironmentId: number;
+        /** @description Shop ID */
+        ShopId: number;
+        /** @description Deployment ID */
+        DeploymentId: number;
+        /** @description API key ID */
+        KeyId: string;
+        /** @description Packages token ID */
+        TokenId: number;
+        /** @description Scheduled task ID */
+        TaskId: string;
+        /** @description SSO provider ID */
+        ProviderId: string;
+        /** @description Notification ID */
+        NotificationId: number;
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          organizationId: string;
-          domain: string;
-          issuer: string;
-          clientId: string;
-          clientSecret: string;
-          authorizationEndpoint: string;
-          tokenEndpoint: string;
-          jwksEndpoint: string;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
+}
+export type $defs = Record<string, never>;
+export interface operations {
+    getHealth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": "ok";
+                };
+            };
+        };
     };
-    responses: {
-      /** @description SSO provider registered */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAccountMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
+        requestBody?: never;
+        responses: {
+            /** @description Current user profile */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
     };
-  };
-  adminStopImpersonating: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    updateAccountMe: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description Preferred language (e.g. "en", "de"). */
+                    locale?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated user profile */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["UserProfile"];
+                };
+            };
+            400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Impersonation ended */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAccountExtensions: {
+        parameters: {
+            query?: {
+                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+                language?: components["parameters"]["LanguageParam"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
+        requestBody?: never;
+        responses: {
+            /** @description List of extensions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountExtension"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
     };
-  };
-  githubCallback: {
-    parameters: {
-      query: {
-        code: string;
-        state: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getAccountExtension: {
+        parameters: {
+            query?: {
+                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+                language?: components["parameters"]["LanguageParam"];
+            };
+            header?: never;
+            path: {
+                /** @description Technical name of the extension */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The extension */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountExtension"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description One-time authorization code */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAccountOrganizations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            code?: string;
-          };
+        requestBody?: never;
+        responses: {
+            /** @description List of organizations */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountOrganization"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
         };
-      };
-      /** @description Missing or invalid parameters */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  exchangeCode: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    getAccountEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountEnvironment"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          code: string;
+    getAccountShops: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description List of shops */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountShop"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
     };
-    responses: {
-      /** @description Session token */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getAccountChangelogs: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": {
-            token?: string;
-          };
+        requestBody?: never;
+        responses: {
+            /** @description List of changelogs */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountChangelog"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
         };
-      };
-      /** @description Invalid or expired code */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
+    getAccountSubscribedEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of subscribed environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SubscribedEnvironment"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getNotificationPreferences: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of notification preferences */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationPreference"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    setNotificationPreference: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["NotificationPreferenceInput"];
+            };
+        };
+        responses: {
+            /** @description Preference saved */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    deleteNotificationPreference: {
+        parameters: {
+            query: {
+                scopeType: string;
+                scopeId?: string;
+                eventType?: string;
+                channel: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Preference deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["ValidationError"];
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getNotifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of notifications */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Notification"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    deleteAllNotifications: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All notifications deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getNotificationEventTypes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of event types */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotificationEventType"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    deleteNotification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Notification ID */
+                id: components["parameters"]["NotificationId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Notification deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    markNotificationsRead: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description All notifications marked as read */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getOrganizationEnvironments: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AccountEnvironment"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateEnvironmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Environment created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getEnvironment: {
+        parameters: {
+            query?: {
+                /** @description Language for localized store text (label, description, manual, changelog). Falls back to English. */
+                language?: components["parameters"]["LanguageParam"];
+            };
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EnvironmentDetail"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateEnvironmentRequest"];
+            };
+        };
+        responses: {
+            /** @description Environment updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    refreshEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    /** @description Also run sitespeed check */
+                    sitespeed?: boolean;
+                };
+            };
+        };
+        responses: {
+            /** @description Environment refresh triggered */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    clearEnvironmentCache: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Cache cleared */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    rescheduleTask: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+                /** @description Scheduled task ID */
+                taskId: components["parameters"]["TaskId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Task rescheduled */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    subscribeToEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Subscribed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    unsubscribeFromEnvironment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Unsubscribed */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    getEnvironmentStatusEvents: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of status events (most recent first) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["StatusEvent"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    updateSitespeedSettings: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SitespeedSettingsRequest"];
+            };
+        };
+        responses: {
+            /** @description Sitespeed settings updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getOrganizationShops: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of shops */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Shop"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createShop: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateShopRequest"];
+            };
+        };
+        responses: {
+            /** @description Shop created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteShop: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Shop deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    updateShop: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateShopRequest"];
+            };
+        };
+        responses: {
+            /** @description Shop updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getApiKeyScopes: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of available scopes */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKeyScope"][];
+                };
+            };
+        };
+    };
+    getApiKeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of API keys */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiKey"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateApiKeyRequest"];
+            };
+        };
+        responses: {
+            /** @description API key created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateApiKeyResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteApiKey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+                /** @description API key ID */
+                keyId: components["parameters"]["KeyId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description API key deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getPackagesTokenConfiguration: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Packages token configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PackagesTokenConfiguration"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    getPackagesTokens: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of packages tokens */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PackagesToken"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    createPackagesToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreatePackagesTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description Packages token created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deletePackagesToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+                /** @description Packages token ID */
+                tokenId: components["parameters"]["TokenId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Packages token deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    syncPackagesToken: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description Shop ID */
+                shopId: components["parameters"]["ShopId"];
+                /** @description Packages token ID */
+                tokenId: components["parameters"]["TokenId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Sync triggered */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    getDeployments: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+            };
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of deployments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Deployment"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    getDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+                /** @description Deployment ID */
+                deploymentId: components["parameters"]["DeploymentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment details with output */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeploymentDetail"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    deleteDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Environment ID */
+                environmentId: components["parameters"]["EnvironmentId"];
+                /** @description Deployment ID */
+                deploymentId: components["parameters"]["DeploymentId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deployment deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    createCliDeployment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateCliDeploymentRequest"];
+            };
+        };
+        responses: {
+            /** @description Deployment created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateCliDeploymentResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getSsoProviders: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of SSO providers */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SsoProvider"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    discoverSso: {
+        parameters: {
+            query: {
+                issuer: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Discovered OIDC configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SsoDiscovery"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    updateSsoProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description SSO provider ID */
+                providerId: components["parameters"]["ProviderId"];
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["UpdateSsoProviderRequest"];
+            };
+        };
+        responses: {
+            /** @description SSO provider updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    deleteSsoProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Organization ID */
+                orgId: components["parameters"]["OrgId"];
+                /** @description SSO provider ID */
+                providerId: components["parameters"]["ProviderId"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description SSO provider deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    adminGetOrganizations: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                sortBy?: "name" | "createdAt" | "shopCount" | "memberCount";
+                sortDirection?: "asc" | "desc";
+                searchField?: string;
+                searchOperator?: string;
+                searchValue?: string;
+                filterField?: string;
+                filterOperator?: string;
+                filterValue?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of organizations */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminOrganizationsResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetEnvironments: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                sortBy?: string;
+                sortDirection?: "asc" | "desc";
+                searchField?: string;
+                searchOperator?: string;
+                searchValue?: string;
+                filterField?: string;
+                filterOperator?: string;
+                filterValue?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of environments */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminEnvironmentsResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetStats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Admin statistics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminStats"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetGrowth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Growth data */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminGrowth"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetOrganizationDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                orgId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Organization detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminOrganizationDetail"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    adminGetEnvironmentDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                envId: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Environment detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminEnvironmentDetail"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
+        };
+    };
+    adminGetAuditLog: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                action?: string;
+                actorUserId?: string;
+                targetUserId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated audit log */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminAuditLogResponse"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetRecentActivity: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Recent activity */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminRecentActivity"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    adminGetShopwareVersions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Version distribution */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShopwareVersionCount"][];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+        };
+    };
+    checkExtensionCompatibility: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ExtensionCompatibilityRequest"];
+            };
+        };
+        responses: {
+            /** @description Compatibility results */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExtensionCompatibilityResult"][];
+                };
+            };
+            422: components["responses"]["ValidationError"];
+        };
+    };
+    getShopwareVersions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Known Shopware versions, newest first */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ShopwareVersion"][];
+                };
+            };
+        };
+    };
+    getInstanceConfig: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Instance configuration */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["InstanceConfig"];
+                };
+            };
+        };
+    };
+    getEcosystemStats: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Ecosystem statistics */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EcosystemStats"];
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    signUpEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    password: string;
+                    name: string;
+                };
+            };
+        };
+        responses: {
+            /** @description User created successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        user?: components["schemas"]["AuthUser"];
+                    };
+                };
+            };
+            400: components["responses"]["ValidationError"];
+            /** @description Email already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
+    };
+    signInEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    password: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Signed in successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        user?: components["schemas"]["AuthUser"];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+            /** @description Account is banned */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    signOut: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Signed out */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Current session */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        user?: components["schemas"]["AuthUser"];
+                        session?: components["schemas"]["SessionInfo"];
+                    };
+                };
+            };
+            401: components["responses"]["Unauthorized"];
+        };
+    };
+    setActiveOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    organizationId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Active organization updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Not a member of the specified organization */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    verifyEmail: {
+        parameters: {
+            query: {
+                token: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Email verified */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid or expired token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    forgetPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Reset email sent (always returns success) */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    resetPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    token: string;
+                    newPassword: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Password reset */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid token or weak password */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    signInSocial: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    provider: "github";
+                    callbackURL?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Authorization URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        url?: string;
+                    };
+                };
+            };
+        };
+    };
+    signInSSO: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    callbackURL?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Authorization URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        url?: string;
+                    };
+                };
+            };
+            /** @description No SSO provider for this domain */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    ssoCallback: {
+        parameters: {
+            query: {
+                code: string;
+                state: string;
+            };
+            header?: never;
+            path: {
+                providerId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One-time authorization code */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        code?: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    passkeyRegisterOptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Registration options and challenge key */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        options?: Record<string, never>;
+                        challengeKey?: string;
+                    };
+                };
+            };
+        };
+    };
+    passkeyRegister: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    challengeKey: string;
+                    name?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Passkey registered */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid or expired challenge */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    passkeyLoginOptions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Login options and challenge key */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    passkeyLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    challengeKey: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Logged in */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Authentication failed */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    createOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    name: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Organization created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id?: string;
+                        name?: string;
+                    };
+                };
+            };
+        };
+    };
+    deleteOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Only owners can delete */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name?: string;
+                    logo?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listOrganizationMembers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of members */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id?: string;
+                        userId?: string;
+                        role?: string;
+                        name?: string;
+                        email?: string;
+                        image?: string | null;
+                    }[];
+                };
+            };
+        };
+    };
+    removeMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Member removed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    setMemberRole: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    role: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Role updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    leaveOrganization: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Left organization */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Cannot leave as only owner */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listOrganizationInvitations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of pending invitations */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    inviteMember: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                organizationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    /** @default member */
+                    role?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Invitation sent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    acceptInvitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                invitationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Invitation accepted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    rejectInvitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                invitationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Invitation rejected */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminListUsers: {
+        parameters: {
+            query?: {
+                limit?: number;
+                offset?: number;
+                /** @description Filter users by email or name (case-insensitive substring) */
+                search?: string;
+                /** @description Filter users by role */
+                role?: "user" | "admin";
+                /** @description Filter users by account status */
+                status?: "active" | "banned" | "unverified";
+                sortBy?: "createdAt" | "name" | "email";
+                sortDirection?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Paginated list of users */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUsersResponse"];
+                };
+            };
+        };
+    };
+    adminGetUserDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AdminUserDetail"];
+                };
+            };
+            404: components["responses"]["NotFound"];
+        };
+    };
+    adminSetUserRole: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @enum {string} */
+                    role: "user" | "admin";
+                };
+            };
+        };
+        responses: {
+            /** @description Role updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminBanUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    banReason?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description User banned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminUnbanUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User unbanned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminImpersonate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                userId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Impersonation session created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        token: string;
+                        session: {
+                            token: string;
+                            impersonatedBy: string;
+                        };
+                    };
+                };
+            };
+        };
+    };
+    getFullOrganization: {
+        parameters: {
+            query: {
+                organizationId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Full organization details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id?: string;
+                        name?: string;
+                        members?: {
+                            id?: string;
+                            userId?: string;
+                            role?: string;
+                            name?: string;
+                            email?: string;
+                        }[];
+                        invitations?: {
+                            id?: string;
+                            email?: string;
+                            role?: string;
+                            status?: string;
+                        }[];
+                    };
+                };
+            };
+        };
+    };
+    listSessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of sessions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        /** Format: date-time */
+                        expiresAt: string;
+                        /** Format: date-time */
+                        createdAt: string;
+                        ipAddress?: string | null;
+                        userAgent?: string | null;
+                        impersonatedBy?: string | null;
+                    }[];
+                };
+            };
+        };
+    };
+    revokeSession: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    sessionId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Session revoked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listAccounts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of linked accounts */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        provider: string;
+                        accountId: string;
+                        /** Format: date-time */
+                        createdAt: string;
+                    }[];
+                };
+            };
+        };
+    };
+    unlinkAccount: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    providerId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Account unlinked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    changeEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    newEmail: string;
+                    currentPassword: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Email changed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    updateUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": {
+                    name?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description User updated */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    changePassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    currentPassword: string;
+                    newPassword: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Password changed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Current password incorrect */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    deleteUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    linkSocial: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    provider: string;
+                    callbackURL?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Authorization URL */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        url?: string;
+                    };
+                };
+            };
+        };
+    };
+    listUserOrganizations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of organizations */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string;
+                        logo?: string | null;
+                        /** Format: date-time */
+                        createdAt?: string;
+                        role?: string;
+                    }[];
+                };
+            };
+        };
+    };
+    hasPermission: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    organizationId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Permission check result */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success?: boolean;
+                    };
+                };
+            };
+        };
+    };
+    cancelInvitation: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    invitationId: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Invitation cancelled */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    listUserPasskeys: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description List of passkeys */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        id: string;
+                        name: string | null;
+                        deviceType?: string;
+                        backedUp?: boolean;
+                        /** Format: date-time */
+                        createdAt: string;
+                    }[];
+                };
+            };
+        };
+    };
+    deletePasskey: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    id: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Passkey deleted */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    registerSSOProvider: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    organizationId: string;
+                    domain: string;
+                    issuer: string;
+                    clientId: string;
+                    clientSecret: string;
+                    authorizationEndpoint: string;
+                    tokenEndpoint: string;
+                    jwksEndpoint: string;
+                };
+            };
+        };
+        responses: {
+            /** @description SSO provider registered */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    adminStopImpersonating: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Impersonation ended */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    githubCallback: {
+        parameters: {
+            query: {
+                code: string;
+                state: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description One-time authorization code */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        code?: string;
+                    };
+                };
+            };
+            /** @description Missing or invalid parameters */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    exchangeCode: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    code: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Session token */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        token?: string;
+                    };
+                };
+            };
+            /** @description Invalid or expired code */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
 }

--- a/frontend/src/views/admin/DetailUser.vue
+++ b/frontend/src/views/admin/DetailUser.vue
@@ -11,11 +11,38 @@
 
     <!-- Content -->
     <template v-else>
-      <PageHeader :title="user.name">
-        <Button variant="outline" size="sm" @click="router.back()">
-          <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
-          {{ t("admin.back") }}
-        </Button>
+      <PageHeader :title="user.name" :description="user.email">
+        <div class="flex flex-wrap items-center justify-end gap-2">
+          <Button v-if="!isSelf" size="sm" :disabled="actionLoading" @click="impersonateUser">
+            <icon-fa6-solid:user-secret class="mr-1.5 size-3" />
+            {{ t("admin.impersonate") }}
+          </Button>
+          <Button
+            v-if="!isSelf && !user.banned"
+            variant="outline"
+            size="sm"
+            class="text-destructive hover:bg-destructive/10 hover:text-destructive"
+            :disabled="actionLoading"
+            @click="banUser"
+          >
+            <icon-fa6-solid:ban class="mr-1.5 size-3" />
+            {{ t("admin.ban") }}
+          </Button>
+          <Button
+            v-else-if="!isSelf && user.banned"
+            variant="outline"
+            size="sm"
+            :disabled="actionLoading"
+            @click="unbanUser"
+          >
+            <icon-fa6-solid:rotate-left class="mr-1.5 size-3" />
+            {{ t("admin.unban") }}
+          </Button>
+          <Button variant="outline" size="sm" @click="router.back()">
+            <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
+            {{ t("admin.back") }}
+          </Button>
+        </div>
       </PageHeader>
 
       <Alert v-if="error" variant="destructive">
@@ -195,8 +222,9 @@ import { computed, onMounted, ref } from "vue";
 import { RouterLink, useRoute, useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 
-import { api } from "@/helpers/api";
+import { api, setToken, stashAdminToken } from "@/helpers/api";
 import { formatDate, formatDateTime } from "@/helpers/formatter";
+import { useSession } from "@/composables/useSession";
 import type { components } from "@/types/api";
 
 import PageHeader from "@/components/PageHeader.vue";
@@ -219,12 +247,16 @@ import IconUserSlash from "~icons/fa6-solid/user-slash";
 const route = useRoute();
 const router = useRouter();
 const { t } = useI18n();
+const { session } = useSession();
 
 const id = route.params.id as string;
 
 const user = ref<components["schemas"]["AdminUserDetail"] | null>(null);
 const loading = ref(true);
+const actionLoading = ref(false);
 const error = ref("");
+
+const isSelf = computed(() => !!user.value && user.value.id === session.value?.user?.id);
 
 const statusLabel = computed(() => {
   if (!user.value) return "";
@@ -266,6 +298,90 @@ async function loadUser() {
     user.value = null;
   } finally {
     loading.value = false;
+  }
+}
+
+async function impersonateUser() {
+  if (!user.value || isSelf.value) return;
+  actionLoading.value = true;
+  error.value = "";
+  try {
+    const { data, error: respError } = await api.POST("/auth/admin/users/{userId}/impersonate", {
+      params: { path: { userId: user.value.id } },
+    });
+    if (respError) {
+      error.value =
+        (respError as unknown as { message?: string })?.message ??
+        t("admin.failedImpersonate", { error: "Unknown error" });
+      return;
+    }
+
+    if (!data?.token) {
+      error.value = t("admin.failedImpersonate", { error: "No token returned" });
+      return;
+    }
+
+    stashAdminToken();
+    setToken(data.token);
+    window.location.href = "/app/dashboard";
+  } catch (err) {
+    error.value = t("admin.failedImpersonate", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    actionLoading.value = false;
+  }
+}
+
+async function banUser() {
+  if (!user.value || isSelf.value) return;
+  const reason = window.prompt(t("admin.banReason"));
+  if (!reason) return;
+
+  actionLoading.value = true;
+  error.value = "";
+  try {
+    const { error: respError } = await api.POST("/auth/admin/users/{userId}/ban", {
+      params: { path: { userId: user.value.id } },
+      body: { banReason: reason },
+    });
+    if (respError) {
+      error.value =
+        (respError as unknown as { message?: string })?.message ??
+        t("admin.failedBan", { error: "Unknown error" });
+      return;
+    }
+    await loadUser();
+  } catch (err) {
+    error.value = t("admin.failedBan", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    actionLoading.value = false;
+  }
+}
+
+async function unbanUser() {
+  if (!user.value || isSelf.value) return;
+  actionLoading.value = true;
+  error.value = "";
+  try {
+    const { error: respError } = await api.POST("/auth/admin/users/{userId}/unban", {
+      params: { path: { userId: user.value.id } },
+    });
+    if (respError) {
+      error.value =
+        (respError as unknown as { message?: string })?.message ??
+        t("admin.failedUnban", { error: "Unknown error" });
+      return;
+    }
+    await loadUser();
+  } catch (err) {
+    error.value = t("admin.failedUnban", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  } finally {
+    actionLoading.value = false;
   }
 }
 


### PR DESCRIPTION
## Summary
- Restore **Impersonate**, **Ban**, and **Unban** on the admin user detail page (actions were removed when list rows became detail links and never re-added)
- Switch to the impersonation token after impersonate, stash the admin token, and restore it when stopping impersonation
- Return `session.impersonatedBy` from `GET /auth/session` so the yellow impersonation banner actually appears

## Test plan
- [ ] As admin, open **Admin → Users → user detail** and confirm **Impersonate** (and Ban/Unban) are visible for other users, not for yourself
- [ ] Click **Impersonate** → land on the app dashboard as the target user
- [ ] Confirm the yellow **Stop Impersonating** banner is shown
- [ ] Click **Stop Impersonating** → return to admin with the original admin session
- [ ] Ban/unban a user from the detail page and confirm status updates