### PR TITLE
feat: send Shopmon User-Agent on outbound HTTP requests

### DIFF
--- a/api/internal/httputil/client.go
+++ b/api/internal/httputil/client.go
@@ -6,16 +6,109 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime/debug"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// NewHTTPClient returns an HTTP client with OpenTelemetry transport instrumentation.
+// UserAgent identifies Shopmon in outbound HTTP requests so operators can
+// whitelist monitoring traffic without relying on Go's default client UA.
+// Prefer UserAgentString() when a versioned value is needed.
+const UserAgent = "Shopmon"
+
+var (
+	userAgentOnce   sync.Once
+	userAgentCached string
+)
+
+// UserAgentString returns "Shopmon/<version>" when a build version is available,
+// otherwise the bare "Shopmon" product name. The version comes from the same
+// VCS revision embedded by the Go toolchain that config.buildVersion uses.
+func UserAgentString() string {
+	userAgentOnce.Do(func() {
+		userAgentCached = buildUserAgent(buildVersion())
+	})
+	return userAgentCached
+}
+
+func buildUserAgent(version string) string {
+	if version == "" {
+		return UserAgent
+	}
+	return UserAgent + "/" + version
+}
+
+// buildVersion returns the short VCS revision the binary was built from, or ""
+// when build info is unavailable (e.g. go run / tests without -buildvcs).
+func buildVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	var revision string
+	var modified bool
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value == "true"
+		}
+	}
+	if revision == "" {
+		return ""
+	}
+	if len(revision) > 12 {
+		revision = revision[:12]
+	}
+	if modified {
+		revision += "-dirty"
+	}
+	return revision
+}
+
+// userAgentTransport injects the Shopmon User-Agent on every outbound request
+// unless the caller already set one explicitly.
+type userAgentTransport struct {
+	base http.RoundTripper
+	ua   string
+}
+
+func (t *userAgentTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("User-Agent") == "" {
+		// Clone so we never mutate a request the caller still holds.
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", t.ua)
+	}
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(req)
+}
+
+// wrapTransport adds the Shopmon User-Agent and OpenTelemetry instrumentation.
+// Order: application -> userAgent -> otelhttp -> base, so the User-Agent is set
+// before tracing observes the request and still applies when a custom base is used.
+func wrapTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &userAgentTransport{
+		base: otelhttp.NewTransport(base),
+		ua:   UserAgentString(),
+	}
+}
+
+// NewHTTPClient returns an HTTP client with OpenTelemetry transport
+// instrumentation and the Shopmon User-Agent set on every request.
 func NewHTTPClient(opts ...func(*http.Client)) *http.Client {
 	c := &http.Client{
-		Transport: otelhttp.NewTransport(http.DefaultTransport),
+		Transport: wrapTransport(http.DefaultTransport),
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -87,7 +180,7 @@ func NewSSRFSafeHTTPClient(timeout time.Duration) *http.Client {
 
 	return &http.Client{
 		Timeout:   timeout,
-		Transport: otelhttp.NewTransport(transport),
+		Transport: wrapTransport(transport),
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects")

--- a/api/internal/httputil/client_test.go
+++ b/api/internal/httputil/client_test.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -121,8 +122,9 @@ func TestNewHTTPClientSetsUserAgent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	client := NewHTTPClient()
-	resp, err := client.Get(srv.URL)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := NewHTTPClient().Do(req)
 	require.NoError(t, err)
 	defer func() { _ = resp.Body.Close() }()
 
@@ -140,7 +142,7 @@ func TestNewHTTPClientPreservesExplicitUserAgent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
 	require.NoError(t, err)
 	req.Header.Set("User-Agent", "CustomAgent/9.9")
 
@@ -164,7 +166,7 @@ func TestUserAgentTransportInjectsHeader(t *testing.T) {
 	})
 
 	rt := &userAgentTransport{base: base, ua: "Shopmon/test"}
-	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://example.com/", nil)
 	require.NoError(t, err)
 	resp, err := rt.RoundTrip(req)
 	require.NoError(t, err)

--- a/api/internal/httputil/client_test.go
+++ b/api/internal/httputil/client_test.go
@@ -2,6 +2,9 @@ package httputil
 
 import (
 	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -87,4 +90,94 @@ func TestClientForURL_PerURLSelection(t *testing.T) {
 		// ClientForURL must return a non-nil client for every URL.
 		assert.NotNil(t, ClientForURL(c.url, 0), "ClientForURL(%q) returned nil", c.url)
 	}
+}
+
+func TestBuildUserAgent(t *testing.T) {
+	assert.Equal(t, "Shopmon", buildUserAgent(""))
+	assert.Equal(t, "Shopmon/1.2.3", buildUserAgent("1.2.3"))
+	assert.Equal(t, "Shopmon/abcdef012345", buildUserAgent("abcdef012345"))
+}
+
+func TestUserAgentStringFormat(t *testing.T) {
+	ua := UserAgentString()
+	require.True(t, strings.HasPrefix(ua, "Shopmon"), "User-Agent must start with Shopmon, got %q", ua)
+	// Either bare product name or Shopmon/<version> — never the Go default.
+	assert.NotContains(t, ua, "Go-http-client")
+	if strings.Contains(ua, "/") {
+		parts := strings.SplitN(ua, "/", 2)
+		require.Len(t, parts, 2)
+		assert.Equal(t, "Shopmon", parts[0])
+		assert.NotEmpty(t, parts[1])
+	} else {
+		assert.Equal(t, "Shopmon", ua)
+	}
+}
+
+func TestNewHTTPClientSetsUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	client := NewHTTPClient()
+	resp, err := client.Get(srv.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	require.NotEmpty(t, gotUA, "expected User-Agent header on outbound request")
+	assert.True(t, strings.HasPrefix(gotUA, "Shopmon"), "got User-Agent %q", gotUA)
+	assert.NotContains(t, gotUA, "Go-http-client")
+	assert.Equal(t, UserAgentString(), gotUA)
+}
+
+func TestNewHTTPClientPreservesExplicitUserAgent(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("User-Agent", "CustomAgent/9.9")
+
+	resp, err := NewHTTPClient().Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "CustomAgent/9.9", gotUA)
+}
+
+func TestUserAgentTransportInjectsHeader(t *testing.T) {
+	var gotUA string
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		gotUA = req.Header.Get("User-Agent")
+		return &http.Response{
+			StatusCode: http.StatusNoContent,
+			Body:       http.NoBody,
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+
+	rt := &userAgentTransport{base: base, ua: "Shopmon/test"}
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, "Shopmon/test", gotUA)
+	// Original request must not be mutated.
+	assert.Empty(t, req.Header.Get("User-Agent"))
+}
+
+// roundTripFunc is a test helper implementing http.RoundTripper.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/api/internal/shopware/client_test.go
+++ b/api/internal/shopware/client_test.go
@@ -250,8 +250,8 @@ func TestRequestHonorsContextCancellation(t *testing.T) {
 func TestClientSendsShopmonUserAgent(t *testing.T) {
 	var tokenUA, apiUA string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/oauth/token":
+		switch r.URL.Path {
+		case "/api/oauth/token":
 			tokenUA = r.Header.Get("User-Agent")
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600})

--- a/api/internal/shopware/client_test.go
+++ b/api/internal/shopware/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -244,4 +245,30 @@ func TestRequestHonorsContextCancellation(t *testing.T) {
 
 	_, err := c.Get(ctx, "/_info/config")
 	require.Error(t, err, "expected error from cancelled context")
+}
+
+func TestClientSendsShopmonUserAgent(t *testing.T) {
+	var tokenUA, apiUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/oauth/token":
+			tokenUA = r.Header.Get("User-Agent")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tokenResponse{AccessToken: "tok", ExpiresIn: 3600})
+		default:
+			apiUA = r.Header.Get("User-Agent")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		}
+	}))
+	defer srv.Close()
+
+	c := newTestClient(srv.URL)
+	_, err := c.Get(context.Background(), "/_info/config")
+	require.NoError(t, err)
+
+	require.True(t, strings.HasPrefix(tokenUA, "Shopmon"), "token request User-Agent = %q", tokenUA)
+	require.True(t, strings.HasPrefix(apiUA, "Shopmon"), "API request User-Agent = %q", apiUA)
+	assert.NotContains(t, tokenUA, "Go-http-client")
+	assert.NotContains(t, apiUA, "Go-http-client")
 }


### PR DESCRIPTION
## Summary
- Set a unique `Shopmon/<version>` (or `Shopmon`) User-Agent on all outbound HTTP clients via `httputil.NewHTTPClient` / `NewSSRFSafeHTTPClient`
- Avoids relying on Go's default `Go-http-client/2.0`, so rate-limit/firewall whitelists can target Shopmon specifically
- Version is derived from the embedded VCS revision (same source as OTEL service version)

## Tests
- `TestBuildUserAgent`, `TestUserAgentStringFormat`, `TestNewHTTPClientSetsUserAgent`, `TestNewHTTPClientPreservesExplicitUserAgent`, `TestUserAgentTransportInjectsHeader`
- `TestClientSendsShopmonUserAgent` on the Shopware admin API client (token + API requests)

Closes #765