### PR TITLE
fix: environment changelogs only load the latest 10

### DIFF
--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -298,7 +298,7 @@ func (q *Queries) GetEnvironmentCache(ctx context.Context, environmentID int32) 
 
 const getEnvironmentChangelogs = `-- name: GetEnvironmentChangelogs :many
 SELECT id, environment_id, extensions, old_shopware_version, new_shopware_version, date
-FROM environment_changelog WHERE environment_id = $1 ORDER BY date DESC LIMIT 10
+FROM environment_changelog WHERE environment_id = $1 ORDER BY date DESC
 `
 
 func (q *Queries) GetEnvironmentChangelogs(ctx context.Context, environmentID *int32) ([]EnvironmentChangelog, error) {

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -91,7 +91,7 @@ FROM environment_sitespeed WHERE environment_id = $1 ORDER BY created_at DESC LI
 
 -- name: GetEnvironmentChangelogs :many
 SELECT id, environment_id, extensions, old_shopware_version, new_shopware_version, date
-FROM environment_changelog WHERE environment_id = $1 ORDER BY date DESC LIMIT 10;
+FROM environment_changelog WHERE environment_id = $1 ORDER BY date DESC;
 
 -- name: CountEnvironmentDeployments :one
 SELECT COUNT(*)::int FROM deployment WHERE environment_id = $1;


### PR DESCRIPTION
Currently the environment changelogs only show the last 10 results. Better to load all results. For the feature we can add paging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Environment changelogs now display the complete history, with the newest entries shown first, instead of limiting results to the latest 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->