### PR TITLE
feat: optional AMQP transport for background jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 /api/files
 /api/tmp
 /api/api
+/compose.override.yml
+/compose.override.yaml
 node_modules
 frontend/components.d.ts
 litestream.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 - **API**: Go (chi router, sqlc, oapi-codegen, go-queue)
 - **Frontend**: Vue.js + TypeScript
 - **Database**: PostgreSQL (pgx)
-- **Queue**: PostgreSQL (go-queue)
+- **Queue**: PostgreSQL (go-queue), optionally AMQP (LavinMQ/RabbitMQ) via `QUEUE_TRANSPORT=amqp`
 - **Storage**: S3-compatible (deployment outputs)
 - **Observability**: OpenTelemetry (traces + logs via OTLP)
 
@@ -125,6 +125,7 @@ Key rules:
 - Handlers follow: `func (h *Handler) HandleX(ctx context.Context, msg MsgType) error`
 - Always create OTel spans for top-level job handlers
 - Register handlers in `internal/jobs/register.go`
+- The transport is chosen in `internal/jobs/bus.go` (`QUEUE_TRANSPORT`): Postgres by default, AMQP when configured. Job code stays transport-agnostic — dispatch through `jobs.Dispatch`, never against a transport directly
 
 ### Testing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,18 @@ Environment variables for local development are pre-configured in [`.mise.toml`]
 
 For production/staging, see [`.env.production`](.env.production) and [`.env.staging`](.env.staging).
 
+### Background Job Queue
+
+Jobs run through PostgreSQL by default. To develop against the AMQP transport instead, point the API and worker at the LavinMQ container started by `mise run up`:
+
+```bash
+export QUEUE_TRANSPORT=amqp
+export QUEUE_AMQP_DSN=amqp://guest:guest@localhost:5672/
+mise run dev
+```
+
+The queue and exchange are declared on startup; inspect them in the LavinMQ UI at http://localhost:15672 (`guest` / `guest`). See [SELF_HOSTING.md](SELF_HOSTING.md#background-job-queue) for the full variable list.
+
 ## Making Changes
 
 ### Branch Naming

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Run `mise tasks` to see all available tasks.
 | Demo Shop Frontend | http://localhost:3889 | |
 | Demo Shop Admin | http://localhost:3889/admin | `admin` / `shopware` |
 | Jaeger (traces) | http://localhost:16686 | OpenTelemetry traces |
+| LavinMQ | http://localhost:15672 | `guest` / `guest`. Only used with `QUEUE_TRANSPORT=amqp` |
 
 ### Environment Variables
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -168,7 +168,7 @@ Background jobs run on PostgreSQL by default — no extra infrastructure needed.
 | `QUEUE_AMQP_EXCHANGE` | `shopmon` | Exchange to publish jobs to (declared on startup) |
 | `QUEUE_AMQP_QUEUE` | `shopmon` | Queue workers consume from; also used as the routing key |
 | `QUEUE_AMQP_PREFETCH` | `10` | Unacknowledged deliveries per consumer. Keep it at or above the worker concurrency (10) |
-| `QUEUE_AMQP_DELAYED_EXCHANGE` | `true` | Declare the exchange as `x-delayed-message` so delayed jobs are held by the broker |
+| `QUEUE_AMQP_DELAYED_EXCHANGE` | `true` | Declare the exchange as `x-delayed-message` so delayed jobs are held by the broker. Accepts `true`/`false`, `1`/`0`, `TRUE`/`FALSE`; an unparseable value keeps delayed delivery on |
 
 Set the same values on the `api` and `worker` services — the API publishes jobs and the worker consumes them.
 

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -9,6 +9,7 @@ Shopmon is distributed as a single Docker image that bundles the API server, bac
 - **PostgreSQL** 18+
 - **Redis** 8+
 - A reverse proxy (Traefik, Caddy, nginx) for TLS termination
