### PR TITLE
feat(admin): elevate admin UI/UX, navigation, and detail page information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea
+/.agents
 /http-client.private.env.json
 /api/.env
 /api/shopmon*.db*

--- a/api/internal/database/queries/admin.sql.go
+++ b/api/internal/database/queries/admin.sql.go
@@ -730,8 +730,12 @@ WHERE ($3::text IS NULL OR e.name ILIKE '%' || $3 || '%' OR e.url ILIKE '%' || $
 ORDER BY
   CASE WHEN $4::text = 'name' AND $5::text = 'asc' THEN e.name END ASC,
   CASE WHEN $4::text = 'name' AND $5::text = 'desc' THEN e.name END DESC,
+  CASE WHEN $4::text = 'url' AND $5::text = 'asc' THEN e.url END ASC,
+  CASE WHEN $4::text = 'url' AND $5::text = 'desc' THEN e.url END DESC,
   CASE WHEN $4::text = 'status' AND $5::text = 'asc' THEN e.status END ASC,
   CASE WHEN $4::text = 'status' AND $5::text = 'desc' THEN e.status END DESC,
+  CASE WHEN $4::text = 'shopwareVersion' AND $5::text = 'asc' THEN e.shopware_version END ASC,
+  CASE WHEN $4::text = 'shopwareVersion' AND $5::text = 'desc' THEN e.shopware_version END DESC,
   CASE WHEN $4::text = 'organizationName' AND $5::text = 'asc' THEN o.name END ASC,
   CASE WHEN $4::text = 'organizationName' AND $5::text = 'desc' THEN o.name END DESC,
   CASE WHEN $4::text = 'createdAt' AND $5::text = 'asc' THEN e.created_at END ASC,

--- a/api/sql/queries/admin.sql
+++ b/api/sql/queries/admin.sql
@@ -37,8 +37,12 @@ WHERE (sqlc.narg('search')::text IS NULL OR e.name ILIKE '%' || sqlc.narg('searc
 ORDER BY
   CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'asc' THEN e.name END ASC,
   CASE WHEN sqlc.arg('sort_by')::text = 'name' AND sqlc.arg('sort_dir')::text = 'desc' THEN e.name END DESC,
+  CASE WHEN sqlc.arg('sort_by')::text = 'url' AND sqlc.arg('sort_dir')::text = 'asc' THEN e.url END ASC,
+  CASE WHEN sqlc.arg('sort_by')::text = 'url' AND sqlc.arg('sort_dir')::text = 'desc' THEN e.url END DESC,
   CASE WHEN sqlc.arg('sort_by')::text = 'status' AND sqlc.arg('sort_dir')::text = 'asc' THEN e.status END ASC,
   CASE WHEN sqlc.arg('sort_by')::text = 'status' AND sqlc.arg('sort_dir')::text = 'desc' THEN e.status END DESC,
+  CASE WHEN sqlc.arg('sort_by')::text = 'shopwareVersion' AND sqlc.arg('sort_dir')::text = 'asc' THEN e.shopware_version END ASC,
+  CASE WHEN sqlc.arg('sort_by')::text = 'shopwareVersion' AND sqlc.arg('sort_dir')::text = 'desc' THEN e.shopware_version END DESC,
   CASE WHEN sqlc.arg('sort_by')::text = 'organizationName' AND sqlc.arg('sort_dir')::text = 'asc' THEN o.name END ASC,
   CASE WHEN sqlc.arg('sort_by')::text = 'organizationName' AND sqlc.arg('sort_dir')::text = 'desc' THEN o.name END DESC,
   CASE WHEN sqlc.arg('sort_by')::text = 'createdAt' AND sqlc.arg('sort_dir')::text = 'asc' THEN e.created_at END ASC,

--- a/frontend/src/components/admin/AdminFilterSidebar.vue
+++ b/frontend/src/components/admin/AdminFilterSidebar.vue
@@ -7,14 +7,23 @@
       </Label>
       <div class="relative">
         <icon-fa6-solid:magnifying-glass
-          class="pointer-events-none absolute left-2.5 top-1/2 size-3 -translate-y-1/2 text-muted-foreground"
+          class="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground"
         />
         <Input
           :model-value="search"
           :placeholder="searchPlaceholder"
-          class="h-9 w-full pl-8 text-sm"
+          class="h-9 w-full pl-8 pr-8 text-sm transition-all focus-visible:ring-1"
           @update:model-value="$emit('update:search', String($event))"
         />
+        <button
+          v-if="search"
+          type="button"
+          class="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground p-0.5 rounded-full"
+          title="Clear search"
+          @click="clearSearch"
+        >
+          <icon-fa6-solid:xmark class="size-3" />
+        </button>
       </div>
     </div>
 
@@ -23,26 +32,35 @@
     <!-- Filter / sort groups -->
     <div class="flex-1 space-y-5 overflow-y-auto px-4 py-4">
       <div v-for="group in groups" :key="group.key">
-        <Label class="mb-2 block text-xs font-medium text-muted-foreground">
-          {{ group.label }}
-        </Label>
+        <div class="mb-2 flex items-center justify-between">
+          <Label class="block text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            {{ group.label }}
+          </Label>
+          <Badge
+            v-if="modelValue[group.key] !== group.defaultValue"
+            variant="outline"
+            class="h-4 border-primary/30 bg-primary/10 px-1 text-[9px] font-bold text-primary"
+          >
+            Active
+          </Badge>
+        </div>
         <div class="flex flex-col gap-1">
           <button
             v-for="opt in group.options"
             :key="String(opt.value)"
             type="button"
             :class="[
-              'flex items-center justify-between rounded-md px-2.5 py-1.5 text-left text-sm transition-colors',
+              'flex items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-sm transition-all duration-150',
               modelValue[group.key] === opt.value
-                ? 'bg-accent font-medium text-accent-foreground'
-                : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground',
+                ? 'bg-primary/10 font-semibold text-primary'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground',
             ]"
             @click="select(group.key, opt.value)"
           >
             <span class="truncate">{{ opt.label }}</span>
             <icon-fa6-solid:check
               v-if="modelValue[group.key] === opt.value"
-              class="size-3 shrink-0 text-primary"
+              class="size-3.5 shrink-0 text-primary"
             />
           </button>
         </div>
@@ -56,7 +74,7 @@
         <Button
           variant="ghost"
           size="sm"
-          class="w-full justify-start text-muted-foreground"
+          class="w-full justify-start text-xs text-muted-foreground hover:text-destructive hover:bg-destructive/10"
           @click="clearAll"
         >
           <icon-fa6-solid:xmark class="mr-1.5 size-3" />
@@ -68,6 +86,7 @@
 </template>
 
 <script setup lang="ts">
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -115,6 +134,11 @@ const activeCount = computed(() => {
 function select(key: string, value: string) {
   if (props.modelValue[key] === value) return;
   emit("update:modelValue", { ...props.modelValue, [key]: value });
+  emit("change");
+}
+
+function clearSearch() {
+  emit("update:search", "");
   emit("change");
 }
 

--- a/frontend/src/components/admin/AdminFilterSidebar.vue
+++ b/frontend/src/components/admin/AdminFilterSidebar.vue
@@ -139,7 +139,6 @@ function select(key: string, value: string) {
 
 function clearSearch() {
   emit("update:search", "");
-  emit("change");
 }
 
 function clearAll() {

--- a/frontend/src/components/admin/AdminListLayout.vue
+++ b/frontend/src/components/admin/AdminListLayout.vue
@@ -29,7 +29,7 @@
 
     <div class="flex flex-col gap-6 lg:flex-row lg:items-start">
       <!-- Desktop: sticky sidebar -->
-      <aside class="hidden w-64 shrink-0 lg:block">
+      <aside class="hidden w-72 shrink-0 lg:block">
         <div class="sticky top-16 rounded-xl border bg-card py-4">
           <div class="px-4 pb-3">
             <span class="flex items-center gap-1.5 text-sm font-semibold">

--- a/frontend/src/composables/useAdminListQuery.ts
+++ b/frontend/src/composables/useAdminListQuery.ts
@@ -1,0 +1,87 @@
+import { ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+export type Defaults = {
+  search?: string;
+  page?: number;
+  filters: Record<string, string>;
+};
+
+export function useAdminListQuery(defaults: Defaults) {
+  const route = useRoute();
+  const router = useRouter();
+
+  const defaultSearch = defaults.search ?? "";
+  const defaultPage = defaults.page ?? 1;
+  const defaultFilters = { ...defaults.filters };
+
+  // Read initial route values
+  const qVal = route.query.q;
+  const initialSearch = typeof qVal === "string" ? qVal : defaultSearch;
+
+  const pageVal = route.query.page;
+  let initialPage = defaultPage;
+  if (typeof pageVal === "string") {
+    const parsed = parseInt(pageVal, 10);
+    initialPage = isNaN(parsed) ? defaultPage : Math.max(1, parsed);
+  }
+
+  const initialFilters: Record<string, string> = {};
+  for (const key of Object.keys(defaultFilters)) {
+    const routeVal = route.query[key];
+    if (typeof routeVal === "string" && routeVal !== "") {
+      initialFilters[key] = routeVal;
+    } else {
+      initialFilters[key] = defaultFilters[key];
+    }
+  }
+
+  const search = ref(initialSearch);
+  const page = ref(initialPage);
+  const filters = ref<Record<string, string>>(initialFilters);
+
+  function syncToUrl() {
+    const query = { ...route.query };
+
+    // Update search (q)
+    if (search.value && search.value !== defaultSearch) {
+      query.q = search.value;
+    } else {
+      delete query.q;
+    }
+
+    // Update page
+    if (page.value && page.value !== defaultPage) {
+      query.page = String(page.value);
+    } else {
+      delete query.page;
+    }
+
+    // Update filters
+    for (const key of Object.keys(defaultFilters)) {
+      const val = filters.value[key];
+      if (val !== undefined && val !== defaultFilters[key]) {
+        query[key] = val;
+      } else {
+        delete query[key];
+      }
+    }
+
+    void router.replace({ query });
+  }
+
+  function reset() {
+    search.value = defaultSearch;
+    page.value = defaultPage;
+    filters.value = { ...defaultFilters };
+    syncToUrl();
+  }
+
+  return {
+    search,
+    page,
+    filters,
+    syncToUrl,
+    reset,
+  };
+}

--- a/frontend/src/composables/useAdminListQuery.ts
+++ b/frontend/src/composables/useAdminListQuery.ts
@@ -1,4 +1,4 @@
-import { ref } from "vue";
+import { ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 export type Defaults = {
@@ -6,6 +6,56 @@ export type Defaults = {
   page?: number;
   filters: Record<string, string>;
 };
+
+function parseQuery(
+  query: Record<string, unknown>,
+  defaultSearch: string,
+  defaultPage: number,
+  defaultFilters: Record<string, string>,
+) {
+  const qVal = query.q;
+  const search = typeof qVal === "string" ? qVal : defaultSearch;
+
+  const pageVal = query.page;
+  let page = defaultPage;
+  if (typeof pageVal === "string") {
+    const parsed = parseInt(pageVal, 10);
+    page = isNaN(parsed) ? defaultPage : Math.max(1, parsed);
+  }
+
+  const filters: Record<string, string> = {};
+  for (const key of Object.keys(defaultFilters)) {
+    const routeVal = query[key];
+    if (typeof routeVal === "string" && routeVal !== "") {
+      filters[key] = routeVal;
+    } else {
+      filters[key] = defaultFilters[key];
+    }
+  }
+
+  return { search, page, filters };
+}
+
+/** Stable key for comparing list query state (ignores unrelated route query keys). */
+function stateKey(
+  search: string,
+  page: number,
+  filters: Record<string, string>,
+  defaultSearch: string,
+  defaultPage: number,
+  defaultFilters: Record<string, string>,
+) {
+  const parts: string[] = [];
+  if (search && search !== defaultSearch) parts.push(`q=${search}`);
+  if (page && page !== defaultPage) parts.push(`page=${page}`);
+  for (const key of Object.keys(defaultFilters).sort()) {
+    const val = filters[key];
+    if (val !== undefined && val !== defaultFilters[key]) {
+      parts.push(`${key}=${val}`);
+    }
+  }
+  return parts.join("&");
+}
 
 export function useAdminListQuery(defaults: Defaults) {
   const route = useRoute();
@@ -15,30 +65,56 @@ export function useAdminListQuery(defaults: Defaults) {
   const defaultPage = defaults.page ?? 1;
   const defaultFilters = { ...defaults.filters };
 
-  // Read initial route values
-  const qVal = route.query.q;
-  const initialSearch = typeof qVal === "string" ? qVal : defaultSearch;
+  const initial = parseQuery(route.query, defaultSearch, defaultPage, defaultFilters);
 
-  const pageVal = route.query.page;
-  let initialPage = defaultPage;
-  if (typeof pageVal === "string") {
-    const parsed = parseInt(pageVal, 10);
-    initialPage = isNaN(parsed) ? defaultPage : Math.max(1, parsed);
+  const search = ref(initial.search);
+  const page = ref(initial.page);
+  const filters = ref<Record<string, string>>(initial.filters);
+
+  /**
+   * Bumped when the route query changes list state from outside this composable
+   * (e.g. browser back/forward or same-route navigation). List views should
+   * watch this and reload. Own syncToUrl updates do not bump it.
+   */
+  const revision = ref(0);
+
+  function currentKey() {
+    return stateKey(
+      search.value,
+      page.value,
+      filters.value,
+      defaultSearch,
+      defaultPage,
+      defaultFilters,
+    );
   }
 
-  const initialFilters: Record<string, string> = {};
-  for (const key of Object.keys(defaultFilters)) {
-    const routeVal = route.query[key];
-    if (typeof routeVal === "string" && routeVal !== "") {
-      initialFilters[key] = routeVal;
-    } else {
-      initialFilters[key] = defaultFilters[key];
-    }
+  function applyFromRoute() {
+    const next = parseQuery(route.query, defaultSearch, defaultPage, defaultFilters);
+    const nextKey = stateKey(
+      next.search,
+      next.page,
+      next.filters,
+      defaultSearch,
+      defaultPage,
+      defaultFilters,
+    );
+    if (currentKey() === nextKey) return false;
+
+    search.value = next.search;
+    page.value = next.page;
+    filters.value = next.filters;
+    return true;
   }
 
-  const search = ref(initialSearch);
-  const page = ref(initialPage);
-  const filters = ref<Record<string, string>>(initialFilters);
+  watch(
+    () => route.query,
+    () => {
+      if (applyFromRoute()) {
+        revision.value++;
+      }
+    },
+  );
 
   function syncToUrl() {
     const query = { ...route.query };
@@ -81,6 +157,7 @@ export function useAdminListQuery(defaults: Defaults) {
     search,
     page,
     filters,
+    revision,
     syncToUrl,
     reset,
   };

--- a/frontend/src/layouts/AdminLayout.vue
+++ b/frontend/src/layouts/AdminLayout.vue
@@ -1,11 +1,78 @@
 <template>
   <div class="min-h-screen bg-background">
-    <nav class="sticky top-0 z-10 border-b bg-background">
-      <div class="container mx-auto flex items-center justify-between gap-4 px-4 py-2">
+    <nav class="sticky top-0 z-20 border-b bg-background/80 backdrop-blur-md">
+      <div class="container mx-auto flex items-center justify-between gap-4 px-4 py-2.5">
         <div class="flex items-center">
+          <Sheet v-model:open="menuOpen">
+            <SheetTrigger as-child>
+              <Button variant="outline" size="sm" class="mr-2 sm:hidden">
+                <icon-fa6-solid:bars class="size-4" />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side="left" class="w-80 p-0">
+              <div class="flex h-full flex-col">
+                <SheetHeader class="border-b px-4 py-3 text-left">
+                  <div class="flex items-center gap-2">
+                    <SheetTitle class="text-base">{{ $t("common.appName") }}</SheetTitle>
+                    <Badge
+                      variant="outline"
+                      class="border-primary/30 bg-primary/10 text-[10px] font-bold uppercase tracking-wider text-primary"
+                    >
+                      Admin
+                    </Badge>
+                  </div>
+                </SheetHeader>
+                <div class="flex-1 flex flex-col gap-1 px-4 py-4">
+                  <RouterLink
+                    v-for="link in navLinks"
+                    :key="link.to"
+                    :to="link.to"
+                    :class="[
+                      'inline-flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-all duration-150',
+                      isLinkActive(link.match)
+                        ? 'bg-primary/10 font-semibold text-primary shadow-xs'
+                        : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+                    ]"
+                    @click="menuOpen = false"
+                  >
+                    {{ $t(link.labelKey) }}
+                  </RouterLink>
+                </div>
+                <Separator />
+                <div class="p-4 space-y-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    class="w-full justify-start text-muted-foreground"
+                    @click="toggleDarkMode"
+                  >
+                    <icon-fa6-solid:moon v-if="!darkMode" class="mr-2 size-4 text-amber-500" />
+                    <icon-fa6-solid:sun v-else class="mr-2 size-4 text-amber-400" />
+                    {{ darkMode ? "Light Mode" : "Dark Mode" }}
+                  </Button>
+
+                  <RouterLink
+                    to="/"
+                    class="inline-flex w-full items-center rounded-lg px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+                    @click="menuOpen = false"
+                  >
+                    <icon-fa6-solid:house class="mr-2 size-4" />
+                    {{ $t("admin.backToDashboard") }}
+                  </RouterLink>
+                </div>
+              </div>
+            </SheetContent>
+          </Sheet>
+
           <RouterLink to="/" class="flex items-center gap-2.5">
-            <Logo class="size-7 shrink-0" />
+            <Logo class="size-7 shrink-0 transition-transform hover:scale-105" />
             <span class="text-base font-bold tracking-tight">{{ $t("common.appName") }}</span>
+            <Badge
+              variant="outline"
+              class="hidden sm:inline-flex border-primary/30 bg-primary/10 text-[10px] font-bold uppercase tracking-wider text-primary px-1.5 py-0.5"
+            >
+              Admin
+            </Badge>
           </RouterLink>
 
           <div class="ml-6 hidden items-center gap-1 sm:flex">
@@ -14,10 +81,10 @@
               :key="link.to"
               :to="link.to"
               :class="[
-                'inline-flex items-center rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                'inline-flex items-center rounded-lg px-3 py-1.5 text-sm font-medium transition-all duration-150',
                 isLinkActive(link.match)
-                  ? 'bg-accent text-accent-foreground'
-                  : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+                  ? 'bg-primary/10 font-semibold text-primary shadow-xs'
+                  : 'text-muted-foreground hover:bg-accent hover:text-foreground',
               ]"
             >
               {{ $t(link.labelKey) }}
@@ -25,12 +92,26 @@
           </div>
         </div>
 
-        <Button as-child variant="outline" size="sm">
-          <RouterLink to="/">
-            <icon-fa6-solid:house class="mr-1 size-4" />
-            {{ $t("admin.backToDashboard") }}
-          </RouterLink>
-        </Button>
+        <div class="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            class="size-8 rounded-lg text-muted-foreground hover:text-foreground"
+            :title="darkMode ? 'Switch to light mode' : 'Switch to dark mode'"
+            @click="toggleDarkMode"
+          >
+            <icon-fa6-solid:moon v-if="!darkMode" class="size-4 text-slate-700" />
+            <icon-fa6-solid:sun v-else class="size-4 text-amber-400" />
+            <span class="sr-only">Toggle theme</span>
+          </Button>
+
+          <Button as-child variant="outline" size="sm" class="h-8 gap-1.5 text-xs font-medium">
+            <RouterLink to="/">
+              <icon-fa6-solid:house class="size-3.5" />
+              {{ $t("admin.backToDashboard") }}
+            </RouterLink>
+          </Button>
+        </div>
       </div>
     </nav>
 
@@ -43,12 +124,19 @@
 </template>
 
 <script setup lang="ts">
+import { ref } from "vue";
 import { useRoute } from "vue-router";
 import ImpersonationBanner from "@/components/ImpersonationBanner.vue";
 import Logo from "@/components/Logo.vue";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { useDarkMode } from "@/composables/useDarkMode";
 
 const route = useRoute();
+const menuOpen = ref(false);
+const { darkMode, toggleDarkMode } = useDarkMode();
 
 const navLinks = [
   { to: "/admin/dashboard", labelKey: "admin.dashboard", match: "admin.dashboard" },

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -905,7 +905,7 @@
     "recentEnvironments": "Letzte Umgebungen",
     "noRecentSignups": "Keine aktuellen Registrierungen",
     "noRecentEnvironments": "Keine aktuellen Umgebungen",
-    "environmentHealth": "Umgebungs-Zustand:",
+    "environmentHealth": "Umgebungs-Zustand",
     "backToDashboard": "Zurück zum Dashboard",
     "noEnvironmentsFound": "Keine Umgebungen gefunden",
     "noEnvironmentsMatch": "Keine Umgebungen entsprechen \"{query}\"",
@@ -985,7 +985,17 @@
     "actionUnbanUser": "Benutzersperre aufgehoben",
     "actionImpersonate": "Identität angenommen",
     "actionPasswordChange": "Passwort geändert",
-    "actionPasswordReset": "Passwort zurückgesetzt"
+    "actionPasswordReset": "Passwort zurückgesetzt",
+    "createdDate": "Erstellungsdatum",
+    "environmentName": "Umgebungsname",
+    "organizationName": "Organisationsname",
+    "resultCount": "{count} Ergebnisse",
+    "sortBy": "Sortieren nach",
+    "url": "URL",
+    "statusGreen": "Gesund",
+    "statusYellow": "Warnung",
+    "statusRed": "Kritisch",
+    "openEnvironment": "Shop öffnen"
   },
   "privacy": {
     "title": "Datenschutzerklärung",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -891,7 +891,7 @@
     "recentEnvironments": "Recent Environments",
     "noRecentSignups": "No recent signups",
     "noRecentEnvironments": "No recent environments",
-    "environmentHealth": "Environment health:",
+    "environmentHealth": "Environment Health",
     "environmentManagement": "Environment Management",
     "searchEnvironments": "Search environments by name or URL...",
     "sortByUrl": "Sort by URL",
@@ -985,7 +985,17 @@
     "actionUnbanUser": "User unbanned",
     "actionImpersonate": "Impersonated",
     "actionPasswordChange": "Password changed",
-    "actionPasswordReset": "Password reset"
+    "actionPasswordReset": "Password reset",
+    "createdDate": "Created Date",
+    "environmentName": "Environment Name",
+    "organizationName": "Organization Name",
+    "resultCount": "{count} results",
+    "sortBy": "Sort by",
+    "url": "URL",
+    "statusGreen": "Healthy",
+    "statusYellow": "Warning",
+    "statusRed": "Critical",
+    "openEnvironment": "Open shop"
   },
   "privacy": {
     "title": "Privacy Policy",

--- a/frontend/src/views/admin/Dashboard.vue
+++ b/frontend/src/views/admin/Dashboard.vue
@@ -1,51 +1,102 @@
 <template>
   <div class="space-y-6">
-    <h1 class="text-2xl font-bold tracking-tight">{{ $t("admin.dashboard") }}</h1>
+    <div class="flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight">{{ $t("admin.dashboard") }}</h1>
+        <p class="text-xs text-muted-foreground mt-0.5">
+          System overview, metrics, and administration insights
+        </p>
+      </div>
+      <div class="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-8 gap-1.5 text-xs"
+          :disabled="loading"
+          @click="loadStats"
+        >
+          <icon-fa6-solid:rotate class="size-3" :class="{ 'animate-spin': loading }" />
+          Refresh
+        </Button>
+      </div>
+    </div>
 
     <Alert v-if="error" variant="destructive">
       <AlertDescription>{{ error }}</AlertDescription>
     </Alert>
 
     <!-- Loading -->
-    <div v-if="loading" class="flex items-center justify-center gap-2 py-16 text-muted-foreground">
+    <div
+      v-if="loading && !stats"
+      class="flex items-center justify-center gap-2 py-16 text-muted-foreground"
+    >
       <icon-line-md:loading-twotone-loop class="size-5" />
       {{ $t("admin.loadingStats") }}
     </div>
 
-    <template v-if="!loading && stats">
+    <template v-if="stats">
       <!-- Stat cards -->
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <Card v-for="stat in statCards" :key="stat.label">
-          <CardContent class="flex items-center gap-3 p-4">
-            <div class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
-              <component :is="stat.icon" class="size-4 text-primary" />
+        <Card
+          v-for="stat in statCards"
+          :key="stat.label"
+          class="transition-all duration-200 hover:border-primary/30 hover:shadow-md"
+        >
+          <CardContent class="flex items-center gap-3.5 p-4">
+            <div
+              :class="[
+                'flex size-11 shrink-0 items-center justify-center rounded-xl transition-transform duration-200 group-hover:scale-105',
+                stat.bgClass,
+              ]"
+            >
+              <component :is="stat.icon" :class="['size-5', stat.textClass]" />
             </div>
             <div>
-              <div class="text-2xl font-bold tabular-nums">{{ stat.value }}</div>
-              <div class="text-xs text-muted-foreground">{{ stat.label }}</div>
+              <div class="text-2xl font-bold tabular-nums tracking-tight">{{ stat.value }}</div>
+              <div class="text-xs font-medium text-muted-foreground">{{ stat.label }}</div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card class="transition-all duration-200 hover:border-primary/30 hover:shadow-md">
+          <CardContent class="flex items-center gap-3.5 p-4">
+            <div
+              class="flex size-11 shrink-0 items-center justify-center rounded-xl bg-rose-500/10 text-rose-500"
+            >
+              <FaHeartPulse class="size-5" />
+            </div>
+            <div class="min-w-0 flex-1">
+              <div class="text-2xl font-bold tabular-nums tracking-tight">
+                {{ stats.totalEnvironments }}
+              </div>
+              <div class="flex flex-wrap items-center gap-x-2 gap-y-1">
+                <span class="text-xs font-medium text-muted-foreground">{{
+                  $t("admin.environmentHealth")
+                }}</span>
+                <div v-if="stats.environmentsByStatus" class="flex items-center gap-1.5">
+                  <div
+                    v-for="(count, status) in stats.environmentsByStatus"
+                    :key="status"
+                    class="flex items-center gap-1 rounded-md px-1.5 py-0.5 bg-muted/60"
+                  >
+                    <StatusIcon :status="String(status)" />
+                    <span class="text-[11px] font-semibold tabular-nums">{{ count }}</span>
+                  </div>
+                </div>
+              </div>
             </div>
           </CardContent>
         </Card>
       </div>
 
-      <!-- Status breakdown -->
-      <div class="flex flex-wrap items-center gap-3">
-        <span class="text-sm text-muted-foreground">{{ $t("admin.environmentHealth") }}</span>
-        <div
-          v-for="(count, status) in stats.environmentsByStatus"
-          :key="status"
-          class="flex items-center gap-1.5"
-        >
-          <StatusIcon :status="String(status)" />
-          <span class="text-sm font-medium tabular-nums">{{ count }}</span>
-        </div>
-      </div>
-
       <!-- Charts row -->
       <div v-if="growthData" class="grid gap-4 lg:grid-cols-2">
-        <Card>
+        <Card class="transition-all duration-200 hover:border-border/80">
           <CardHeader class="pb-2">
-            <CardTitle class="text-base">{{ $t("admin.userGrowth") }}</CardTitle>
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-base font-semibold">{{ $t("admin.userGrowth") }}</CardTitle>
+              <Badge variant="outline" class="text-[10px] text-muted-foreground">Monthly</Badge>
+            </div>
           </CardHeader>
           <CardContent>
             <div class="h-56">
@@ -54,9 +105,14 @@
           </CardContent>
         </Card>
 
-        <Card>
+        <Card class="transition-all duration-200 hover:border-border/80">
           <CardHeader class="pb-2">
-            <CardTitle class="text-base">{{ $t("admin.environmentGrowth") }}</CardTitle>
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-base font-semibold">{{
+                $t("admin.environmentGrowth")
+              }}</CardTitle>
+              <Badge variant="outline" class="text-[10px] text-muted-foreground">Monthly</Badge>
+            </div>
           </CardHeader>
           <CardContent>
             <div class="h-56">
@@ -71,23 +127,27 @@
         <!-- Version distribution -->
         <Card v-if="versionData?.length">
           <CardHeader class="pb-3">
-            <CardTitle class="text-base">{{ $t("admin.shopwareVersions") }}</CardTitle>
+            <CardTitle class="text-base font-semibold">{{
+              $t("admin.shopwareVersions")
+            }}</CardTitle>
           </CardHeader>
           <CardContent>
-            <div class="space-y-2">
+            <div class="space-y-3">
               <div v-for="v in versionData" :key="v.version" class="flex items-center gap-3">
-                <Badge variant="secondary" class="min-w-20 justify-center font-mono text-xs">{{
-                  v.version
-                }}</Badge>
+                <Badge
+                  variant="secondary"
+                  class="min-w-20 justify-center font-mono text-xs font-semibold"
+                  >{{ v.version }}</Badge
+                >
                 <div class="flex-1">
-                  <div class="h-2 overflow-hidden rounded-full bg-muted">
+                  <div class="h-2.5 overflow-hidden rounded-full bg-muted">
                     <div
-                      class="h-full rounded-full bg-primary transition-all"
+                      class="h-full rounded-full bg-primary transition-all duration-500"
                       :style="{ width: `${(v.count / totalEnvCount) * 100}%` }"
                     />
                   </div>
                 </div>
-                <span class="w-6 text-right text-xs tabular-nums text-muted-foreground">{{
+                <span class="w-8 text-right text-xs font-semibold tabular-nums text-foreground">{{
                   v.count
                 }}</span>
               </div>
@@ -98,7 +158,15 @@
         <!-- Recent signups -->
         <Card>
           <CardHeader class="pb-3">
-            <CardTitle class="text-base">{{ $t("admin.recentSignups") }}</CardTitle>
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-base font-semibold">{{ $t("admin.recentSignups") }}</CardTitle>
+              <RouterLink
+                to="/admin/users"
+                class="text-xs font-medium text-primary hover:underline"
+              >
+                View all
+              </RouterLink>
+            </div>
           </CardHeader>
           <CardContent>
             <div
@@ -109,24 +177,29 @@
               <p class="text-sm">{{ $t("admin.noRecentSignups") }}</p>
             </div>
             <div v-else class="space-y-1.5">
-              <div
+              <RouterLink
                 v-for="user in activity.recentUsers"
                 :key="user.id"
-                class="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-accent"
+                :to="{ name: 'admin.users.detail', params: { id: user.id } }"
+                class="group flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-accent/70"
               >
                 <div
-                  class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10"
+                  class="flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 transition-transform group-hover:scale-105"
                 >
                   <icon-fa6-solid:user class="size-3 text-primary" />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="truncate text-sm font-medium">{{ user.displayName }}</div>
+                  <div
+                    class="truncate text-sm font-medium transition-colors group-hover:text-primary"
+                  >
+                    {{ user.displayName }}
+                  </div>
                   <div class="truncate text-xs text-muted-foreground">{{ user.email }}</div>
                 </div>
-                <span class="shrink-0 text-xs tabular-nums text-muted-foreground">{{
+                <span class="shrink-0 text-[11px] tabular-nums text-muted-foreground">{{
                   formatDate(user.createdAt)
                 }}</span>
-              </div>
+              </RouterLink>
             </div>
           </CardContent>
         </Card>
@@ -134,7 +207,17 @@
         <!-- Recent environments -->
         <Card>
           <CardHeader class="pb-3">
-            <CardTitle class="text-base">{{ $t("admin.recentEnvironments") }}</CardTitle>
+            <div class="flex items-center justify-between">
+              <CardTitle class="text-base font-semibold">{{
+                $t("admin.recentEnvironments")
+              }}</CardTitle>
+              <RouterLink
+                to="/admin/environments"
+                class="text-xs font-medium text-primary hover:underline"
+              >
+                View all
+              </RouterLink>
+            </div>
           </CardHeader>
           <CardContent>
             <div
@@ -145,43 +228,34 @@
               <p class="text-sm">{{ $t("admin.noRecentEnvironments") }}</p>
             </div>
             <div v-else class="space-y-1.5">
-              <div
+              <RouterLink
                 v-for="env in activity.recentEnvironments"
                 :key="env.id"
-                class="flex items-center gap-3 rounded-lg px-3 py-2 hover:bg-accent"
+                :to="{ name: 'admin.environments.detail', params: { id: env.id } }"
+                class="group flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-accent/70"
               >
                 <div
-                  class="flex size-8 shrink-0 items-center justify-center rounded-lg border bg-muted"
+                  class="flex size-8 shrink-0 items-center justify-center rounded-lg border bg-muted transition-transform group-hover:scale-105"
                 >
-                  <icon-fa6-solid:earth-americas class="size-3 text-muted-foreground" />
+                  <icon-fa6-solid:earth-americas
+                    class="size-3 text-muted-foreground group-hover:text-primary"
+                  />
                 </div>
                 <div class="min-w-0 flex-1">
-                  <div class="truncate text-sm font-medium">{{ env.name }}</div>
+                  <div
+                    class="truncate text-sm font-medium transition-colors group-hover:text-primary"
+                  >
+                    {{ env.name }}
+                  </div>
                   <div class="truncate text-xs text-muted-foreground">
                     {{ env.organizationName }}
                   </div>
                 </div>
                 <StatusIcon :status="env.status" />
-              </div>
+              </RouterLink>
             </div>
           </CardContent>
         </Card>
-      </div>
-
-      <!-- Quick actions -->
-      <div class="flex flex-wrap gap-2">
-        <Button variant="outline" size="sm" as-child>
-          <RouterLink to="/admin/organizations">
-            <icon-fa6-solid:users class="mr-1.5 size-3" />
-            {{ $t("admin.manageOrgs") }}
-          </RouterLink>
-        </Button>
-        <Button variant="outline" size="sm" as-child>
-          <RouterLink to="/admin/environments">
-            <icon-fa6-solid:earth-americas class="mr-1.5 size-3" />
-            {{ $t("admin.manageEnvironments") }}
-          </RouterLink>
-        </Button>
       </div>
     </template>
   </div>
@@ -211,6 +285,10 @@ import { Chart, registerables } from "chart.js";
 import FaUsers from "~icons/fa6-solid/users";
 import FaBuilding from "~icons/fa6-solid/building";
 import FaEarth from "~icons/fa6-solid/earth-americas";
+import FaHeartPulse from "~icons/fa6-solid/heart-pulse";
+import FaRotate from "~icons/fa6-solid/rotate";
+import FaUser from "~icons/fa6-solid/user";
+import FaClockRotateLeft from "~icons/fa6-solid/clock-rotate-left";
 
 Chart.register(...registerables);
 
@@ -231,9 +309,27 @@ const error = ref("");
 const statCards = computed(() => {
   if (!stats.value) return [];
   return [
-    { icon: FaUsers, value: stats.value.totalUsers, label: t("common.users") },
-    { icon: FaBuilding, value: stats.value.totalOrganizations, label: t("common.organizations") },
-    { icon: FaEarth, value: stats.value.totalEnvironments, label: t("common.environments") },
+    {
+      icon: FaUsers,
+      value: stats.value.totalUsers,
+      label: t("common.users"),
+      bgClass: "bg-indigo-500/10",
+      textClass: "text-indigo-500",
+    },
+    {
+      icon: FaBuilding,
+      value: stats.value.totalOrganizations,
+      label: t("common.organizations"),
+      bgClass: "bg-sky-500/10",
+      textClass: "text-sky-500",
+    },
+    {
+      icon: FaEarth,
+      value: stats.value.totalEnvironments,
+      label: t("common.environments"),
+      bgClass: "bg-emerald-500/10",
+      textClass: "text-emerald-500",
+    },
   ];
 });
 
@@ -247,10 +343,15 @@ let shopChartInstance: Chart | null = null;
 function createGrowthChart(
   canvas: HTMLCanvasElement,
   data: { month: string; count: number }[],
-  color: string,
+  primaryColor: string,
+  gradientColor: string,
 ) {
   const ctx = canvas.getContext("2d");
   if (!ctx) return null;
+
+  const gradient = ctx.createLinearGradient(0, 0, 0, 220);
+  gradient.addColorStop(0, gradientColor);
+  gradient.addColorStop(1, "rgba(0, 0, 0, 0)");
 
   return new Chart(ctx, {
     type: "line",
@@ -259,22 +360,45 @@ function createGrowthChart(
       datasets: [
         {
           data: data.map((d) => d.count),
-          borderColor: color,
-          backgroundColor: color + "20",
+          borderColor: primaryColor,
+          backgroundColor: gradient,
           fill: true,
-          tension: 0.3,
-          pointRadius: 3,
-          pointHoverRadius: 5,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: 4,
+          pointHoverRadius: 6,
+          pointBackgroundColor: primaryColor,
+          pointBorderColor: "#fff",
+          pointBorderWidth: 1.5,
         },
       ],
     },
     options: {
       responsive: true,
       maintainAspectRatio: false,
-      plugins: { legend: { display: false }, title: { display: false } },
+      interaction: {
+        mode: "index",
+        intersect: false,
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          padding: 10,
+          cornerRadius: 8,
+          titleFont: { size: 12, weight: "bold" },
+          bodyFont: { size: 12 },
+        },
+      },
       scales: {
-        x: { title: { display: false } },
-        y: { beginAtZero: true, ticks: { precision: 0 } },
+        x: {
+          grid: { display: false },
+          ticks: { font: { size: 11 } },
+        },
+        y: {
+          beginAtZero: true,
+          ticks: { precision: 0, font: { size: 11 } },
+          grid: { color: "rgba(150, 150, 150, 0.1)" },
+        },
       },
     },
   });
@@ -290,6 +414,7 @@ function renderCharts() {
         userChartCanvas.value,
         growthData.value.users,
         "#6366f1",
+        "rgba(99, 102, 241, 0.25)",
       );
     }
     if (shopChartCanvas.value) {
@@ -297,6 +422,7 @@ function renderCharts() {
         shopChartCanvas.value,
         growthData.value.environments,
         "#10b981",
+        "rgba(16, 185, 129, 0.25)",
       );
     }
   }

--- a/frontend/src/views/admin/DetailEnvironment.vue
+++ b/frontend/src/views/admin/DetailEnvironment.vue
@@ -20,24 +20,51 @@
 
     <!-- Detail -->
     <template v-else>
-      <PageHeader :title="environment.name">
-        <Button variant="outline" size="sm" @click="router.back()">
-          <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
-          {{ t("admin.back") }}
-        </Button>
-        <Button size="sm" as-child>
-          <a :href="environment.url" target="_blank" rel="noopener noreferrer">
-            <icon-fa6-solid:arrow-up-right-from-square class="mr-1.5 size-3" />
-            {{ environment.url }}
-          </a>
-        </Button>
-      </PageHeader>
+      <div class="space-y-4">
+        <!-- Breadcrumb nav -->
+        <nav class="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RouterLink
+            :to="{ name: 'admin.dashboard' }"
+            class="hover:text-primary transition-colors"
+          >
+            {{ t("admin.dashboard") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <RouterLink
+            :to="{ name: 'admin.environments' }"
+            class="hover:text-primary transition-colors"
+          >
+            {{ t("common.environments") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <span class="font-medium text-foreground">{{ environment.name }}</span>
+        </nav>
+
+        <PageHeader :title="environment.name">
+          <div class="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              @click="router.push({ name: 'admin.environments' })"
+            >
+              <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
+              {{ t("admin.back") }}
+            </Button>
+            <Button size="sm" as-child class="gap-1.5 shadow-xs">
+              <a :href="environment.url" target="_blank" rel="noopener noreferrer">
+                <icon-fa6-solid:arrow-up-right-from-square class="size-3" />
+                {{ t("admin.openEnvironment") }}
+              </a>
+            </Button>
+          </div>
+        </PageHeader>
+      </div>
 
       <!-- Stat cards -->
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           :icon="IconHeartPulse"
-          :value="environment.status"
+          :value="friendlyStatusLabel"
           :label="t('common.status')"
           :color="statusColor"
         />
@@ -45,36 +72,64 @@
           :icon="IconTag"
           :value="environment.shopwareVersion"
           :label="t('admin.shopwareVersion')"
+          color="primary"
         />
         <StatCard
           :icon="IconPuzzlePiece"
           :value="environment.extensions.length"
           :label="t('admin.extensions')"
+          color="primary"
         />
         <StatCard
           :icon="IconClock"
           :value="environment.lastScrapedAt ? formatDateTime(environment.lastScrapedAt) : '—'"
           :label="t('admin.lastScraped')"
+          color="muted"
         />
       </div>
 
       <!-- Scrape error -->
-      <Alert v-if="environment.lastScrapedError" variant="destructive">
-        <AlertTitle>{{ t("admin.lastScrapedError") }}</AlertTitle>
+      <Alert
+        v-if="environment.lastScrapedError"
+        variant="destructive"
+        class="border-destructive/30 bg-destructive/10"
+      >
+        <AlertTitle class="font-semibold">{{ t("admin.lastScrapedError") }}</AlertTitle>
         <AlertDescription>{{ environment.lastScrapedError }}</AlertDescription>
       </Alert>
 
+      <!-- Connection issue warning -->
+      <Alert
+        v-if="environment.connectionIssueCount > 0"
+        variant="destructive"
+        class="border-amber-500/30 bg-amber-500/10 text-amber-900 dark:text-amber-200"
+      >
+        <icon-fa6-solid:triangle-exclamation class="size-4 text-amber-600 dark:text-amber-400" />
+        <AlertTitle class="font-semibold text-amber-700 dark:text-amber-300"
+          >Unstable Connection</AlertTitle
+        >
+        <AlertDescription class="text-amber-800 dark:text-amber-300">
+          This environment has recorded {{ environment.connectionIssueCount }} consecutive
+          connection issue(s) during background monitoring.
+        </AlertDescription>
+      </Alert>
+
       <!-- Org / shop info -->
-      <div class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground">
-        <icon-fa6-solid:building class="size-3" />
+      <div
+        class="flex flex-wrap items-center gap-2 text-sm text-muted-foreground rounded-lg border bg-card/50 px-3.5 py-2"
+      >
+        <icon-fa6-solid:building class="size-3.5 text-primary" />
         <RouterLink
           :to="{ name: 'admin.organizations.detail', params: { id: environment.organizationId } }"
-          class="font-medium text-foreground hover:text-primary transition-colors"
+          class="font-semibold text-foreground hover:text-primary transition-colors"
         >
           {{ environment.organizationName }}
         </RouterLink>
-        <span class="text-muted-foreground/50">/</span>
-        <span>{{ environment.shopName }}</span>
+        <span class="text-muted-foreground/40">/</span>
+        <span class="flex items-center gap-1.5 font-medium text-foreground">
+          <icon-fa6-solid:store class="size-3 text-muted-foreground" />
+          {{ environment.shopName }}
+        </span>
       </div>
 
       <!-- Bento grid -->
@@ -87,25 +142,45 @@
             :title="t('admin.noChecks')"
             size="sm"
           />
-          <div v-else class="space-y-2">
+          <div v-else class="space-y-2 max-h-96 overflow-y-auto pr-1">
             <div
               v-for="check in environment.checks"
               :key="check.id"
-              class="flex items-start gap-3 rounded-xl border bg-card px-4 py-3"
+              class="group flex items-start gap-3 rounded-xl border bg-card px-4 py-3 transition-all hover:border-primary/30"
             >
-              <Badge :class="checkLevelClass(check.level)" class="shrink-0 capitalize">{{
-                check.level
-              }}</Badge>
+              <Badge
+                v-if="check.level === 'green'"
+                class="inline-flex items-center gap-1 shrink-0 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20 text-xs px-2 py-0.5 font-medium"
+              >
+                <span class="size-1.5 rounded-full bg-emerald-500" />
+                Pass
+              </Badge>
+              <Badge
+                v-else-if="check.level === 'yellow'"
+                class="inline-flex items-center gap-1 shrink-0 bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20 text-xs px-2 py-0.5 font-medium"
+              >
+                <span class="size-1.5 rounded-full bg-amber-500" />
+                Warning
+              </Badge>
+              <Badge
+                v-else
+                class="inline-flex items-center gap-1 shrink-0 bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20 text-xs px-2 py-0.5 font-medium"
+              >
+                <span class="size-1.5 rounded-full bg-rose-500 animate-pulse" />
+                Error
+              </Badge>
               <div class="min-w-0 flex-1">
-                <div class="text-sm">{{ check.message }}</div>
-                <div class="mt-0.5 text-xs text-muted-foreground">{{ check.source }}</div>
+                <div class="text-sm font-medium leading-snug">{{ check.message }}</div>
+                <div class="mt-0.5 text-xs text-muted-foreground font-mono text-[11px]">
+                  {{ check.source }}
+                </div>
               </div>
               <a
                 v-if="check.link"
                 :href="check.link"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="shrink-0 text-muted-foreground hover:text-foreground"
+                class="shrink-0 p-1 text-muted-foreground hover:text-primary transition-colors"
               >
                 <icon-fa6-solid:arrow-up-right-from-square class="size-3" />
               </a>
@@ -266,6 +341,19 @@ const statusColor = computed(() => {
       return "warning" as const;
     default:
       return "destructive" as const;
+  }
+});
+
+const friendlyStatusLabel = computed(() => {
+  switch (environment.value?.status) {
+    case "green":
+      return t("admin.statusGreen");
+    case "yellow":
+      return t("admin.statusYellow");
+    case "red":
+      return t("admin.statusRed");
+    default:
+      return environment.value?.status ?? "";
   }
 });
 

--- a/frontend/src/views/admin/DetailOrganization.vue
+++ b/frontend/src/views/admin/DetailOrganization.vue
@@ -20,32 +20,59 @@
 
     <!-- Detail -->
     <template v-else>
-      <PageHeader :title="organization.name">
-        <Button variant="outline" size="sm" @click="router.back()">
-          <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
-          {{ t("admin.back") }}
-        </Button>
-      </PageHeader>
+      <div class="space-y-4">
+        <!-- Breadcrumb nav -->
+        <nav class="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RouterLink
+            :to="{ name: 'admin.dashboard' }"
+            class="hover:text-primary transition-colors"
+          >
+            {{ t("admin.dashboard") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <RouterLink
+            :to="{ name: 'admin.organizations' }"
+            class="hover:text-primary transition-colors"
+          >
+            {{ t("common.organizations") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <span class="font-medium text-foreground">{{ organization.name }}</span>
+        </nav>
 
-      <p class="-mt-4 text-sm text-muted-foreground">{{ organization.slug }}</p>
+        <PageHeader :title="organization.name" :description="organization.slug">
+          <Button variant="outline" size="sm" @click="router.push({ name: 'admin.organizations' })">
+            <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
+            {{ t("admin.back") }}
+          </Button>
+        </PageHeader>
+      </div>
 
       <!-- Stats -->
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <StatCard :icon="IconUsers" :value="organization.memberCount" :label="t('admin.members')" />
+        <StatCard
+          :icon="IconUsers"
+          :value="organization.memberCount"
+          :label="t('admin.members')"
+          color="primary"
+        />
         <StatCard
           :icon="IconEarthAmericas"
           :value="organization.environmentCount"
           :label="t('common.environments')"
+          color="success"
         />
         <StatCard
           :icon="IconEnvelope"
           :value="organization.invitations.length"
           :label="t('admin.invitations')"
+          color="warning"
         />
         <StatCard
           :icon="IconCalendar"
           :value="formatDate(organization.createdAt)"
           :label="t('admin.created')"
+          color="muted"
         />
       </div>
 

--- a/frontend/src/views/admin/DetailUser.vue
+++ b/frontend/src/views/admin/DetailUser.vue
@@ -11,49 +11,118 @@
 
     <!-- Content -->
     <template v-else>
-      <PageHeader :title="user.name" :description="user.email">
-        <div class="flex flex-wrap items-center justify-end gap-2">
-          <Button v-if="!isSelf" size="sm" :disabled="actionLoading" @click="impersonateUser">
-            <icon-fa6-solid:user-secret class="mr-1.5 size-3" />
-            {{ t("admin.impersonate") }}
-          </Button>
-          <Button
-            v-if="!isSelf && !user.banned"
-            variant="outline"
-            size="sm"
-            class="text-destructive hover:bg-destructive/10 hover:text-destructive"
-            :disabled="actionLoading"
-            @click="banUser"
+      <div class="space-y-4">
+        <!-- Breadcrumb nav -->
+        <nav class="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RouterLink
+            :to="{ name: 'admin.dashboard' }"
+            class="hover:text-primary transition-colors"
           >
-            <icon-fa6-solid:ban class="mr-1.5 size-3" />
-            {{ t("admin.ban") }}
-          </Button>
-          <Button
-            v-else-if="!isSelf && user.banned"
-            variant="outline"
-            size="sm"
-            :disabled="actionLoading"
-            @click="unbanUser"
-          >
-            <icon-fa6-solid:rotate-left class="mr-1.5 size-3" />
-            {{ t("admin.unban") }}
-          </Button>
-          <Button variant="outline" size="sm" @click="router.back()">
-            <icon-fa6-solid:arrow-left class="mr-1.5 size-3" />
-            {{ t("admin.back") }}
-          </Button>
-        </div>
-      </PageHeader>
+            {{ t("admin.dashboard") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <RouterLink :to="{ name: 'admin.users' }" class="hover:text-primary transition-colors">
+            {{ t("admin.users") }}
+          </RouterLink>
+          <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
+          <span class="font-medium text-foreground">{{ user.name }}</span>
+        </nav>
 
-      <Alert v-if="error" variant="destructive">
+        <PageHeader :title="user.name">
+          <template #description>
+            <div class="flex items-center gap-2">
+              <span>{{ user.email }}</span>
+              <Badge
+                v-if="user.emailVerified"
+                class="bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20 text-[10px] font-semibold"
+              >
+                Verified
+              </Badge>
+              <Badge
+                v-else
+                class="bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20 text-[10px] font-semibold"
+              >
+                Unverified
+              </Badge>
+            </div>
+          </template>
+
+          <div class="flex flex-wrap items-center justify-end gap-2">
+            <Button
+              v-if="!isSelf"
+              size="sm"
+              :disabled="actionLoading"
+              class="gap-1.5 shadow-xs"
+              @click="impersonateUser"
+            >
+              <icon-fa6-solid:user-secret class="size-3" />
+              {{ t("admin.impersonate") }}
+            </Button>
+            <Button
+              v-if="!isSelf && !user.banned"
+              variant="outline"
+              size="sm"
+              class="border-destructive/30 text-destructive hover:bg-destructive/10 hover:text-destructive gap-1.5"
+              :disabled="actionLoading"
+              @click="banUser"
+            >
+              <icon-fa6-solid:ban class="size-3" />
+              {{ t("admin.ban") }}
+            </Button>
+            <Button
+              v-else-if="!isSelf && user.banned"
+              variant="outline"
+              size="sm"
+              class="gap-1.5"
+              :disabled="actionLoading"
+              @click="unbanUser"
+            >
+              <icon-fa6-solid:rotate-left class="size-3" />
+              {{ t("admin.unban") }}
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              class="gap-1.5"
+              @click="router.push({ name: 'admin.users' })"
+            >
+              <icon-fa6-solid:arrow-left class="size-3" />
+              {{ t("admin.back") }}
+            </Button>
+          </div>
+        </PageHeader>
+      </div>
+
+      <Alert v-if="error" variant="destructive" class="border-destructive/30 bg-destructive/10">
         <AlertDescription>{{ error }}</AlertDescription>
+      </Alert>
+
+      <!-- Ban info banner if banned -->
+      <Alert
+        v-if="user.banned"
+        variant="destructive"
+        class="border-destructive/40 bg-destructive/10"
+      >
+        <icon-fa6-solid:ban class="size-4 text-destructive" />
+        <AlertTitle class="font-semibold text-destructive">{{ t("admin.banned") }}</AlertTitle>
+        <AlertDescription class="mt-1 space-y-1 text-sm">
+          <p v-if="user.banReason">
+            <span class="font-semibold">Reason:</span> {{ user.banReason }}
+          </p>
+          <p v-if="user.banExpires">
+            <span class="font-semibold">Expires:</span> {{ formatDateTime(user.banExpires) }}
+          </p>
+          <p v-if="!user.banReason && !user.banExpires">
+            This user account is currently suspended from accessing the platform.
+          </p>
+        </AlertDescription>
       </Alert>
 
       <!-- Stat cards -->
       <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard
           :icon="IconUserShield"
-          :value="user.role"
+          :value="roleLabel"
           :label="t('common.role')"
           :color="user.role === 'admin' ? 'primary' : 'muted'"
         />
@@ -67,11 +136,13 @@
           :icon="IconBuilding"
           :value="user.memberships.length"
           :label="t('admin.memberships')"
+          color="primary"
         />
         <StatCard
           :icon="IconCalendar"
           :value="formatDate(user.createdAt)"
           :label="t('admin.memberSince')"
+          color="muted"
         />
       </div>
 
@@ -118,7 +189,7 @@
             :title="t('admin.noSessions')"
             size="sm"
           />
-          <div v-else class="space-y-2">
+          <div v-else class="space-y-2 max-h-80 overflow-y-auto">
             <div
               v-for="s in user.sessions"
               :key="s.id"
@@ -237,7 +308,7 @@ import PageHeader from "@/components/PageHeader.vue";
 import StatCard from "@/components/StatCard.vue";
 import CardSection from "@/components/CardSection.vue";
 import EmptyState from "@/components/EmptyState.vue";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -269,6 +340,13 @@ const statusLabel = computed(() => {
   if (user.value.banned) return t("admin.banned");
   if (!user.value.emailVerified) return t("admin.unverified");
   return t("admin.active");
+});
+
+const roleLabel = computed(() => {
+  if (!user.value) return "";
+  if (user.value.role === "admin") return t("admin.roleAdmin");
+  if (user.value.role === "user") return t("admin.roleUser");
+  return user.value.role.charAt(0).toUpperCase() + user.value.role.slice(1);
 });
 
 const actionLabels: Record<string, string> = {

--- a/frontend/src/views/admin/DetailUser.vue
+++ b/frontend/src/views/admin/DetailUser.vue
@@ -22,7 +22,7 @@
           </RouterLink>
           <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
           <RouterLink :to="{ name: 'admin.users' }" class="hover:text-primary transition-colors">
-            {{ t("admin.users") }}
+            {{ t("common.users") }}
           </RouterLink>
           <icon-fa6-solid:chevron-right class="size-2.5 opacity-50" />
           <span class="font-medium text-foreground">{{ user.name }}</span>

--- a/frontend/src/views/admin/ListAuditLog.vue
+++ b/frontend/src/views/admin/ListAuditLog.vue
@@ -8,6 +8,10 @@
       <AlertDescription>{{ error }}</AlertDescription>
     </Alert>
 
+    <div v-if="!loading && !error" class="mb-3 text-sm text-muted-foreground">
+      {{ $t("admin.resultCount", { count: total }) }}
+    </div>
+
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center gap-2 py-12 text-muted-foreground">
       <icon-line-md:loading-twotone-loop class="size-5" />
@@ -19,13 +23,13 @@
       <div
         v-for="entry in entries"
         :key="entry.id"
-        class="flex flex-wrap items-center gap-3 rounded-xl border bg-card px-4 py-3"
+        class="group flex flex-wrap items-center gap-3.5 rounded-xl border bg-card px-4 py-3.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-sm"
       >
         <Badge
           :class="
             entry.action.startsWith('admin.')
-              ? 'bg-destructive/10 text-destructive border-destructive/20 text-xs'
-              : 'bg-warning/10 text-warning border-warning/20 text-xs'
+              ? 'bg-rose-500/10 text-rose-600 dark:text-rose-400 border-rose-500/20 text-xs px-2.5 py-0.5 font-medium'
+              : 'bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20 text-xs px-2.5 py-0.5 font-medium'
           "
         >
           {{ actionLabel(entry.action) }}
@@ -36,7 +40,7 @@
             <RouterLink
               v-if="entry.actorUserId"
               :to="{ name: 'admin.users.detail', params: { id: entry.actorUserId } }"
-              class="font-medium hover:text-primary"
+              class="font-semibold text-foreground hover:text-primary transition-colors"
             >
               {{ entry.actorName ?? entry.actorEmail }}
             </RouterLink>
@@ -47,11 +51,11 @@
               <RouterLink
                 v-if="entry.targetUserId"
                 :to="{ name: 'admin.users.detail', params: { id: entry.targetUserId } }"
-                class="hover:text-primary"
+                class="font-medium text-foreground hover:text-primary transition-colors"
               >
                 {{ entry.targetName ?? entry.targetEmail }}
               </RouterLink>
-              <span v-else>{{ entry.targetName ?? entry.targetEmail }}</span>
+              <span v-else class="font-medium">{{ entry.targetName ?? entry.targetEmail }}</span>
             </template>
           </div>
           <div
@@ -59,11 +63,15 @@
             class="mt-0.5 flex flex-wrap items-center gap-x-3 text-xs text-muted-foreground"
           >
             <span v-if="entry.detail" class="truncate">{{ entry.detail }}</span>
-            <span v-if="entry.ipAddress" class="shrink-0 tabular-nums">{{ entry.ipAddress }}</span>
+            <span
+              v-if="entry.ipAddress"
+              class="shrink-0 tabular-nums font-mono text-[11px] bg-muted/60 px-1.5 py-0.5 rounded"
+              >{{ entry.ipAddress }}</span
+            >
           </div>
         </div>
 
-        <span class="shrink-0 text-xs text-muted-foreground tabular-nums">
+        <span class="shrink-0 text-xs text-muted-foreground tabular-nums font-medium">
           {{ formatDateTime(entry.createdAt) }}
         </span>
       </div>
@@ -110,19 +118,26 @@ import IconClock from "~icons/fa6-solid/clock-rotate-left";
 import { computed, onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import { RouterLink } from "vue-router";
+import { useAdminListQuery } from "@/composables/useAdminListQuery";
 
 const { t } = useI18n();
+
+const {
+  page: currentPage,
+  filters,
+  syncToUrl,
+} = useAdminListQuery({
+  page: 1,
+  filters: {
+    action: "",
+  },
+});
 
 const entries = ref<AuditLogEntry[]>([]);
 const loading = ref(true);
 const error = ref("");
-const currentPage = ref(1);
 const pageSize = 50;
 const total = ref(0);
-
-const filters = ref<Record<string, string>>({
-  action: "",
-});
 
 const totalPages = computed(() => Math.ceil(total.value / pageSize));
 
@@ -199,11 +214,13 @@ async function loadEntries() {
 
 function onFilterChange() {
   currentPage.value = 1;
+  syncToUrl();
   loadEntries();
 }
 
 function changePage(page: number) {
   currentPage.value = page;
+  syncToUrl();
   loadEntries();
 }
 

--- a/frontend/src/views/admin/ListAuditLog.vue
+++ b/frontend/src/views/admin/ListAuditLog.vue
@@ -115,7 +115,7 @@ import { Button } from "@/components/ui/button";
 import { adminGetAuditLog, type AdminAuditLogEntry as AuditLogEntry } from "@/api/generated";
 import { formatDateTime } from "@/helpers/formatter";
 import IconClock from "~icons/fa6-solid/clock-rotate-left";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import { RouterLink } from "vue-router";
 import { useAdminListQuery } from "@/composables/useAdminListQuery";
@@ -125,6 +125,7 @@ const { t } = useI18n();
 const {
   page: currentPage,
   filters,
+  revision,
   syncToUrl,
 } = useAdminListQuery({
   page: 1,
@@ -223,6 +224,10 @@ function changePage(page: number) {
   syncToUrl();
   loadEntries();
 }
+
+watch(revision, () => {
+  loadEntries();
+});
 
 onMounted(() => {
   loadEntries();

--- a/frontend/src/views/admin/ListEnvironments.vue
+++ b/frontend/src/views/admin/ListEnvironments.vue
@@ -16,6 +16,10 @@
       <AlertDescription>{{ error }}</AlertDescription>
     </Alert>
 
+    <div v-if="!loading && !error" class="mb-3 text-sm text-muted-foreground">
+      {{ $t("admin.resultCount", { count: totalEnvironments }) }}
+    </div>
+
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center gap-2 py-12 text-muted-foreground">
       <icon-line-md:loading-twotone-loop class="size-5" />
@@ -27,31 +31,34 @@
       <div
         v-for="env in environments"
         :key="env.id"
-        class="flex items-center gap-4 rounded-xl border bg-card px-4 py-3"
+        class="group flex items-center gap-4 rounded-xl border bg-card px-4 py-3.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-sm"
       >
-        <StatusIcon :status="env.status" class="shrink-0" />
+        <StatusIcon
+          :status="env.status"
+          class="shrink-0 transition-transform group-hover:scale-110"
+        />
 
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
             <RouterLink
               :to="{ name: 'admin.environments.detail', params: { id: env.id } }"
-              class="truncate font-medium hover:text-primary transition-colors"
+              class="truncate font-semibold hover:text-primary transition-colors"
             >
               {{ env.name }}
             </RouterLink>
-            <Badge variant="secondary" class="font-mono text-[10px]">{{
+            <Badge variant="secondary" class="font-mono text-[10px] font-semibold">{{
               env.shopwareVersion
             }}</Badge>
           </div>
           <div class="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
             <RouterLink
               :to="{ name: 'admin.organizations.detail', params: { id: env.organizationId } }"
-              class="hover:text-primary transition-colors"
+              class="font-medium hover:text-primary transition-colors"
             >
               {{ env.organizationName }}
             </RouterLink>
             <span v-if="env.shopName" class="flex items-center gap-1">
-              <icon-fa6-solid:store class="size-2.5" />
+              <icon-fa6-solid:store class="size-3 text-muted-foreground" />
               {{ env.shopName }}
             </span>
             <span v-if="env.lastScrapedAt" class="hidden tabular-nums sm:inline">{{
@@ -63,9 +70,10 @@
         <a
           :href="env.url"
           target="_blank"
-          class="shrink-0 text-muted-foreground hover:text-foreground"
+          class="shrink-0 p-1.5 rounded-lg text-muted-foreground hover:bg-accent hover:text-primary transition-colors"
+          title="Open environment URL"
         >
-          <icon-fa6-solid:arrow-up-right-from-square class="size-3" />
+          <icon-fa6-solid:arrow-up-right-from-square class="size-3.5" />
         </a>
       </div>
     </div>
@@ -122,6 +130,7 @@ import {
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
 import { computed, onMounted, ref } from "vue";
+import { useAdminListQuery } from "@/composables/useAdminListQuery";
 
 type SortBy =
   | "createdAt"
@@ -132,22 +141,29 @@ type SortBy =
   | "lastScrapedAt"
   | "organizationName";
 
+const {
+  search: searchQuery,
+  page: currentPage,
+  filters,
+  syncToUrl,
+} = useAdminListQuery({
+  search: "",
+  page: 1,
+  filters: {
+    sortBy: "createdAt",
+  },
+});
+
 const environments = ref<Environment[]>([]);
 const loading = ref(true);
 const error = ref("");
-const searchQuery = ref("");
 const sortDirection = ref<"asc" | "desc">("desc");
-const currentPage = ref(1);
 const pageSize = ref(20);
 const totalEnvironments = ref(0);
 
 const { t } = useI18n();
 
 const totalPages = computed(() => Math.ceil(totalEnvironments.value / pageSize.value));
-
-const filters = ref<Record<string, string>>({
-  sortBy: "createdAt",
-});
 
 const filterGroups = computed<FilterGroup[]>(() => [
   {
@@ -208,11 +224,13 @@ async function loadEnvironments() {
 
 function onFilterChange() {
   currentPage.value = 1;
+  syncToUrl();
   loadEnvironments();
 }
 
 function changePage(page: number) {
   currentPage.value = page;
+  syncToUrl();
   loadEnvironments();
 }
 
@@ -221,6 +239,7 @@ function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
     currentPage.value = 1;
+    syncToUrl();
     loadEnvironments();
   }, 300);
 }

--- a/frontend/src/views/admin/ListEnvironments.vue
+++ b/frontend/src/views/admin/ListEnvironments.vue
@@ -129,7 +129,7 @@ import {
 } from "@/api/generated";
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useAdminListQuery } from "@/composables/useAdminListQuery";
 
 type SortBy =
@@ -145,6 +145,7 @@ const {
   search: searchQuery,
   page: currentPage,
   filters,
+  revision,
   syncToUrl,
 } = useAdminListQuery({
   search: "",
@@ -222,7 +223,10 @@ async function loadEnvironments() {
   }
 }
 
+let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+
 function onFilterChange() {
+  clearTimeout(searchTimeout);
   currentPage.value = 1;
   syncToUrl();
   loadEnvironments();
@@ -234,7 +238,6 @@ function changePage(page: number) {
   loadEnvironments();
 }
 
-let searchTimeout: ReturnType<typeof setTimeout>;
 function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
@@ -243,6 +246,10 @@ function debouncedSearch() {
     loadEnvironments();
   }, 300);
 }
+
+watch(revision, () => {
+  loadEnvironments();
+});
 
 onMounted(() => {
   loadEnvironments();

--- a/frontend/src/views/admin/ListOrganizations.vue
+++ b/frontend/src/views/admin/ListOrganizations.vue
@@ -16,6 +16,10 @@
       <AlertDescription>{{ error }}</AlertDescription>
     </Alert>
 
+    <div v-if="!loading && !error" class="mb-3 text-sm text-muted-foreground">
+      {{ $t("admin.resultCount", { count: totalOrganizations }) }}
+    </div>
+
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center gap-2 py-12 text-muted-foreground">
       <icon-line-md:loading-twotone-loop class="size-5" />
@@ -28,29 +32,34 @@
         v-for="org in organizations"
         :key="org.id"
         :to="{ name: 'admin.organizations.detail', params: { id: org.id } }"
-        class="group flex items-center gap-4 rounded-xl border bg-card px-4 py-3 transition-all duration-200 hover:border-primary/30 hover:shadow-sm"
+        class="group flex items-center gap-4 rounded-xl border bg-card px-4 py-3.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-sm"
       >
-        <div class="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted">
+        <div
+          class="flex size-10 shrink-0 items-center justify-center rounded-lg border bg-muted transition-transform group-hover:scale-105"
+        >
           <img
             v-if="org.logo"
             :src="org.logo"
             :alt="org.name"
             class="size-7 rounded object-cover"
           />
-          <icon-fa6-solid:building v-else class="size-4 text-muted-foreground" />
+          <icon-fa6-solid:building
+            v-else
+            class="size-4 text-muted-foreground group-hover:text-primary transition-colors"
+          />
         </div>
 
         <div class="min-w-0 flex-1">
-          <div class="truncate font-medium transition-colors group-hover:text-primary">
+          <div class="truncate font-semibold transition-colors group-hover:text-primary">
             {{ org.name }}
           </div>
           <div class="mt-0.5 flex items-center gap-3 text-xs text-muted-foreground">
-            <span class="flex items-center gap-1">
-              <icon-fa6-solid:earth-americas class="size-2.5" />
+            <span class="flex items-center gap-1 font-medium">
+              <icon-fa6-solid:earth-americas class="size-3 text-emerald-500" />
               {{ org.environmentCount }}
             </span>
-            <span class="flex items-center gap-1">
-              <icon-fa6-solid:users class="size-2.5" />
+            <span class="flex items-center gap-1 font-medium">
+              <icon-fa6-solid:users class="size-3 text-indigo-500" />
               {{ org.memberCount }}
             </span>
             <span class="hidden tabular-nums sm:inline">{{ formatDate(org.createdAt) }}</span>
@@ -58,7 +67,7 @@
         </div>
 
         <icon-fa6-solid:chevron-right
-          class="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+          class="size-3.5 shrink-0 text-muted-foreground opacity-30 transition-all duration-150 group-hover:opacity-100 group-hover:translate-x-0.5 group-hover:text-primary"
         />
       </RouterLink>
     </div>
@@ -113,19 +122,27 @@ import {
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
 import { computed, onMounted, ref } from "vue";
+import { useAdminListQuery } from "@/composables/useAdminListQuery";
+
+const {
+  search: searchQuery,
+  page: currentPage,
+  filters,
+  syncToUrl,
+} = useAdminListQuery({
+  search: "",
+  page: 1,
+  filters: {
+    sortBy: "createdAt",
+  },
+});
 
 const organizations = ref<Organization[]>([]);
 const loading = ref(true);
 const error = ref("");
-const searchQuery = ref("");
 const sortDirection = ref<"asc" | "desc">("desc");
-const currentPage = ref(1);
 const pageSize = ref(20);
 const totalOrganizations = ref(0);
-
-const filters = ref<Record<string, string>>({
-  sortBy: "createdAt",
-});
 
 const totalPages = computed(() => Math.ceil(totalOrganizations.value / pageSize.value));
 const { t } = useI18n();
@@ -187,11 +204,13 @@ async function loadOrganizations() {
 
 function onFilterChange() {
   currentPage.value = 1;
+  syncToUrl();
   loadOrganizations();
 }
 
 function changePage(page: number) {
   currentPage.value = page;
+  syncToUrl();
   loadOrganizations();
 }
 
@@ -200,6 +219,7 @@ function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
     currentPage.value = 1;
+    syncToUrl();
     loadOrganizations();
   }, 300);
 }

--- a/frontend/src/views/admin/ListOrganizations.vue
+++ b/frontend/src/views/admin/ListOrganizations.vue
@@ -121,13 +121,14 @@ import {
 } from "@/api/generated";
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useAdminListQuery } from "@/composables/useAdminListQuery";
 
 const {
   search: searchQuery,
   page: currentPage,
   filters,
+  revision,
   syncToUrl,
 } = useAdminListQuery({
   search: "",
@@ -202,7 +203,10 @@ async function loadOrganizations() {
   }
 }
 
+let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+
 function onFilterChange() {
+  clearTimeout(searchTimeout);
   currentPage.value = 1;
   syncToUrl();
   loadOrganizations();
@@ -214,7 +218,6 @@ function changePage(page: number) {
   loadOrganizations();
 }
 
-let searchTimeout: ReturnType<typeof setTimeout>;
 function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
@@ -223,6 +226,10 @@ function debouncedSearch() {
     loadOrganizations();
   }, 300);
 }
+
+watch(revision, () => {
+  loadOrganizations();
+});
 
 onMounted(() => {
   loadOrganizations();

--- a/frontend/src/views/admin/ListUsers.vue
+++ b/frontend/src/views/admin/ListUsers.vue
@@ -16,6 +16,10 @@
       <AlertDescription>{{ error }}</AlertDescription>
     </Alert>
 
+    <div v-if="!loading && !error" class="mb-3 text-sm text-muted-foreground">
+      {{ $t("admin.resultCount", { count: totalUsers }) }}
+    </div>
+
     <!-- Loading -->
     <div v-if="loading" class="flex items-center justify-center gap-2 py-12 text-muted-foreground">
       <icon-line-md:loading-twotone-loop class="size-5" />
@@ -28,22 +32,24 @@
         v-for="user in users"
         :key="user.id"
         :to="{ name: 'admin.users.detail', params: { id: user.id } }"
-        class="group flex items-center gap-4 rounded-xl border bg-card px-4 py-3 transition-all duration-200 hover:border-primary/30 hover:shadow-sm"
+        class="group flex items-center gap-4 rounded-xl border bg-card px-4 py-3.5 transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:shadow-sm"
       >
         <!-- Avatar -->
-        <div class="flex size-9 shrink-0 items-center justify-center rounded-full bg-primary/10">
-          <icon-fa6-solid:user class="size-3.5 text-primary" />
+        <div
+          class="flex size-10 shrink-0 items-center justify-center rounded-full bg-primary/10 transition-transform group-hover:scale-105"
+        >
+          <icon-fa6-solid:user class="size-4 text-primary" />
         </div>
 
         <!-- Info -->
         <div class="min-w-0 flex-1">
           <div class="flex items-center gap-2">
-            <span class="truncate font-medium transition-colors group-hover:text-primary">{{
+            <span class="truncate font-semibold transition-colors group-hover:text-primary">{{
               user.name
             }}</span>
             <Badge
               v-if="user.role === 'admin'"
-              class="bg-primary/10 text-primary border-primary/20 text-[10px]"
+              class="bg-primary/10 text-primary border-primary/20 text-[10px] font-bold uppercase tracking-wider"
               >{{ $t("admin.roleAdmin") }}</Badge
             >
           </div>
@@ -59,24 +65,30 @@
         <div class="hidden shrink-0 sm:block">
           <Badge
             v-if="user.banned"
-            class="bg-destructive/10 text-destructive border-destructive/20 text-xs"
+            class="inline-flex items-center gap-1.5 bg-destructive/10 text-destructive border-destructive/20 text-xs px-2.5 py-0.5"
           >
+            <span class="size-1.5 rounded-full bg-destructive animate-pulse" />
             {{ $t("admin.banned") }}
           </Badge>
           <Badge
             v-else-if="!user.emailVerified"
-            class="bg-warning/10 text-warning border-warning/20 text-xs"
+            class="inline-flex items-center gap-1.5 bg-warning/10 text-amber-600 dark:text-amber-400 border-amber-500/20 text-xs px-2.5 py-0.5"
           >
+            <span class="size-1.5 rounded-full bg-amber-500" />
             {{ $t("admin.unverified") }}
           </Badge>
-          <Badge v-else class="bg-success/10 text-success border-success/20 text-xs">
+          <Badge
+            v-else
+            class="inline-flex items-center gap-1.5 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 border-emerald-500/20 text-xs px-2.5 py-0.5"
+          >
+            <span class="size-1.5 rounded-full bg-emerald-500" />
             {{ $t("admin.active") }}
           </Badge>
         </div>
 
         <!-- Chevron -->
         <icon-fa6-solid:chevron-right
-          class="size-3 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100"
+          class="size-3.5 shrink-0 text-muted-foreground opacity-30 transition-all duration-150 group-hover:opacity-100 group-hover:translate-x-0.5 group-hover:text-primary"
         />
       </RouterLink>
     </div>
@@ -128,20 +140,28 @@ import { adminListUsers, type AdminListUsersData, type AdminUser as User } from 
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
 import { computed, onMounted, ref } from "vue";
+import { useAdminListQuery } from "@/composables/useAdminListQuery";
+
+const {
+  search: searchQuery,
+  page: currentPage,
+  filters,
+  syncToUrl,
+} = useAdminListQuery({
+  search: "",
+  page: 1,
+  filters: {
+    role: "all",
+    status: "all",
+    sortBy: "createdAt",
+  },
+});
 
 const users = ref<User[]>([]);
 const loading = ref(true);
 const error = ref("");
-const searchQuery = ref("");
-const currentPage = ref(1);
 const pageSize = ref(20);
 const totalUsers = ref(0);
-
-const filters = ref<Record<string, string>>({
-  role: "all",
-  status: "all",
-  sortBy: "createdAt",
-});
 
 const totalPages = computed(() => Math.ceil(totalUsers.value / pageSize.value));
 const { t } = useI18n();
@@ -235,11 +255,13 @@ async function loadUsers() {
 
 function onFilterChange() {
   currentPage.value = 1;
+  syncToUrl();
   loadUsers();
 }
 
 function changePage(page: number) {
   currentPage.value = page;
+  syncToUrl();
   loadUsers();
 }
 
@@ -248,6 +270,7 @@ function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
     currentPage.value = 1;
+    syncToUrl();
     loadUsers();
   }, 300);
 }

--- a/frontend/src/views/admin/ListUsers.vue
+++ b/frontend/src/views/admin/ListUsers.vue
@@ -139,13 +139,14 @@ import { Button } from "@/components/ui/button";
 import { adminListUsers, type AdminListUsersData, type AdminUser as User } from "@/api/generated";
 import { formatDate } from "@/helpers/formatter";
 import { useI18n } from "vue-i18n";
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import { useAdminListQuery } from "@/composables/useAdminListQuery";
 
 const {
   search: searchQuery,
   page: currentPage,
   filters,
+  revision,
   syncToUrl,
 } = useAdminListQuery({
   search: "",
@@ -253,7 +254,10 @@ async function loadUsers() {
   }
 }
 
+let searchTimeout: ReturnType<typeof setTimeout> | undefined;
+
 function onFilterChange() {
+  clearTimeout(searchTimeout);
   currentPage.value = 1;
   syncToUrl();
   loadUsers();
@@ -265,7 +269,6 @@ function changePage(page: number) {
   loadUsers();
 }
 
-let searchTimeout: ReturnType<typeof setTimeout>;
 function debouncedSearch() {
   clearTimeout(searchTimeout);
   searchTimeout = setTimeout(() => {
@@ -274,6 +277,10 @@ function debouncedSearch() {
     loadUsers();
   }, 300);
 }
+
+watch(revision, () => {
+  loadUsers();
+});
 
 onMounted(() => {
   loadUsers();


### PR DESCRIPTION
## Summary
This PR brings comprehensive UI/UX polish and administrative data surface enhancements to the Shopmon Administration area (`/admin/*`).

### 🎨 Key Improvements
1. **Admin Header & Navigation (`AdminLayout.vue`)**:
   - Added stylized `ADMIN` badge next to logo and highlighted active tab pill.
   - Integrated dark mode toggle button directly into top navigation bar with backdrop blur.
2. **Admin Dashboard (`Dashboard.vue`)**:
   - Upgraded KPI stat cards with colored icon backgrounds (`indigo`, `sky`, `emerald`, `rose`) and status count pills.
   - Refined Chart.js area charts with smooth linear gradients, curved tension (`0.4`), and zero-gridlines layout.
   - Removed obsolete bottom quick actions button row in favor of header navigation & direct activity links.
3. **Filter Controls (`AdminFilterSidebar.vue`)**:
   - Added instant clear search button (`×`) and active category indicator badges.
4. **List Views & Status Indicators (`ListUsers.vue`, `ListOrganizations.vue`, `ListEnvironments.vue`, `ListAuditLog.vue`)**:
   - Added visual status dots (active green, banned red pulse, unverified amber) and hover card elevation effects (`hover:-translate-y-0.5 hover:shadow-sm`).
5. **Detail Views Information Polish (`DetailUser.vue`, `DetailOrganization.vue`, `DetailEnvironment.vue`)**:
   - **Breadcrumb Navigation**: Added breadcrumb trail on all detail pages.
   - **User Detail**: Surfaced `banReason`, `banExpires` in a dedicated Alert banner when a user is suspended, plus `emailVerified` badge.
   - **Environment Detail**: Added `connectionIssueCount` warning banner and upgraded health check level badges to color-coded pass/warning/error pills with dots.
   - **Organization Detail**: Surfaced invitation expiration and inviter context alongside custom OIDC SSO provider details.

### ✅ Verification
- `mise run lint`: **0 issues** (`oxfmt`, `vue-tsc`, `oxlint`, Vitest unit tests).
- `mise run test`: Go API integration tests passed cleanly.