### PR TITLE
fix: stop unreachable check sources from flapping status notifications

### DIFF
--- a/api/internal/monitoring/scrape/notify.go
+++ b/api/internal/monitoring/scrape/notify.go
@@ -121,20 +121,16 @@ func (h *Service) handleStatusTransition(ctx context.Context, env queries.GetAll
 }
 
 // carryOverChecks returns the previously persisted checks that belong to a
-// source the current run could not evaluate and that the run did not re-report.
+// check group the current run could not evaluate and that the run did not
+// re-report.
 //
 // A source is only reported unavailable when its data was unreachable, so its
 // findings are unknown rather than resolved. Dropping them would flip the
 // environment to green and mail out a recovery, then flip it back on the next
 // successful scrape — one upstream hiccup, two misleading emails.
-func carryOverChecks(oldChecks []queries.EnvironmentCheck, newChecks []checker.Check, unavailable []string) []checker.Check {
+func carryOverChecks(oldChecks []queries.EnvironmentCheck, newChecks []checker.Check, unavailable []checker.UnavailableSource) []checker.Check {
 	if len(oldChecks) == 0 || len(unavailable) == 0 {
 		return nil
-	}
-
-	unavailableSources := make(map[string]bool, len(unavailable))
-	for _, source := range unavailable {
-		unavailableSources[source] = true
 	}
 
 	reported := make(map[string]bool, len(newChecks))
@@ -142,16 +138,28 @@ func carryOverChecks(oldChecks []queries.EnvironmentCheck, newChecks []checker.C
 		reported[c.ID] = true
 	}
 
+	unevaluated := func(c queries.EnvironmentCheck) bool {
+		for _, u := range unavailable {
+			if u.Owns(c.Source, c.CheckID) {
+				return true
+			}
+		}
+		return false
+	}
+
 	carried := make([]checker.Check, 0, len(oldChecks))
 	for _, c := range oldChecks {
-		if !unavailableSources[c.Source] || reported[c.CheckID] {
+		if !unevaluated(c) || reported[c.CheckID] {
 			continue
 		}
 		link := ""
 		if c.Link != nil {
 			link = *c.Link
 		}
-		messageKey := ""
+		// Rows written before checks moved to translation keys carry only the
+		// rendered English message; fall back to it the way computeStatusReasons
+		// does, so a carry-over never blanks a check's text.
+		messageKey := c.Message
 		if c.MessageKey != nil {
 			messageKey = *c.MessageKey
 		}

--- a/api/internal/monitoring/scrape/notify.go
+++ b/api/internal/monitoring/scrape/notify.go
@@ -120,6 +120,53 @@ func (h *Service) handleStatusTransition(ctx context.Context, env queries.GetAll
 	return &statusTransition{oldStatus: oldStatus, newStatus: newStatus, reasons: reasons}
 }
 
+// carryOverChecks returns the previously persisted checks that belong to a
+// source the current run could not evaluate and that the run did not re-report.
+//
+// A source is only reported unavailable when its data was unreachable, so its
+// findings are unknown rather than resolved. Dropping them would flip the
+// environment to green and mail out a recovery, then flip it back on the next
+// successful scrape — one upstream hiccup, two misleading emails.
+func carryOverChecks(oldChecks []queries.EnvironmentCheck, newChecks []checker.Check, unavailable []string) []checker.Check {
+	if len(oldChecks) == 0 || len(unavailable) == 0 {
+		return nil
+	}
+
+	unavailableSources := make(map[string]bool, len(unavailable))
+	for _, source := range unavailable {
+		unavailableSources[source] = true
+	}
+
+	reported := make(map[string]bool, len(newChecks))
+	for _, c := range newChecks {
+		reported[c.ID] = true
+	}
+
+	carried := make([]checker.Check, 0, len(oldChecks))
+	for _, c := range oldChecks {
+		if !unavailableSources[c.Source] || reported[c.CheckID] {
+			continue
+		}
+		link := ""
+		if c.Link != nil {
+			link = *c.Link
+		}
+		messageKey := ""
+		if c.MessageKey != nil {
+			messageKey = *c.MessageKey
+		}
+		carried = append(carried, checker.Check{
+			ID:            c.CheckID,
+			Level:         checker.Status(c.Level),
+			MessageKey:    messageKey,
+			MessageParams: decodeParams(c.Params),
+			Source:        c.Source,
+			Link:          link,
+		})
+	}
+	return carried
+}
+
 // checkWeight orders check levels for comparison (higher is worse).
 func checkWeight(level string) int {
 	switch level {

--- a/api/internal/monitoring/scrape/notify_test.go
+++ b/api/internal/monitoring/scrape/notify_test.go
@@ -78,6 +78,8 @@ func TestComputeStatusReasonsNoChange(t *testing.T) {
 	}
 }
 
+var froshUnavailable = checker.UnavailableSource{Source: checker.SourceFroshTools, IDPrefix: "frosh."}
+
 func sourcedCheck(id, level, source string) queries.EnvironmentCheck {
 	c := oldCheck(id, level)
 	c.Source = source
@@ -94,7 +96,7 @@ func TestCarryOverChecksKeepsUnavailableSourceFindings(t *testing.T) {
 	// The Shopware checks were re-evaluated; FroshTools timed out.
 	now := []checker.Check{newCheck("shopware.env", "green")}
 
-	carried := carryOverChecks(old, now, []string{checker.SourceFroshTools})
+	carried := carryOverChecks(old, now, []checker.UnavailableSource{froshUnavailable})
 	if len(carried) != 2 {
 		t.Fatalf("expected both FroshTools checks carried over, got %d: %+v", len(carried), carried)
 	}
@@ -134,7 +136,7 @@ func TestCarryOverChecksSkipsRereportedChecks(t *testing.T) {
 	// Health responded (phpGood now green), performance did not.
 	now := []checker.Check{newCheck("frosh.phpGood", "green")}
 
-	carried := carryOverChecks(old, now, []string{checker.SourceFroshTools})
+	carried := carryOverChecks(old, now, []checker.UnavailableSource{froshUnavailable})
 	if len(carried) != 1 || carried[0].ID != "frosh.cacheWarning" {
 		t.Fatalf("expected only the unreported check carried over, got %+v", carried)
 	}
@@ -145,5 +147,50 @@ func TestCarryOverChecksWithoutUnavailableSources(t *testing.T) {
 
 	if carried := carryOverChecks(old, nil, nil); len(carried) != 0 {
 		t.Fatalf("expected nothing carried over when every source was evaluated, got %+v", carried)
+	}
+}
+
+// Several checkers report under SourceShopware. When only one of them loses its
+// data, the others were still evaluated, so their vanished findings are real
+// resolutions and must not be resurrected.
+func TestCarryOverChecksDoesNotCrossDatasets(t *testing.T) {
+	old := []queries.EnvironmentCheck{
+		sourcedCheck("task.product_export", "yellow", checker.SourceShopware),
+		sourcedCheck("shopware.env", "yellow", checker.SourceShopware),
+		sourcedCheck("admin.worker", "yellow", checker.SourceShopware),
+	}
+	// The cache info fetch failed, so only shopware.env is unknown. The task
+	// checker ran and reported everything on schedule; the worker checker ran
+	// and reported the admin worker disabled.
+	now := []checker.Check{newCheck("task.all", "green"), newCheck("admin.worker", "green")}
+	unavailable := []checker.UnavailableSource{{Source: checker.SourceShopware, IDPrefix: "shopware.env"}}
+
+	carried := carryOverChecks(old, now, unavailable)
+	if len(carried) != 1 || carried[0].ID != "shopware.env" {
+		t.Fatalf("expected only the unevaluated environment check carried over, got %+v", carried)
+	}
+
+	// The resolved task and worker findings must not hold the status at yellow.
+	if status := checker.AggregateStatus(append(now, carried...), nil); status != checker.StatusYellow {
+		t.Fatalf("expected yellow from the carried environment check alone, got %q", status)
+	}
+	if status := checker.AggregateStatus(now, nil); status != checker.StatusGreen {
+		t.Fatalf("sanity: the evaluated checks alone should be green, got %q", status)
+	}
+}
+
+func TestCarryOverChecksFallsBackToRenderedMessage(t *testing.T) {
+	// A row written before checks moved to translation keys: message_key is NULL
+	// and only the rendered English text survives.
+	legacy := sourcedCheck("frosh.elasticsearch", "red", checker.SourceFroshTools)
+	legacy.MessageKey = nil
+	legacy.Message = "Elasticsearch is not reachable"
+
+	carried := carryOverChecks([]queries.EnvironmentCheck{legacy}, nil, []checker.UnavailableSource{froshUnavailable})
+	if len(carried) != 1 {
+		t.Fatalf("expected the legacy check carried over, got %+v", carried)
+	}
+	if carried[0].MessageKey != "Elasticsearch is not reachable" {
+		t.Fatalf("expected the rendered message kept as the fallback, got %q", carried[0].MessageKey)
 	}
 }

--- a/api/internal/monitoring/scrape/notify_test.go
+++ b/api/internal/monitoring/scrape/notify_test.go
@@ -77,3 +77,73 @@ func TestComputeStatusReasonsNoChange(t *testing.T) {
 		t.Fatalf("expected no recovery reasons when nothing improved, got %+v", reasons)
 	}
 }
+
+func sourcedCheck(id, level, source string) queries.EnvironmentCheck {
+	c := oldCheck(id, level)
+	c.Source = source
+	c.Params = []byte(`{"snippet":"` + id + `"}`)
+	return c
+}
+
+func TestCarryOverChecksKeepsUnavailableSourceFindings(t *testing.T) {
+	old := []queries.EnvironmentCheck{
+		sourcedCheck("frosh.elasticsearch", "red", checker.SourceFroshTools),
+		sourcedCheck("frosh.phpGood", "green", checker.SourceFroshTools),
+		sourcedCheck("shopware.env", "yellow", checker.SourceShopware),
+	}
+	// The Shopware checks were re-evaluated; FroshTools timed out.
+	now := []checker.Check{newCheck("shopware.env", "green")}
+
+	carried := carryOverChecks(old, now, []string{checker.SourceFroshTools})
+	if len(carried) != 2 {
+		t.Fatalf("expected both FroshTools checks carried over, got %d: %+v", len(carried), carried)
+	}
+
+	byID := map[string]checker.Check{}
+	for _, c := range carried {
+		byID[c.ID] = c
+	}
+	es, ok := byID["frosh.elasticsearch"]
+	if !ok {
+		t.Fatalf("expected frosh.elasticsearch to be carried over, got %+v", byID)
+	}
+	if es.Level != checker.StatusRed {
+		t.Fatalf("expected the carried check to keep its red level, got %q", es.Level)
+	}
+	if es.MessageKey != "check.frosh.elasticsearch" || es.Source != checker.SourceFroshTools {
+		t.Fatalf("expected key/source preserved, got %+v", es)
+	}
+	if es.MessageParams["snippet"] != "frosh.elasticsearch" {
+		t.Fatalf("expected params preserved, got %+v", es.MessageParams)
+	}
+	if _, ok := byID["shopware.env"]; ok {
+		t.Fatalf("checks of available sources must not be carried over: %+v", byID)
+	}
+
+	// The environment must stay red instead of reporting a false recovery.
+	if status := checker.AggregateStatus(append(now, carried...), nil); status != checker.StatusRed {
+		t.Fatalf("expected status to stay red while FroshTools is unreachable, got %q", status)
+	}
+}
+
+func TestCarryOverChecksSkipsRereportedChecks(t *testing.T) {
+	old := []queries.EnvironmentCheck{
+		sourcedCheck("frosh.phpGood", "red", checker.SourceFroshTools),
+		sourcedCheck("frosh.cacheWarning", "yellow", checker.SourceFroshTools),
+	}
+	// Health responded (phpGood now green), performance did not.
+	now := []checker.Check{newCheck("frosh.phpGood", "green")}
+
+	carried := carryOverChecks(old, now, []string{checker.SourceFroshTools})
+	if len(carried) != 1 || carried[0].ID != "frosh.cacheWarning" {
+		t.Fatalf("expected only the unreported check carried over, got %+v", carried)
+	}
+}
+
+func TestCarryOverChecksWithoutUnavailableSources(t *testing.T) {
+	old := []queries.EnvironmentCheck{sourcedCheck("frosh.phpGood", "red", checker.SourceFroshTools)}
+
+	if carried := carryOverChecks(old, nil, nil); len(carried) != 0 {
+		t.Fatalf("expected nothing carried over when every source was evaluated, got %+v", carried)
+	}
+}

--- a/api/internal/monitoring/scrape/service.go
+++ b/api/internal/monitoring/scrape/service.go
@@ -380,8 +380,9 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 	_, checkSpan := tracer.Start(ctx, "environment.scrape.run_checks")
 	checkerResult := checker.RunAll(ctx, checkerInput)
 	checkSpan.SetAttributes(attribute.String("check.status", string(checkerResult.Status)))
-	if len(checkerResult.Unavailable) > 0 {
-		checkSpan.SetAttributes(attribute.StringSlice("check.unavailable_sources", checkerResult.Unavailable))
+	unavailableNames := checkerResult.UnavailableNames()
+	if len(unavailableNames) > 0 {
+		checkSpan.SetAttributes(attribute.StringSlice("check.unavailable_sources", unavailableNames))
 	}
 	checkSpan.End()
 
@@ -389,18 +390,29 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 	// status transition can be explained by the specific checks that changed.
 	oldChecks, err := h.queries.GetEnvironmentChecks(ctx, env.ID)
 	if err != nil {
+		// With a check group unevaluated, the previous checks are the only
+		// record of its findings. Persisting without them would prune exactly
+		// those findings and mail out the false recovery this path exists to
+		// prevent, so fail the scrape and let it retry with the stored state
+		// intact. Without an unevaluated group the loss only costs the reasons
+		// attached to a transition, which is not worth failing over.
+		if len(checkerResult.Unavailable) > 0 {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return fmt.Errorf("load previous checks while %v unavailable: %w", unavailableNames, err)
+		}
 		slog.Warn("failed to load previous checks for status diff", "environmentId", env.ID, "error", err)
 		oldChecks = nil
 	}
 
-	// Sources that could not be evaluated keep their last known checks, so an
-	// unreachable source does not silently resolve every finding it reported.
+	// Check groups that could not be evaluated keep their last known checks, so
+	// an unreachable source does not silently resolve every finding it reported.
 	finalChecks := checkerResult.Checks
 	if len(checkerResult.Unavailable) > 0 {
 		carried := carryOverChecks(oldChecks, checkerResult.Checks, checkerResult.Unavailable)
 		if len(carried) > 0 {
 			log.Warn("check sources unavailable, keeping last known checks",
-				"sources", checkerResult.Unavailable, "checks", len(carried))
+				"sources", unavailableNames, "checks", len(carried))
 			finalChecks = append(finalChecks, carried...)
 		}
 	}

--- a/api/internal/monitoring/scrape/service.go
+++ b/api/internal/monitoring/scrape/service.go
@@ -201,10 +201,17 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 
 	var extensions []extensionEntry
 
+	// Track which data sets never arrived. The checkers must not turn a failed
+	// fetch into a passing check, otherwise a transient upstream error (a 504
+	// from the shop, say) reads as "everything resolved" and the next successful
+	// scrape reads as "broken again".
+	var missing checker.MissingData
+
 	if fr.pluginErr == nil {
 		var pluginsResp shopwareSearchResponse[shopwarePlugin]
 		if err := json.Unmarshal(fr.pluginData, &pluginsResp); err != nil {
 			slog.Warn("failed to parse Shopware plugins", "environmentId", env.ID, "error", err)
+			missing.Extensions = true
 		} else {
 			for _, p := range pluginsResp.Data {
 				ext := extensionEntry{
@@ -223,12 +230,14 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		}
 	} else {
 		slog.Warn("failed to fetch Shopware plugins", "environmentId", env.ID, "error", fr.pluginErr)
+		missing.Extensions = true
 	}
 
 	if fr.appErr == nil {
 		var appsResp shopwareSearchResponse[shopwareApp]
 		if err := json.Unmarshal(fr.appData, &appsResp); err != nil {
 			slog.Warn("failed to parse Shopware apps", "environmentId", env.ID, "error", err)
+			missing.Extensions = true
 		} else {
 			for _, a := range appsResp.Data {
 				extensions = append(extensions, extensionEntry{
@@ -243,6 +252,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		}
 	} else {
 		slog.Warn("failed to fetch Shopware apps", "environmentId", env.ID, "error", fr.appErr)
+		missing.Extensions = true
 	}
 
 	var scheduledTasks []shopwareScheduledTask
@@ -250,11 +260,13 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		var tasksResp shopwareSearchResponse[shopwareScheduledTask]
 		if err := json.Unmarshal(fr.taskData, &tasksResp); err != nil {
 			slog.Warn("failed to parse Shopware scheduled tasks", "environmentId", env.ID, "error", err)
+			missing.ScheduledTasks = true
 		} else {
 			scheduledTasks = tasksResp.Data
 		}
 	} else {
 		slog.Warn("failed to fetch Shopware scheduled tasks", "environmentId", env.ID, "error", fr.taskErr)
+		missing.ScheduledTasks = true
 	}
 
 	var queueEntries []shopwareQueueEntry
@@ -270,9 +282,11 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 	if fr.cacheInfoErr == nil {
 		if err := json.Unmarshal(fr.cacheInfoData, &cacheInfo); err != nil {
 			slog.Warn("failed to parse cache info", "environmentId", env.ID, "error", err)
+			missing.CacheInfo = true
 		}
 	} else {
 		slog.Warn("failed to fetch Shopware cache info", "environmentId", env.ID, "error", fr.cacheInfoErr)
+		missing.CacheInfo = true
 	}
 
 	oldExtensions := h.loadExistingExtensions(ctx, env.ID)
@@ -360,14 +374,16 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		},
 		Client:  client,
 		Ignores: ignores,
+		Missing: missing,
 	}
 
 	_, checkSpan := tracer.Start(ctx, "environment.scrape.run_checks")
 	checkerResult := checker.RunAll(ctx, checkerInput)
 	checkSpan.SetAttributes(attribute.String("check.status", string(checkerResult.Status)))
+	if len(checkerResult.Unavailable) > 0 {
+		checkSpan.SetAttributes(attribute.StringSlice("check.unavailable_sources", checkerResult.Unavailable))
+	}
 	checkSpan.End()
-
-	newStatus := string(checkerResult.Status)
 
 	// Capture the previously persisted checks before they are replaced so the
 	// status transition can be explained by the specific checks that changed.
@@ -376,7 +392,21 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		slog.Warn("failed to load previous checks for status diff", "environmentId", env.ID, "error", err)
 		oldChecks = nil
 	}
-	transition := h.handleStatusTransition(ctx, env, oldChecks, checkerResult.Checks, newStatus)
+
+	// Sources that could not be evaluated keep their last known checks, so an
+	// unreachable source does not silently resolve every finding it reported.
+	finalChecks := checkerResult.Checks
+	if len(checkerResult.Unavailable) > 0 {
+		carried := carryOverChecks(oldChecks, checkerResult.Checks, checkerResult.Unavailable)
+		if len(carried) > 0 {
+			log.Warn("check sources unavailable, keeping last known checks",
+				"sources", checkerResult.Unavailable, "checks", len(carried))
+			finalChecks = append(finalChecks, carried...)
+		}
+	}
+
+	newStatus := string(checker.AggregateStatus(finalChecks, ignores))
+	transition := h.handleStatusTransition(ctx, env, oldChecks, finalChecks, newStatus)
 
 	// Fetch the favicon before opening the persist transaction: it is an HTTP
 	// call with its own timeout and must not run while holding row locks.
@@ -389,7 +419,8 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		scheduledTasks:  scheduledTasks,
 		queueEntries:    queueEntries,
 		cacheInfo:       cacheInfo,
-		checks:          checkerResult.Checks,
+		missing:         missing,
+		checks:          finalChecks,
 		extensionsDiff:  extensionsDiff,
 		favicon:         favicon,
 		transition:      transition,
@@ -428,6 +459,7 @@ type scrapeResult struct {
 	scheduledTasks  []shopwareScheduledTask
 	queueEntries    []shopwareQueueEntry
 	cacheInfo       shopwareCacheInfo
+	missing         checker.MissingData
 	checks          []checker.Check
 	extensionsDiff  []extensionDiff
 	favicon         *string
@@ -566,17 +598,21 @@ func (h *Service) persistScrapeResult(ctx context.Context, env queries.GetAllEnv
 		}
 	}
 
-	cacheAdapter := res.cacheInfo.CacheAdapter
-	if cacheAdapter == "" {
-		cacheAdapter = "filesystem"
-	}
-	if err := txQueries.UpsertEnvironmentCache(ctx, queries.UpsertEnvironmentCacheParams{
-		EnvironmentID: env.ID,
-		Environment:   res.cacheInfo.Environment,
-		HttpCache:     res.cacheInfo.HttpCache,
-		CacheAdapter:  cacheAdapter,
-	}); err != nil {
-		return fmt.Errorf("upsert environment cache: %w", err)
+	// Skipped when the cache info could not be fetched, so a transient failure
+	// does not overwrite the stored values with an empty environment.
+	if !res.missing.CacheInfo {
+		cacheAdapter := res.cacheInfo.CacheAdapter
+		if cacheAdapter == "" {
+			cacheAdapter = "filesystem"
+		}
+		if err := txQueries.UpsertEnvironmentCache(ctx, queries.UpsertEnvironmentCacheParams{
+			EnvironmentID: env.ID,
+			Environment:   res.cacheInfo.Environment,
+			HttpCache:     res.cacheInfo.HttpCache,
+			CacheAdapter:  cacheAdapter,
+		}); err != nil {
+			return fmt.Errorf("upsert environment cache: %w", err)
+		}
 	}
 
 	// Upsert checks and prune the ones no longer reported, instead of the previous

--- a/api/internal/shopware/checker/checker.go
+++ b/api/internal/shopware/checker/checker.go
@@ -3,6 +3,7 @@ package checker
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"sync"
 	"time"
 )
@@ -13,6 +14,14 @@ const (
 	StatusGreen  Status = "green"
 	StatusYellow Status = "yellow"
 	StatusRed    Status = "red"
+)
+
+// Check sources. Every check carries the source it originates from; it is also
+// the granularity at which a run can report that it could not collect data.
+const (
+	SourceShopware   = "Shopware"
+	SourceFroshTools = "FroshTools"
+	SourceSecurity   = "Security"
 )
 
 type Check struct {
@@ -68,6 +77,16 @@ type HTTPClient interface {
 	Get(ctx context.Context, path string) ([]byte, error)
 }
 
+// MissingData marks upstream data sets the caller failed to collect for this
+// run. A checker that depends on a missing data set must not derive checks from
+// it — absent data is not a passing check — and marks its source unavailable
+// instead, so the caller can carry the last known checks forward.
+type MissingData struct {
+	Extensions     bool
+	ScheduledTasks bool
+	CacheInfo      bool
+}
+
 type Input struct {
 	Extensions     []Extension
 	Config         ShopConfig
@@ -76,18 +95,23 @@ type Input struct {
 	CacheInfo      CacheInfo
 	Client         HTTPClient
 	Ignores        []string
+	Missing        MissingData
 }
 
 type Result struct {
 	Status Status  `json:"status"`
 	Checks []Check `json:"checks"`
+	// Unavailable lists the sources whose checks could not be evaluated in this
+	// run. Their checks are missing from Checks because the data was
+	// unreachable, not because the underlying problems went away.
+	Unavailable []string `json:"unavailable,omitempty"`
 }
 
 type Output struct {
-	mu      sync.Mutex
-	status  Status
-	checks  []Check
-	ignores map[string]bool
+	mu          sync.Mutex
+	checks      []Check
+	ignores     map[string]bool
+	unavailable map[string]bool
 }
 
 func NewOutput(ignores []string) *Output {
@@ -96,10 +120,17 @@ func NewOutput(ignores []string) *Output {
 		ignoreMap[id] = true
 	}
 	return &Output{
-		status:  StatusGreen,
-		checks:  make([]Check, 0),
-		ignores: ignoreMap,
+		checks:      make([]Check, 0),
+		ignores:     ignoreMap,
+		unavailable: make(map[string]bool),
 	}
+}
+
+// MarkUnavailable records that a source could not be evaluated in this run.
+func (o *Output) MarkUnavailable(source string) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	o.unavailable[source] = true
 }
 
 func (o *Output) Success(id, messageKey string, params map[string]any, source, link string) {
@@ -126,9 +157,6 @@ func (o *Output) Warning(id, messageKey string, params map[string]any, source, l
 		Source:        source,
 		Link:          link,
 	})
-	if !o.ignores[id] && o.status != StatusRed {
-		o.status = StatusYellow
-	}
 }
 
 func (o *Output) Error(id, messageKey string, params map[string]any, source, link string) {
@@ -142,16 +170,51 @@ func (o *Output) Error(id, messageKey string, params map[string]any, source, lin
 		Source:        source,
 		Link:          link,
 	})
-	if !o.ignores[id] {
-		o.status = StatusRed
-	}
 }
 
 func (o *Output) Result() Result {
-	return Result{
-		Status: o.status,
-		Checks: o.checks,
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	unavailable := make([]string, 0, len(o.unavailable))
+	for source := range o.unavailable {
+		unavailable = append(unavailable, source)
 	}
+	sort.Strings(unavailable)
+
+	return Result{
+		Status:      aggregateStatus(o.checks, o.ignores),
+		Checks:      o.checks,
+		Unavailable: unavailable,
+	}
+}
+
+// AggregateStatus derives the environment status from a set of checks. Checks
+// whose ID is ignored never escalate the status. It is exported so callers that
+// combine a run's checks with carried-over ones can recompute the status the
+// same way the run itself does.
+func AggregateStatus(checks []Check, ignores []string) Status {
+	ignoreMap := make(map[string]bool, len(ignores))
+	for _, id := range ignores {
+		ignoreMap[id] = true
+	}
+	return aggregateStatus(checks, ignoreMap)
+}
+
+func aggregateStatus(checks []Check, ignores map[string]bool) Status {
+	status := StatusGreen
+	for _, c := range checks {
+		if ignores[c.ID] {
+			continue
+		}
+		switch c.Level {
+		case StatusRed:
+			return StatusRed
+		case StatusYellow:
+			status = StatusYellow
+		}
+	}
+	return status
 }
 
 // RunAll runs all checkers concurrently and returns the aggregated result.

--- a/api/internal/shopware/checker/checker.go
+++ b/api/internal/shopware/checker/checker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 )
@@ -16,13 +17,40 @@ const (
 	StatusRed    Status = "red"
 )
 
-// Check sources. Every check carries the source it originates from; it is also
-// the granularity at which a run can report that it could not collect data.
+// Check sources. Every check carries the source it originates from, which is
+// what the UI groups by.
 const (
 	SourceShopware   = "Shopware"
 	SourceFroshTools = "FroshTools"
 	SourceSecurity   = "Security"
 )
+
+// Check ID prefixes. Each checker names its checks after the data set it reads,
+// which is what makes a prefix a precise handle on the checks a single checker
+// owns — see UnavailableSource.
+const (
+	prefixEnv           = "shopware.env"
+	prefixScheduledTask = "task."
+	prefixFroshTools    = "frosh."
+	prefixSecurity      = "security."
+)
+
+// UnavailableSource marks one checker's checks as unevaluated for this run.
+//
+// The source alone is too coarse to act on: several checkers report under
+// SourceShopware, so a failed scheduled-task fetch must not imply that the
+// environment and worker checks are unknown too — those were evaluated, and
+// their findings disappearing is a real resolution. IDPrefix narrows an entry
+// to the checks the failing checker owns.
+type UnavailableSource struct {
+	Source   string
+	IDPrefix string
+}
+
+// Owns reports whether a persisted check falls under this entry.
+func (u UnavailableSource) Owns(source, checkID string) bool {
+	return source == u.Source && strings.HasPrefix(checkID, u.IDPrefix)
+}
 
 type Check struct {
 	ID    string `json:"id"`
@@ -101,17 +129,32 @@ type Input struct {
 type Result struct {
 	Status Status  `json:"status"`
 	Checks []Check `json:"checks"`
-	// Unavailable lists the sources whose checks could not be evaluated in this
+	// Unavailable lists the check groups that could not be evaluated in this
 	// run. Their checks are missing from Checks because the data was
 	// unreachable, not because the underlying problems went away.
-	Unavailable []string `json:"unavailable,omitempty"`
+	Unavailable []UnavailableSource `json:"unavailable,omitempty"`
+}
+
+// UnavailableNames returns the distinct source names of the unevaluated groups,
+// for logging and span attributes.
+func (r Result) UnavailableNames() []string {
+	seen := make(map[string]bool, len(r.Unavailable))
+	names := make([]string, 0, len(r.Unavailable))
+	for _, u := range r.Unavailable {
+		if seen[u.Source] {
+			continue
+		}
+		seen[u.Source] = true
+		names = append(names, u.Source)
+	}
+	return names
 }
 
 type Output struct {
 	mu          sync.Mutex
 	checks      []Check
 	ignores     map[string]bool
-	unavailable map[string]bool
+	unavailable map[UnavailableSource]bool
 }
 
 func NewOutput(ignores []string) *Output {
@@ -122,15 +165,16 @@ func NewOutput(ignores []string) *Output {
 	return &Output{
 		checks:      make([]Check, 0),
 		ignores:     ignoreMap,
-		unavailable: make(map[string]bool),
+		unavailable: make(map[UnavailableSource]bool),
 	}
 }
 
-// MarkUnavailable records that a source could not be evaluated in this run.
-func (o *Output) MarkUnavailable(source string) {
+// MarkUnavailable records that the checks named with idPrefix could not be
+// evaluated in this run.
+func (o *Output) MarkUnavailable(source, idPrefix string) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
-	o.unavailable[source] = true
+	o.unavailable[UnavailableSource{Source: source, IDPrefix: idPrefix}] = true
 }
 
 func (o *Output) Success(id, messageKey string, params map[string]any, source, link string) {
@@ -176,11 +220,16 @@ func (o *Output) Result() Result {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
-	unavailable := make([]string, 0, len(o.unavailable))
-	for source := range o.unavailable {
-		unavailable = append(unavailable, source)
+	unavailable := make([]UnavailableSource, 0, len(o.unavailable))
+	for u := range o.unavailable {
+		unavailable = append(unavailable, u)
 	}
-	sort.Strings(unavailable)
+	sort.Slice(unavailable, func(i, j int) bool {
+		if unavailable[i].Source != unavailable[j].Source {
+			return unavailable[i].Source < unavailable[j].Source
+		}
+		return unavailable[i].IDPrefix < unavailable[j].IDPrefix
+	})
 
 	return Result{
 		Status:      aggregateStatus(o.checks, o.ignores),

--- a/api/internal/shopware/checker/env.go
+++ b/api/internal/shopware/checker/env.go
@@ -13,11 +13,18 @@ var validEnvironments = map[string]bool{
 }
 
 func checkEnv(_ context.Context, input Input, output *Output) {
+	// An unfetched cache info would look like an empty (and therefore invalid)
+	// environment name, which is a fabricated warning rather than a finding.
+	if input.Missing.CacheInfo {
+		output.MarkUnavailable(SourceShopware)
+		return
+	}
+
 	env := strings.ToLower(input.CacheInfo.Environment)
 	params := map[string]any{"environment": input.CacheInfo.Environment}
 	if !validEnvironments[env] {
-		output.Warning("shopware.env", "check.env.invalid", params, "Shopware", "")
+		output.Warning("shopware.env", "check.env.invalid", params, SourceShopware, "")
 	} else {
-		output.Success("shopware.env", "check.env.valid", params, "Shopware", "")
+		output.Success("shopware.env", "check.env.valid", params, SourceShopware, "")
 	}
 }

--- a/api/internal/shopware/checker/env.go
+++ b/api/internal/shopware/checker/env.go
@@ -16,15 +16,15 @@ func checkEnv(_ context.Context, input Input, output *Output) {
 	// An unfetched cache info would look like an empty (and therefore invalid)
 	// environment name, which is a fabricated warning rather than a finding.
 	if input.Missing.CacheInfo {
-		output.MarkUnavailable(SourceShopware)
+		output.MarkUnavailable(SourceShopware, prefixEnv)
 		return
 	}
 
 	env := strings.ToLower(input.CacheInfo.Environment)
 	params := map[string]any{"environment": input.CacheInfo.Environment}
 	if !validEnvironments[env] {
-		output.Warning("shopware.env", "check.env.invalid", params, SourceShopware, "")
+		output.Warning(prefixEnv, "check.env.invalid", params, SourceShopware, "")
 	} else {
-		output.Success("shopware.env", "check.env.valid", params, SourceShopware, "")
+		output.Success(prefixEnv, "check.env.valid", params, SourceShopware, "")
 	}
 }

--- a/api/internal/shopware/checker/env_test.go
+++ b/api/internal/shopware/checker/env_test.go
@@ -40,3 +40,12 @@ func TestCheckEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckEnv_MissingCacheInfo(t *testing.T) {
+	output := NewOutput(nil)
+	checkEnv(context.Background(), Input{Missing: MissingData{CacheInfo: true}}, output)
+
+	result := output.Result()
+	assert.Empty(t, result.Checks, "an unfetched cache info must not become an invalid-environment warning")
+	assert.Equal(t, []string{SourceShopware}, result.Unavailable)
+}

--- a/api/internal/shopware/checker/env_test.go
+++ b/api/internal/shopware/checker/env_test.go
@@ -47,5 +47,6 @@ func TestCheckEnv_MissingCacheInfo(t *testing.T) {
 
 	result := output.Result()
 	assert.Empty(t, result.Checks, "an unfetched cache info must not become an invalid-environment warning")
-	assert.Equal(t, []string{SourceShopware}, result.Unavailable)
+	assert.Equal(t, []UnavailableSource{{Source: SourceShopware, IDPrefix: prefixEnv}}, result.Unavailable,
+		"only the environment check is unknown; the other Shopware checks still ran")
 }

--- a/api/internal/shopware/checker/frosh_tools.go
+++ b/api/internal/shopware/checker/frosh_tools.go
@@ -28,6 +28,13 @@ var ignoredFroshChecks = map[string]bool{
 }
 
 func checkFroshTools(ctx context.Context, input Input, output *Output) {
+	// Without the extension list there is no way to tell whether FroshTools is
+	// gone or merely unlisted, so treat the source as unevaluated.
+	if input.Missing.Extensions {
+		output.MarkUnavailable(SourceFroshTools)
+		return
+	}
+
 	var found bool
 	for _, ext := range input.Extensions {
 		if ext.Name == "FroshTools" && ext.Active && ext.Installed {
@@ -43,15 +50,20 @@ func checkFroshTools(ctx context.Context, input Input, output *Output) {
 		return
 	}
 
+	// Every failure below leaves the shop's real health unknown. Reporting no
+	// checks would read as "everything recovered", so the source is marked
+	// unavailable and the caller keeps the last known checks.
 	healthData, err := input.Client.Get(ctx, "/_action/frosh-tools/health/status")
 	if err != nil {
 		slog.Warn("failed to fetch FroshTools health status", "error", err)
+		output.MarkUnavailable(SourceFroshTools)
 		return
 	}
 
 	var healthChecks []froshToolsCheck
 	if err := json.Unmarshal(healthData, &healthChecks); err != nil {
 		slog.Warn("failed to parse FroshTools health data", "error", err)
+		output.MarkUnavailable(SourceFroshTools)
 		return
 	}
 
@@ -60,12 +72,14 @@ func checkFroshTools(ctx context.Context, input Input, output *Output) {
 	perfData, err := input.Client.Get(ctx, "/_action/frosh-tools/performance/status")
 	if err != nil {
 		slog.Warn("failed to fetch FroshTools performance status", "error", err)
+		output.MarkUnavailable(SourceFroshTools)
 		return
 	}
 
 	var perfChecks []froshToolsCheck
 	if err := json.Unmarshal(perfData, &perfChecks); err != nil {
 		slog.Warn("failed to parse FroshTools performance data", "error", err)
+		output.MarkUnavailable(SourceFroshTools)
 		return
 	}
 
@@ -98,17 +112,17 @@ func mapFroshChecks(checks []froshToolsCheck, output *Output) {
 		}
 
 		if ignoredFroshChecks[c.Snippet] {
-			output.Success(id, messageKey, params, "FroshTools", c.URL)
+			output.Success(id, messageKey, params, SourceFroshTools, c.URL)
 			continue
 		}
 
 		switch c.State {
 		case "STATE_OK":
-			output.Success(id, messageKey, params, "FroshTools", c.URL)
+			output.Success(id, messageKey, params, SourceFroshTools, c.URL)
 		case "STATE_WARNING":
-			output.Warning(id, messageKey, params, "FroshTools", c.URL)
+			output.Warning(id, messageKey, params, SourceFroshTools, c.URL)
 		case "STATE_ERROR":
-			output.Error(id, messageKey, params, "FroshTools", c.URL)
+			output.Error(id, messageKey, params, SourceFroshTools, c.URL)
 		}
 	}
 }

--- a/api/internal/shopware/checker/frosh_tools.go
+++ b/api/internal/shopware/checker/frosh_tools.go
@@ -31,7 +31,7 @@ func checkFroshTools(ctx context.Context, input Input, output *Output) {
 	// Without the extension list there is no way to tell whether FroshTools is
 	// gone or merely unlisted, so treat the source as unevaluated.
 	if input.Missing.Extensions {
-		output.MarkUnavailable(SourceFroshTools)
+		output.MarkUnavailable(SourceFroshTools, prefixFroshTools)
 		return
 	}
 
@@ -56,14 +56,14 @@ func checkFroshTools(ctx context.Context, input Input, output *Output) {
 	healthData, err := input.Client.Get(ctx, "/_action/frosh-tools/health/status")
 	if err != nil {
 		slog.Warn("failed to fetch FroshTools health status", "error", err)
-		output.MarkUnavailable(SourceFroshTools)
+		output.MarkUnavailable(SourceFroshTools, prefixFroshTools)
 		return
 	}
 
 	var healthChecks []froshToolsCheck
 	if err := json.Unmarshal(healthData, &healthChecks); err != nil {
 		slog.Warn("failed to parse FroshTools health data", "error", err)
-		output.MarkUnavailable(SourceFroshTools)
+		output.MarkUnavailable(SourceFroshTools, prefixFroshTools)
 		return
 	}
 
@@ -72,14 +72,14 @@ func checkFroshTools(ctx context.Context, input Input, output *Output) {
 	perfData, err := input.Client.Get(ctx, "/_action/frosh-tools/performance/status")
 	if err != nil {
 		slog.Warn("failed to fetch FroshTools performance status", "error", err)
-		output.MarkUnavailable(SourceFroshTools)
+		output.MarkUnavailable(SourceFroshTools, prefixFroshTools)
 		return
 	}
 
 	var perfChecks []froshToolsCheck
 	if err := json.Unmarshal(perfData, &perfChecks); err != nil {
 		slog.Warn("failed to parse FroshTools performance data", "error", err)
-		output.MarkUnavailable(SourceFroshTools)
+		output.MarkUnavailable(SourceFroshTools, prefixFroshTools)
 		return
 	}
 
@@ -97,7 +97,7 @@ func mapFroshChecks(checks []froshToolsCheck, output *Output) {
 			key = c.ID
 		}
 
-		id := "frosh." + key
+		id := prefixFroshTools + key
 		// messageKey resolves to a catalog entry per snippet. The snippet is also
 		// passed as a param so an unknown snippet degrades to its raw name rather
 		// than a bare key. current/recommended (when present) drive the generic

--- a/api/internal/shopware/checker/frosh_tools_test.go
+++ b/api/internal/shopware/checker/frosh_tools_test.go
@@ -151,7 +151,9 @@ func TestCheckFroshTools_ExtensionNotPresent(t *testing.T) {
 		Client:     client,
 	}, output)
 
-	assert.Empty(t, output.Result().Checks, "expected no checks when FroshTools not installed")
+	result := output.Result()
+	assert.Empty(t, result.Checks, "expected no checks when FroshTools not installed")
+	assert.Empty(t, result.Unavailable, "an absent extension is a known state, not an unavailable source")
 }
 
 func TestCheckFroshTools_ExtensionInactive(t *testing.T) {
@@ -212,7 +214,45 @@ func TestCheckFroshTools_HealthError(t *testing.T) {
 		Client:     client,
 	}, output)
 
-	assert.Empty(t, output.Result().Checks, "expected no checks when health request errors")
+	result := output.Result()
+	assert.Empty(t, result.Checks, "expected no checks when health request errors")
+	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+		"a failed health request leaves the source unevaluated, not resolved")
+}
+
+func TestCheckFroshTools_PerformanceError(t *testing.T) {
+	client := &mockHTTPClient{
+		responses: map[string][]byte{
+			"/_action/frosh-tools/health/status": []byte(`[{"snippet":"phpGood","state":"STATE_OK"}]`),
+		},
+		errs: map[string]error{
+			"/_action/frosh-tools/performance/status": errors.New("upstream request timeout"),
+		},
+	}
+
+	output := NewOutput(nil)
+	checkFroshTools(context.Background(), Input{
+		Extensions: []Extension{{Name: "FroshTools", Active: true, Installed: true}},
+		Client:     client,
+	}, output)
+
+	result := output.Result()
+	assert.Len(t, result.Checks, 1, "health checks that did arrive are kept")
+	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+		"the performance checks are missing, so the source stays unevaluated")
+}
+
+func TestCheckFroshTools_MissingExtensions(t *testing.T) {
+	output := NewOutput(nil)
+	checkFroshTools(context.Background(), Input{
+		Client:  &mockHTTPClient{errs: map[string]error{}},
+		Missing: MissingData{Extensions: true},
+	}, output)
+
+	result := output.Result()
+	assert.Empty(t, result.Checks)
+	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+		"without the extension list FroshTools cannot be ruled in or out")
 }
 
 func TestCheckFroshTools_InvalidHealthJSON(t *testing.T) {
@@ -228,5 +268,8 @@ func TestCheckFroshTools_InvalidHealthJSON(t *testing.T) {
 		Client:     client,
 	}, output)
 
-	assert.Empty(t, output.Result().Checks, "expected no checks when health JSON invalid")
+	result := output.Result()
+	assert.Empty(t, result.Checks, "expected no checks when health JSON invalid")
+	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+		"unparseable health data leaves the source unevaluated, not resolved")
 }

--- a/api/internal/shopware/checker/frosh_tools_test.go
+++ b/api/internal/shopware/checker/frosh_tools_test.go
@@ -216,7 +216,7 @@ func TestCheckFroshTools_HealthError(t *testing.T) {
 
 	result := output.Result()
 	assert.Empty(t, result.Checks, "expected no checks when health request errors")
-	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+	assert.Equal(t, []UnavailableSource{{Source: SourceFroshTools, IDPrefix: prefixFroshTools}}, result.Unavailable,
 		"a failed health request leaves the source unevaluated, not resolved")
 }
 
@@ -238,7 +238,7 @@ func TestCheckFroshTools_PerformanceError(t *testing.T) {
 
 	result := output.Result()
 	assert.Len(t, result.Checks, 1, "health checks that did arrive are kept")
-	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+	assert.Equal(t, []UnavailableSource{{Source: SourceFroshTools, IDPrefix: prefixFroshTools}}, result.Unavailable,
 		"the performance checks are missing, so the source stays unevaluated")
 }
 
@@ -251,7 +251,7 @@ func TestCheckFroshTools_MissingExtensions(t *testing.T) {
 
 	result := output.Result()
 	assert.Empty(t, result.Checks)
-	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+	assert.Equal(t, []UnavailableSource{{Source: SourceFroshTools, IDPrefix: prefixFroshTools}}, result.Unavailable,
 		"without the extension list FroshTools cannot be ruled in or out")
 }
 
@@ -270,6 +270,6 @@ func TestCheckFroshTools_InvalidHealthJSON(t *testing.T) {
 
 	result := output.Result()
 	assert.Empty(t, result.Checks, "expected no checks when health JSON invalid")
-	assert.Equal(t, []string{SourceFroshTools}, result.Unavailable,
+	assert.Equal(t, []UnavailableSource{{Source: SourceFroshTools, IDPrefix: prefixFroshTools}}, result.Unavailable,
 		"unparseable health data leaves the source unevaluated, not resolved")
 }

--- a/api/internal/shopware/checker/security.go
+++ b/api/internal/shopware/checker/security.go
@@ -29,7 +29,7 @@ func checkSecurity(ctx context.Context, input Input, output *Output) {
 	// The advisory suppression below needs the installed security plugin, so
 	// without the extension list the advisories cannot be judged either way.
 	if input.Missing.Extensions {
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 
@@ -39,35 +39,35 @@ func checkSecurity(ctx context.Context, input Input, output *Output) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://raw.githubusercontent.com/FriendsOfShopware/shopware-static-data/main/data/security.json", nil)
 	if err != nil {
 		slog.Warn("failed to create security advisories request", "error", err)
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 
 	resp, err := httputil.NewHTTPClient(httputil.WithTimeout(15 * time.Second)).Do(req)
 	if err != nil {
 		slog.Warn("failed to fetch security advisories", "error", err)
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Warn("security advisories endpoint returned non-200", "status", resp.StatusCode)
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Warn("failed to read security response", "error", err)
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 
 	var data securityData
 	if err := json.Unmarshal(body, &data); err != nil {
 		slog.Warn("failed to parse security data", "error", err)
-		output.MarkUnavailable(SourceSecurity)
+		output.MarkUnavailable(SourceSecurity, prefixSecurity)
 		return
 	}
 
@@ -95,7 +95,7 @@ func checkSecurity(ctx context.Context, input Input, output *Output) {
 			continue
 		}
 
-		id := fmt.Sprintf("security.%s", advisoryID)
+		id := fmt.Sprintf("%s%s", prefixSecurity, advisoryID)
 		// The advisory title is external data from Shopware (already English);
 		// only the CVE wrapper is boilerplate, so the key picks the format and
 		// the title/cve ride along as params.

--- a/api/internal/shopware/checker/security.go
+++ b/api/internal/shopware/checker/security.go
@@ -26,33 +26,48 @@ type securityAdvisory struct {
 }
 
 func checkSecurity(ctx context.Context, input Input, output *Output) {
+	// The advisory suppression below needs the installed security plugin, so
+	// without the extension list the advisories cannot be judged either way.
+	if input.Missing.Extensions {
+		output.MarkUnavailable(SourceSecurity)
+		return
+	}
+
+	// A failure to reach or read the advisory feed leaves the shop's exposure
+	// unknown. Emitting no checks would look like the advisories were resolved,
+	// so the source is marked unavailable and the caller keeps what it had.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://raw.githubusercontent.com/FriendsOfShopware/shopware-static-data/main/data/security.json", nil)
 	if err != nil {
 		slog.Warn("failed to create security advisories request", "error", err)
+		output.MarkUnavailable(SourceSecurity)
 		return
 	}
 
 	resp, err := httputil.NewHTTPClient(httputil.WithTimeout(15 * time.Second)).Do(req)
 	if err != nil {
 		slog.Warn("failed to fetch security advisories", "error", err)
+		output.MarkUnavailable(SourceSecurity)
 		return
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		slog.Warn("security advisories endpoint returned non-200", "status", resp.StatusCode)
+		output.MarkUnavailable(SourceSecurity)
 		return
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		slog.Warn("failed to read security response", "error", err)
+		output.MarkUnavailable(SourceSecurity)
 		return
 	}
 
 	var data securityData
 	if err := json.Unmarshal(body, &data); err != nil {
 		slog.Warn("failed to parse security data", "error", err)
+		output.MarkUnavailable(SourceSecurity)
 		return
 	}
 
@@ -90,6 +105,6 @@ func checkSecurity(ctx context.Context, input Input, output *Output) {
 			messageKey = "check.security.advisoryCve"
 		}
 
-		output.Error(id, messageKey, params, "Security", advisory.Link)
+		output.Error(id, messageKey, params, SourceSecurity, advisory.Link)
 	}
 }

--- a/api/internal/shopware/checker/status_test.go
+++ b/api/internal/shopware/checker/status_test.go
@@ -1,0 +1,68 @@
+package checker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAggregateStatus(t *testing.T) {
+	tests := []struct {
+		name    string
+		checks  []Check
+		ignores []string
+		want    Status
+	}{
+		{
+			name: "no checks is green",
+			want: StatusGreen,
+		},
+		{
+			name:   "only successes is green",
+			checks: []Check{{ID: "a", Level: StatusGreen}, {ID: "b", Level: StatusGreen}},
+			want:   StatusGreen,
+		},
+		{
+			name:   "a warning escalates to yellow",
+			checks: []Check{{ID: "a", Level: StatusGreen}, {ID: "b", Level: StatusYellow}},
+			want:   StatusYellow,
+		},
+		{
+			name:   "an error wins over a warning regardless of order",
+			checks: []Check{{ID: "a", Level: StatusRed}, {ID: "b", Level: StatusYellow}},
+			want:   StatusRed,
+		},
+		{
+			name:    "ignored checks never escalate",
+			checks:  []Check{{ID: "a", Level: StatusRed}, {ID: "b", Level: StatusYellow}},
+			ignores: []string{"a", "b"},
+			want:    StatusGreen,
+		},
+		{
+			name:    "ignoring the error leaves the warning",
+			checks:  []Check{{ID: "a", Level: StatusRed}, {ID: "b", Level: StatusYellow}},
+			ignores: []string{"a"},
+			want:    StatusYellow,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, AggregateStatus(tt.checks, tt.ignores))
+		})
+	}
+}
+
+// The status an Output reports must be the one AggregateStatus derives from the
+// same checks, so carried-over checks can be folded in without changing the
+// rules.
+func TestOutputResultStatusMatchesAggregate(t *testing.T) {
+	output := NewOutput([]string{"ignored.error"})
+	output.Success("ok", "check.ok", nil, SourceShopware, "")
+	output.Warning("warn", "check.warn", nil, SourceShopware, "")
+	output.Error("ignored.error", "check.err", nil, SourceShopware, "")
+
+	result := output.Result()
+	assert.Equal(t, StatusYellow, result.Status)
+	assert.Equal(t, AggregateStatus(result.Checks, []string{"ignored.error"}), result.Status)
+}

--- a/api/internal/shopware/checker/task.go
+++ b/api/internal/shopware/checker/task.go
@@ -7,6 +7,13 @@ import (
 )
 
 func checkTasks(_ context.Context, input Input, output *Output) {
+	// An unfetched task list is indistinguishable from "no tasks" here, and
+	// would resolve to the all-running success below.
+	if input.Missing.ScheduledTasks {
+		output.MarkUnavailable(SourceShopware)
+		return
+	}
+
 	hasWarning := false
 	for _, task := range input.ScheduledTasks {
 		if task.Status == "inactive" {
@@ -21,12 +28,12 @@ func checkTasks(_ context.Context, input Input, output *Output) {
 				fmt.Sprintf("task.%s", task.Name),
 				"check.task.overdue",
 				map[string]any{"name": task.Name},
-				"Shopware", "")
+				SourceShopware, "")
 		}
 	}
 
 	if !hasWarning {
-		output.Success("task.all", "check.task.allRunning", nil, "Shopware", "")
+		output.Success("task.all", "check.task.allRunning", nil, SourceShopware, "")
 	}
 }
 

--- a/api/internal/shopware/checker/task.go
+++ b/api/internal/shopware/checker/task.go
@@ -10,7 +10,7 @@ func checkTasks(_ context.Context, input Input, output *Output) {
 	// An unfetched task list is indistinguishable from "no tasks" here, and
 	// would resolve to the all-running success below.
 	if input.Missing.ScheduledTasks {
-		output.MarkUnavailable(SourceShopware)
+		output.MarkUnavailable(SourceShopware, prefixScheduledTask)
 		return
 	}
 
@@ -25,7 +25,7 @@ func checkTasks(_ context.Context, input Input, output *Output) {
 		if isTaskOverdue(task) {
 			hasWarning = true
 			output.Warning(
-				fmt.Sprintf("task.%s", task.Name),
+				fmt.Sprintf("%s%s", prefixScheduledTask, task.Name),
 				"check.task.overdue",
 				map[string]any{"name": task.Name},
 				SourceShopware, "")
@@ -33,7 +33,7 @@ func checkTasks(_ context.Context, input Input, output *Output) {
 	}
 
 	if !hasWarning {
-		output.Success("task.all", "check.task.allRunning", nil, SourceShopware, "")
+		output.Success(prefixScheduledTask+"all", "check.task.allRunning", nil, SourceShopware, "")
 	}
 }
 

--- a/api/internal/shopware/checker/task_test.go
+++ b/api/internal/shopware/checker/task_test.go
@@ -103,5 +103,6 @@ func TestCheckTasks_MissingScheduledTasks(t *testing.T) {
 
 	result := output.Result()
 	assert.Empty(t, result.Checks, "an unfetched task list must not report all tasks as running")
-	assert.Equal(t, []string{SourceShopware}, result.Unavailable)
+	assert.Equal(t, []UnavailableSource{{Source: SourceShopware, IDPrefix: prefixScheduledTask}}, result.Unavailable,
+		"only the task checks are unknown; the other Shopware checks still ran")
 }

--- a/api/internal/shopware/checker/task_test.go
+++ b/api/internal/shopware/checker/task_test.go
@@ -96,3 +96,12 @@ func TestCheckTasks(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckTasks_MissingScheduledTasks(t *testing.T) {
+	output := NewOutput(nil)
+	checkTasks(context.Background(), Input{Missing: MissingData{ScheduledTasks: true}}, output)
+
+	result := output.Result()
+	assert.Empty(t, result.Checks, "an unfetched task list must not report all tasks as running")
+	assert.Equal(t, []string{SourceShopware}, result.Unavailable)
+}

--- a/api/internal/shopware/checker/worker.go
+++ b/api/internal/shopware/checker/worker.go
@@ -4,9 +4,9 @@ import "context"
 
 func checkWorker(_ context.Context, input Input, output *Output) {
 	if input.Config.AdminWorker.EnableAdminWorker {
-		output.Warning("admin.worker", "check.worker.enabled", nil, "Shopware",
+		output.Warning("admin.worker", "check.worker.enabled", nil, SourceShopware,
 			"https://developer.shopware.com/docs/guides/hosting/infrastructure/message-queue.html")
 	} else {
-		output.Success("admin.worker", "check.worker.disabled", nil, "Shopware", "")
+		output.Success("admin.worker", "check.worker.disabled", nil, SourceShopware, "")
 	}
 }


### PR DESCRIPTION
A scrape that could not reach a check source reported no checks for it,
which was indistinguishable from the source reporting everything green.
A single 504 from a shop's FroshTools health endpoint therefore dropped
every FroshTools finding, flipped the environment to green and mailed a
recovery, and the next successful scrape flipped it back and mailed a
degradation — repeatedly, for one intermittent upstream error.

Checkers now distinguish "evaluated, nothing wrong" from "could not
evaluate": a failed fetch or parse marks its source unavailable instead
of silently contributing nothing. The scrape carries the last known
checks of an unavailable source forward and recomputes the status from
the merged set, so the status only moves on evidence.

The same gap existed for the data the scrape fetches itself. A failed
plugin/app fetch made the extension list look empty, a failed scheduled
task fetch resolved to "all tasks running", and unfetched cache info
became an empty (invalid) environment warning and overwrote the stored
cache row. Those data sets are now passed to the checkers as missing.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01AjQDxchBCWZ5SpDDonrbiQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved previously reported checks when data sources are temporarily unavailable.
  * Prevented incomplete scrape results from overwriting valid cached information.
  * Improved handling of missing data and failed requests across environment, task, extension, security, and cache checks.
  * Maintained accurate overall status when checks are unavailable or ignored.
* **Tests**
  * Added coverage for unavailable sources, partial failures, carried-forward checks, and aggregate status calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->