+- *Optional:* an AMQP broker (LavinMQ or RabbitMQ) if you want background jobs off PostgreSQL — see [Background Job Queue](#background-job-queue)
 
 ## Quick Start
 
@@ -155,6 +156,25 @@ When not set, the packages token management UI and documentation section are hid
 | `DISABLE_REGISTRATION` | `false` | Set to `true` to disable email/password registration |
 
 When enabled, the registration page is blocked, the "Create account" link is hidden from the login page, and the API returns 403 on sign-up attempts. Useful when you want to restrict access to invited users only.
+
+### Background Job Queue
+
+Background jobs run on PostgreSQL by default — no extra infrastructure needed. If you already operate a message broker, or want the queue off your database, switch the transport to AMQP (RabbitMQ or LavinMQ).
+
+| Variable | Default | Description |
+|---|---|---|
+| `QUEUE_TRANSPORT` | `postgres` | Job backend: `postgres` (jobs stored in the `queue_messages` table) or `amqp` |
+| `QUEUE_AMQP_DSN` | `amqp://guest:guest@localhost:5672/` | Broker connection string |
+| `QUEUE_AMQP_EXCHANGE` | `shopmon` | Exchange to publish jobs to (declared on startup) |
+| `QUEUE_AMQP_QUEUE` | `shopmon` | Queue workers consume from; also used as the routing key |
+| `QUEUE_AMQP_PREFETCH` | `10` | Unacknowledged deliveries per consumer. Keep it at or above the worker concurrency (10) |
+| `QUEUE_AMQP_DELAYED_EXCHANGE` | `true` | Declare the exchange as `x-delayed-message` so delayed jobs are held by the broker |
+
+Set the same values on the `api` and `worker` services — the API publishes jobs and the worker consumes them.
+
+Shopmon delays some jobs (post-deployment scrapes, sitespeed reruns), which needs broker-side delayed delivery: **LavinMQ supports it natively**, RabbitMQ needs the [rabbitmq_delayed_message_exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin. Only set `QUEUE_AMQP_DELAYED_EXCHANGE=false` if your broker has neither — delayed jobs are then delivered immediately, so a post-deployment scrape runs before the shop has settled.
+
+Switching transports does not migrate jobs that are already queued. Drain the worker on the old transport before flipping the variable, or those jobs are left behind.
 
 ### S3 Storage (Deployments)
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -27,6 +27,18 @@ DATABASE_URL=postgres://shopmon:shopmon@localhost:5432/shopmon
 # Redis (BullMQ)
 REDIS_URL=redis://localhost:6379
 
+# Background job queue: "postgres" (default) or "amqp" (RabbitMQ/LavinMQ).
+# The AMQP_* settings below are only read when QUEUE_TRANSPORT=amqp.
+QUEUE_TRANSPORT=postgres
+QUEUE_AMQP_DSN=amqp://guest:guest@localhost:5672/
+QUEUE_AMQP_EXCHANGE=shopmon
+QUEUE_AMQP_QUEUE=shopmon
+QUEUE_AMQP_PREFETCH=10
+# Delayed jobs need a broker that supports x-delayed-message: LavinMQ natively,
+# RabbitMQ via the delayed-message plugin. Set to false only if yours does not
+# — delayed jobs are then delivered immediately.
+QUEUE_AMQP_DELAYED_EXCHANGE=true
+
 # S3 Storage (MinIO in development)
 APP_S3_ENDPOINT=http://localhost:9000
 APP_S3_ACCESS_KEY_ID=rustfsadmin

--- a/api/fixtures.go
+++ b/api/fixtures.go
@@ -444,10 +444,11 @@ func (s *seeder) seedShopAndEnvironments(org orgFixture) (int32, []int32, error)
 // dispatchEnvironmentScrapes enqueues an initial scrape for each environment so
 // the worker populates them immediately.
 func (s *seeder) dispatchEnvironmentScrapes(environmentIDs []int32) error {
-	bus, err := jobs.NewBus(s.ctx, s.pool, jobs.BusConfig{OTelEnabled: s.cfg.OtelEnabled})
+	bus, closeBus, err := jobs.NewBus(s.ctx, s.pool, busConfig(s.cfg))
 	if err != nil {
 		return fmt.Errorf("create queue bus: %w", err)
 	}
+	defer func() { _ = closeBus() }()
 	for _, envID := range environmentIDs {
 		if err := jobs.Dispatch(s.ctx, bus, jobs.EnvironmentScrape{EnvironmentID: envID}); err != nil {
 			slog.Warn("failed to dispatch environment scrape", "environmentId", envID, "error", err)

--- a/api/go.mod
+++ b/api/go.mod
@@ -133,6 +133,7 @@ require (
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/rabbitmq/amqp091-go v1.10.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -242,6 +242,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55/go.mod h1:OmDBASR4679mdNQnz2pUhc2G8CO2JrUAVFDRBDP/hJE=
+github.com/rabbitmq/amqp091-go v1.10.0 h1:STpn5XsHlHGcecLmMFCtg7mqq0RnD+zFr4uzukfVhBw=
+github.com/rabbitmq/amqp091-go v1.10.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=
 github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
@@ -285,6 +287,8 @@ github.com/testcontainers/testcontainers-go v0.43.0 h1:oEQx5MW2DGd9z3AeEQfB2lPM0
 github.com/testcontainers/testcontainers-go v0.43.0/go.mod h1:+VxkT2NQnKOZPKi6praMuMKYHYyOGXr0XSBSlSMCzFo=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0 h1:ShNOFYAF4lKHvdIG258hi69bSxC88uXnxJkJvNs/IVs=
 github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0/go.mod h1:vdq5/RqmGfWeefzyfcVI/pID1rzmc1TDvqXa15bPJks=
+github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.41.0 h1:JQS8FXKuzRTxvfEfHUhNFOgRAv0rovEw7c4+Ne2nqtY=
+github.com/testcontainers/testcontainers-go/modules/rabbitmq v0.41.0/go.mod h1:p7PE0uLxjRRNZJnnndNoJUadUZoE0jMzzjpSP0DxcUM=
 github.com/testcontainers/testcontainers-go/modules/redis v0.43.0 h1:qzATMhrltLr07KcGl/d674ouqI0AFtf6wnQb3VnqP7M=
 github.com/testcontainers/testcontainers-go/modules/redis v0.43.0/go.mod h1:ygEcEUIZzmIlOKpjBfnPn/lUIRNorr1kPj3XfFPTQXM=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -19,6 +19,12 @@ type Config struct {
 	RedisURL    string
 	FrontendURL string
 
+	// QueueTransport selects the background job backend: "postgres" (default,
+	// jobs live in the app database) or "amqp" (RabbitMQ/LavinMQ broker).
+	QueueTransport string
+	// QueueAMQP is only read when QueueTransport is "amqp".
+	QueueAMQP QueueAMQPConfig
+
 	MailDSN     string
 	MailFrom    string
 	SMTPReplyTo string
@@ -70,6 +76,21 @@ type Config struct {
 	AuthRateLimitMax int
 }
 
+// QueueAMQPConfig holds the broker settings for the AMQP job transport.
+type QueueAMQPConfig struct {
+	DSN      string
+	Exchange string
+	Queue    string
+	// PrefetchCount bounds unacknowledged deliveries per consumer. Keep it at or
+	// above the worker concurrency so workers never idle waiting for messages.
+	PrefetchCount int
+	// DelayedExchange declares the exchange as x-delayed-message so delayed jobs
+	// (post-deployment scrapes, sitespeed reruns) are held by the broker instead
+	// of being delivered immediately. Needs LavinMQ (native) or the RabbitMQ
+	// delayed-message plugin.
+	DelayedExchange bool
+}
+
 func loadDotEnv() {
 	_ = godotenv.Load()
 }
@@ -82,6 +103,14 @@ func Load() *Config {
 		DatabaseURL: getEnv("DATABASE_URL", "postgres://shopmon:shopmon@localhost:5432/shopmon"),
 		RedisURL:    getEnv("REDIS_URL", "redis://localhost:6379"),
 		FrontendURL: getEnv("FRONTEND_URL", "http://localhost:3000"),
+
+		QueueTransport: strings.ToLower(strings.TrimSpace(getEnv("QUEUE_TRANSPORT", "postgres"))),
+		QueueAMQP: QueueAMQPConfig{
+			DSN:             getEnv("QUEUE_AMQP_DSN", "amqp://guest:guest@localhost:5672/"),
+			Exchange:        getEnv("QUEUE_AMQP_EXCHANGE", "shopmon"),
+			Queue:           getEnv("QUEUE_AMQP_QUEUE", "shopmon"),
+			DelayedExchange: getEnv("QUEUE_AMQP_DELAYED_EXCHANGE", "true") == "true",
+		},
 
 		MailDSN:     mailDSN(),
 		MailFrom:    getEnv("MAIL_FROM", "noreply@shopmon.io"),
@@ -138,6 +167,17 @@ func Load() *Config {
 			cfg.AuthRateLimitMax = n
 		} else {
 			slog.Warn("invalid AUTH_RATE_LIMIT_MAX, using default", "value", raw, "default", cfg.AuthRateLimitMax)
+		}
+	}
+
+	// Parse the AMQP consumer prefetch, falling back to 10 (the worker
+	// concurrency) on an empty or invalid value.
+	cfg.QueueAMQP.PrefetchCount = 10
+	if raw := getEnv("QUEUE_AMQP_PREFETCH", ""); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			cfg.QueueAMQP.PrefetchCount = n
+		} else {
+			slog.Warn("invalid QUEUE_AMQP_PREFETCH, using default", "value", raw, "default", cfg.QueueAMQP.PrefetchCount)
 		}
 	}
 

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -109,7 +109,7 @@ func Load() *Config {
 			DSN:             getEnv("QUEUE_AMQP_DSN", "amqp://guest:guest@localhost:5672/"),
 			Exchange:        getEnv("QUEUE_AMQP_EXCHANGE", "shopmon"),
 			Queue:           getEnv("QUEUE_AMQP_QUEUE", "shopmon"),
-			DelayedExchange: getEnv("QUEUE_AMQP_DELAYED_EXCHANGE", "true") == "true",
+			DelayedExchange: getEnvBool("QUEUE_AMQP_DELAYED_EXCHANGE", true),
 		},
 
 		MailDSN:     mailDSN(),
@@ -256,6 +256,24 @@ func mailDSN() string {
 		u.User = url.UserPassword(user, getEnv("SMTP_PASS", ""))
 	}
 	return u.String()
+}
+
+// getEnvBool parses a boolean env var, accepting every representation
+// strconv.ParseBool does (1, t, T, TRUE, true, True and their false
+// counterparts). An unset or unparseable value keeps the fallback and warns,
+// so a typo cannot silently flip a flag that defaults to on.
+func getEnvBool(key string, fallback bool) bool {
+	raw := getEnv(key, "")
+	if raw == "" {
+		return fallback
+	}
+
+	value, err := strconv.ParseBool(raw)
+	if err != nil {
+		slog.Warn("invalid boolean value, using default", "key", key, "value", raw, "default", fallback)
+		return fallback
+	}
+	return value
 }
 
 func getEnv(key, fallback string) string {

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -33,3 +33,73 @@ func TestDeploymentScrapeDelay(t *testing.T) {
 		})
 	}
 }
+
+func TestQueueTransportDefaultsToPostgres(t *testing.T) {
+	for _, key := range []string{
+		"QUEUE_TRANSPORT",
+		"QUEUE_AMQP_DSN",
+		"QUEUE_AMQP_EXCHANGE",
+		"QUEUE_AMQP_QUEUE",
+		"QUEUE_AMQP_PREFETCH",
+		"QUEUE_AMQP_DELAYED_EXCHANGE",
+	} {
+		t.Setenv(key, "")
+	}
+
+	cfg := Load()
+
+	assert.Equal(t, "postgres", cfg.QueueTransport)
+	assert.Equal(t, "amqp://guest:guest@localhost:5672/", cfg.QueueAMQP.DSN)
+	assert.Equal(t, "shopmon", cfg.QueueAMQP.Exchange)
+	assert.Equal(t, "shopmon", cfg.QueueAMQP.Queue)
+	assert.Equal(t, 10, cfg.QueueAMQP.PrefetchCount)
+	assert.True(t, cfg.QueueAMQP.DelayedExchange)
+}
+
+func TestQueueTransportIsNormalized(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want string
+	}{
+		{name: "lowercased", env: "AMQP", want: "amqp"},
+		{name: "trimmed", env: "  amqp  ", want: "amqp"},
+		{name: "unknown value kept for the bus to reject", env: "kafka", want: "kafka"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("QUEUE_TRANSPORT", tt.env)
+
+			assert.Equal(t, tt.want, Load().QueueTransport)
+		})
+	}
+}
+
+func TestQueueAMQPPrefetch(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want int
+	}{
+		{name: "default when unset", env: "", want: 10},
+		{name: "custom count", env: "50", want: 50},
+		{name: "invalid falls back to default", env: "many", want: 10},
+		{name: "zero falls back to default", env: "0", want: 10},
+		{name: "negative falls back to default", env: "-1", want: 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("QUEUE_AMQP_PREFETCH", tt.env)
+
+			assert.Equal(t, tt.want, Load().QueueAMQP.PrefetchCount)
+		})
+	}
+}
+
+func TestQueueAMQPDelayedExchangeOptOut(t *testing.T) {
+	t.Setenv("QUEUE_AMQP_DELAYED_EXCHANGE", "false")
+
+	assert.False(t, Load().QueueAMQP.DelayedExchange)
+}

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -98,8 +98,30 @@ func TestQueueAMQPPrefetch(t *testing.T) {
 	}
 }
 
