### PR TITLE
fix: name the deployment env var SHOPMON_ENVIRONMENT_ID in setup hint

### DIFF
--- a/frontend/src/views/environment/detail/DetailDeployments.vue
+++ b/frontend/src/views/environment/detail/DetailDeployments.vue
@@ -177,7 +177,9 @@
 
         <div class="flex flex-col gap-3">
           <div class="flex flex-wrap items-center gap-x-3 gap-y-1 sm:flex-nowrap">
-            <code class="font-mono text-xs font-semibold sm:min-w-[180px]">SHOPMON_SHOP_ID</code>
+            <code class="font-mono text-xs font-semibold sm:min-w-[180px]"
+              >SHOPMON_ENVIRONMENT_ID</code
+            >
             <Badge variant="secondary" class="font-mono text-xs break-all">{{
               environment.id
             }}</Badge>
@@ -288,7 +290,7 @@ const cliCommand = computed(() => {
   if (window.location.host !== "shopmon.fos.gg") {
     parts.push(`SHOPMON_BASE_URL=${window.location.protocol}//${window.location.host}`);
   }
-  parts.push(`SHOPMON_SHOP_ID=${environment.value?.id ?? ""}`);
+  parts.push(`SHOPMON_ENVIRONMENT_ID=${environment.value?.id ?? ""}`);
   parts.push("SHOPMON_API_KEY=your-api-key");
   parts.push("./shopmon-cli deploy -- vendor/bin/shopware-deployment-helper run");
   return parts.join(" ");


### PR DESCRIPTION
## Problem

The deployment setup panel labels the variable `SHOPMON_SHOP_ID`, but the value next to it is `environment.id` — and the copyable command has the same mismatch:

```
SHOPMON_SHOP_ID=42 SHOPMON_API_KEY=your-api-key ./shopmon-cli deploy -- ...
```

The name says shop, the value is an environment. Anyone reading the panel to understand what to configure gets a misleading answer.

## Change

Renames it to `SHOPMON_ENVIRONMENT_ID` in both places (`DetailDeployments.vue:180` and the `cliCommand` builder at `:293`). The value was already correct and is untouched.

Pairs with FriendsOfShopware/shopmon-cli#6, which migrates the CLI to the current API and makes `SHOPMON_ENVIRONMENT_ID` the documented name. That PR keeps `SHOPMON_SHOP_ID` working as a legacy alias, so this UI change is safe to ship independently — anyone who already copied the old snippet keeps working.

## Notes

No locale changes needed: `deployments.setupDesc`, `cliIntro`, and `cliGitHint` describe the setup generically and only hardcode `SHOPMON_DEPLOYMENT_VERSION_REFERENCE`, which is unchanged. I grepped `src/` for other references to the old name — there are none.

## Testing

`oxfmt --check` and `oxlint` clean, `vue-tsc --noEmit` exits 0, full suite passes (31 files, 259 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)