-func TestQueueAMQPDelayedExchangeOptOut(t *testing.T) {
-	t.Setenv("QUEUE_AMQP_DELAYED_EXCHANGE", "false")
+func TestQueueAMQPDelayedExchange(t *testing.T) {
+	// Delayed delivery is load-bearing (post-deployment scrapes, sitespeed
+	// reruns), so only an explicit, parseable false may turn it off.
+	tests := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{name: "default when unset", env: "", want: true},
+		{name: "explicit false", env: "false", want: false},
+		{name: "uppercase FALSE", env: "FALSE", want: false},
+		{name: "zero", env: "0", want: false},
+		{name: "uppercase TRUE", env: "TRUE", want: true},
+		{name: "titlecase True", env: "True", want: true},
+		{name: "one", env: "1", want: true},
+		{name: "unparseable keeps delayed delivery on", env: "yes", want: true},
+		{name: "typo keeps delayed delivery on", env: "flase", want: true},
+	}
 
-	assert.False(t, Load().QueueAMQP.DelayedExchange)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("QUEUE_AMQP_DELAYED_EXCHANGE", tt.env)
+
+			assert.Equal(t, tt.want, Load().QueueAMQP.DelayedExchange)
+		})
+	}
 }

--- a/api/internal/jobs/bus.go
+++ b/api/internal/jobs/bus.go
@@ -7,20 +7,51 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	goqueue "github.com/shyim/go-queue"
 	queueotel "github.com/shyim/go-queue/middleware/otel"
+	"github.com/shyim/go-queue/transport/amqp"
 	"github.com/shyim/go-queue/transport/postgres"
+)
+
+const (
+	// DriverPostgres keeps jobs in the queue_messages table of the app database.
+	DriverPostgres = "postgres"
+	// DriverAMQP publishes jobs to a RabbitMQ/LavinMQ broker.
+	DriverAMQP = "amqp"
 )
 
 type BusConfig struct {
 	OTelEnabled bool
+	// Driver selects the queue backend, DriverPostgres when empty.
+	Driver string
+	// AMQP is only read when Driver is DriverAMQP.
+	AMQP AMQPConfig
 }
 
-// NewBus creates and sets up a PostgreSQL-backed bus. It intentionally does
-// not register handlers: API and fixture processes only dispatch messages,
-// while the worker adds executable handlers through RegisterHandlers.
-func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue.Bus, error) {
-	transport := postgres.NewTransportFromPool(pool, postgres.Config{
-		Table: "queue_messages",
-	})
+// AMQPConfig describes the broker Shopmon jobs are published to and consumed
+// from when the AMQP driver is selected.
+type AMQPConfig struct {
+	DSN           string
+	Exchange      string
+	Queue         string
+	PrefetchCount int
+	// DelayedExchange declares the exchange as x-delayed-message so the broker
+	// holds back delayed jobs instead of delivering them immediately. Requires
+	// LavinMQ (native) or the RabbitMQ delayed-message plugin.
+	DelayedExchange bool
+}
+
+// NewBus creates and sets up the job bus for the configured driver. It
+// intentionally does not register handlers: API and fixture processes only
+// dispatch messages, while the worker adds executable handlers through
+// RegisterHandlers.
+//
+// The returned close function releases resources the bus owns itself (the AMQP
+// connection). It never touches the caller-owned pgx pool, so callers keep
+// closing that themselves.
+func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue.Bus, func() error, error) {
+	transport, closeTransport, err := newTransport(pool, config)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	bus := goqueue.NewBus()
 	if config.OTelEnabled {
@@ -31,9 +62,45 @@ func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue
 	bus.AddTransport(TransportName, transport)
 
 	if err := bus.Setup(ctx); err != nil {
-		return nil, fmt.Errorf("setup job bus: %w", err)
+		_ = closeTransport()
+		return nil, nil, fmt.Errorf("setup job bus: %w", err)
 	}
-	return bus, nil
+	return bus, closeTransport, nil
+}
+
+func newTransport(pool *pgxpool.Pool, config BusConfig) (goqueue.Transport, func() error, error) {
+	noopClose := func() error { return nil }
+
+	switch config.Driver {
+	case "", DriverPostgres:
+		if pool == nil {
+			return nil, nil, fmt.Errorf("job bus: postgres driver requires a database pool")
+		}
+		// The pool is shared with the rest of the process, so the transport must
+		// not be closed with the bus — postgres.Transport.Close() closes the pool.
+		return postgres.NewTransportFromPool(pool, postgres.Config{
+			Table: "queue_messages",
+		}), noopClose, nil
+	case DriverAMQP:
+		if config.AMQP.DSN == "" {
+			return nil, nil, fmt.Errorf("job bus: amqp driver requires a broker DSN")
+		}
+		transport := amqp.NewTransport(amqp.Config{
+			DSN:           config.AMQP.DSN,
+			Exchange:      config.AMQP.Exchange,
+			Queue:         config.AMQP.Queue,
+			RoutingKey:    config.AMQP.Queue,
+			PrefetchCount: config.AMQP.PrefetchCount,
+			Durable:       true,
+			// Re-declare exchange, queue, and binding after a broker restart.
+			AutoSetup:         true,
+			PublisherConfirms: true,
+			DelayedExchange:   config.AMQP.DelayedExchange,
+		})
+		return transport, transport.Close, nil
+	default:
+		return nil, nil, fmt.Errorf("job bus: unknown queue driver %q (supported: %s, %s)", config.Driver, DriverPostgres, DriverAMQP)
+	}
 }
 
 // Dispatch routes a Shopmon job explicitly to the stable async transport.

--- a/api/internal/jobs/bus_test.go
+++ b/api/internal/jobs/bus_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5/pgxpool"
 	goqueue "github.com/shyim/go-queue"
 	"github.com/shyim/go-queue/transport/memory"
 	"github.com/stretchr/testify/assert"
@@ -92,6 +93,60 @@ func TestRegisterHandlersRejectsIncompleteWorkerGraph(t *testing.T) {
 	bus, _ := newMemoryBus()
 	require.Error(t, RegisterHandlers(bus, Handlers{}))
 	require.Error(t, RegisterHandlers(nil, completeHandlers()))
+}
+
+func TestNewTransportSelectsDriver(t *testing.T) {
+	amqpConfig := AMQPConfig{DSN: "amqp://guest:guest@localhost:5672/", Exchange: "shopmon", Queue: "shopmon"}
+
+	tests := []struct {
+		name        string
+		config      BusConfig
+		expectedErr string
+	}{
+		{name: "amqp driver", config: BusConfig{Driver: DriverAMQP, AMQP: amqpConfig}},
+		{name: "amqp driver without dsn", config: BusConfig{Driver: DriverAMQP}, expectedErr: "requires a broker DSN"},
+		// The pool is nil in this test, so only the driver dispatch is asserted:
+		// the postgres transport is the one branch that needs it.
+		{name: "postgres driver without pool", config: BusConfig{Driver: DriverPostgres}, expectedErr: "requires a database pool"},
+		{name: "empty driver defaults to postgres", config: BusConfig{}, expectedErr: "requires a database pool"},
+		{name: "unknown driver", config: BusConfig{Driver: "kafka"}, expectedErr: `unknown queue driver "kafka"`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			transport, closeTransport, err := newTransport(nil, test.config)
+
+			if test.expectedErr != "" {
+				assert.ErrorContains(t, err, test.expectedErr)
+				assert.Nil(t, transport)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, transport)
+			// Constructing the AMQP transport must not dial the broker; only
+			// bus.Setup does, so dispatch-only processes fail fast with a clear error.
+			require.NoError(t, closeTransport())
+		})
+	}
+}
+
+func TestNewTransportKeepsPostgresPoolOpen(t *testing.T) {
+	// postgres.Transport.Close() closes the pool it was handed, which the rest of
+	// the process still uses — NewBus must therefore hand back a no-op closer.
+	pool, err := pgxpool.New(context.Background(), "postgres://user:pass@127.0.0.1:1/db")
+	require.NoError(t, err)
+	defer pool.Close()
+
+	_, closeTransport, err := newTransport(pool, BusConfig{Driver: DriverPostgres})
+	require.NoError(t, err)
+	require.NoError(t, closeTransport())
+
+	// A closed pool rejects acquisition with "closed pool"; a live one gets as far
+	// as dialing the (unreachable) address instead.
+	_, err = pool.Acquire(context.Background())
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "closed pool")
 }
 
 func newMemoryBus() (*goqueue.Bus, *memory.Transport) {

--- a/api/queue.go
+++ b/api/queue.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"github.com/friendsofshopware/shopmon/api/internal/config"
+	"github.com/friendsofshopware/shopmon/api/internal/jobs"
+)
+
+// busConfig translates the queue-related environment configuration into the
+// job bus configuration shared by the server, worker, and fixture commands.
+func busConfig(cfg *config.Config) jobs.BusConfig {
+	return jobs.BusConfig{
+		OTelEnabled: cfg.OtelEnabled,
+		Driver:      cfg.QueueTransport,
+		AMQP: jobs.AMQPConfig{
+			DSN:             cfg.QueueAMQP.DSN,
+			Exchange:        cfg.QueueAMQP.Exchange,
+			Queue:           cfg.QueueAMQP.Queue,
+			PrefetchCount:   cfg.QueueAMQP.PrefetchCount,
+			DelayedExchange: cfg.QueueAMQP.DelayedExchange,
+		},
+	}
+}

--- a/api/server.go
+++ b/api/server.go
@@ -121,10 +121,11 @@ func runServer(cmd *cobra.Command, args []string) error {
 
 	// Dispatch-only queue bus. Executable handlers are registered exclusively by
 	// the worker process.
-	bus, err := jobs.NewBus(ctx, pool, jobs.BusConfig{OTelEnabled: cfg.OtelEnabled})
+	bus, closeBus, err := jobs.NewBus(ctx, pool, busConfig(cfg))
 	if err != nil {
 		return err
 	}
+	defer func() { _ = closeBus() }()
 
 	organizationRepository := organizationpostgres.NewAuthorizationRepository(q)
 	organizationAuthorizer := organization.NewAuthorizer(organizationRepository)

--- a/api/worker.go
+++ b/api/worker.go
@@ -68,10 +68,13 @@ func runWorker(cmd *cobra.Command, args []string) error {
 
 	// The worker owns executable handlers; API and fixture processes use the
 	// same bus strictly for dispatch.
-	bus, err := jobs.NewBus(ctx, pool, jobs.BusConfig{OTelEnabled: cfg.OtelEnabled})
+	bus, closeBus, err := jobs.NewBus(ctx, pool, busConfig(cfg))
 	if err != nil {
 		return err
 	}
+	// Deferred after the in-flight drain below, so no job loses its ack because
+	// the broker connection went away early.
+	defer func() { _ = closeBus() }()
 
 	storeSync := catalogsync.NewService(pool, q, cfg)
 	jobDispatcher := jobs.NewDispatcher(bus)

--- a/compose.yml
+++ b/compose.yml
@@ -11,6 +11,17 @@ services:
     ports:
       - "6379:6379"
 
+  # Optional job queue broker. Jobs run on Postgres by default; set
+  # QUEUE_TRANSPORT=amqp to route them through LavinMQ instead. Management UI on
+  # http://localhost:15672 (guest/guest).
+  lavinmq:
+    image: cloudamqp/lavinmq:2.9.1
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - lavinmq-data:/var/lib/lavinmq
+
   db:
     image: postgres:18.3
     environment:
@@ -75,3 +86,4 @@ services:
 
 volumes:
   db-data:
+  lavinmq-data:


### PR DESCRIPTION
Background jobs run on PostgreSQL by default — unchanged, no new infrastructure. Setting `QUEUE_TRANSPORT=amqp` routes them through a RabbitMQ/LavinMQ broker instead, for deployments that already operate one or want the queue off their database.

The driver is selected in `jobs.NewBus`; dispatchers, handlers, and job types stay transport-agnostic.

## Configuration

| Variable | Default | Description |
|---|---|---|
| `QUEUE_TRANSPORT` | `postgres` | `postgres` or `amqp`; unknown values fail at startup with a clear error |
| `QUEUE_AMQP_DSN` | `amqp://guest:guest@localhost:5672/` | Broker connection string |
| `QUEUE_AMQP_EXCHANGE` / `QUEUE_AMQP_QUEUE` | `shopmon` | Declared on startup; queue name doubles as the routing key |
| `QUEUE_AMQP_PREFETCH` | `10` | Matches worker concurrency |
| `QUEUE_AMQP_DELAYED_EXCHANGE` | `true` | Declares the exchange as `x-delayed-message` |

## Local setup

`compose.yml` gains a pinned `cloudamqp/lavinmq:2.9.1` service (5672, management UI on 15672, `guest`/`guest`). `mise run up` still runs jobs on Postgres unless `QUEUE_TRANSPORT=amqp` is exported — see the new CONTRIBUTING section.

## Two details worth reviewing

- **Delayed delivery.** `WithDelay` is load-bearing (post-deployment scrapes, sitespeed reruns), so `DELAYED_EXCHANGE` defaults to on. LavinMQ supports it natively; RabbitMQ needs the delayed-message plugin. Docs warn that turning it off makes delayed jobs fire immediately.
- **`NewBus` now returns a close function** (3 call sites updated). It is a no-op for Postgres *on purpose*: `postgres.Transport.Close()` closes the pgx pool it was handed, which the rest of the process still uses. There is a regression test pinning that.

## Verification

Smoke-tested end to end against a real LavinMQ container: immediate job delivered in 3ms, a 5s-delayed job arrived at 5.0013s — confirming the delayed exchange works. That throwaway test file is not included, since CI has no broker; what remains is driver-selection and config-parsing unit tests.

`mise run lint:api` clean, `mise run test` passes. `mise run lint:fe` fails on `openapi-ts.config.ts` (`Cannot find module '@hey-api/openapi-ts'`) — pre-existing, reproduces on a clean tree, looks like local `node_modules` drift rather than anything in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)