### PR TITLE
fix: respect Shopware Store API 429s during catalog sync

### DIFF
--- a/api/internal/catalog/sync/service.go
+++ b/api/internal/catalog/sync/service.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"math"
 	"sort"
-	"sync"
 
 	"github.com/friendsofshopware/shopmon/api/internal/catalog/storemodel"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
@@ -31,11 +30,21 @@ type Service struct {
 	pool    *pgxpool.Pool
 	queries *queries.Queries
 	cfg     *config.Config
+	// account is an optional store client override (tests). When nil, SyncNames
+	// constructs one from cfg.ShopwareAPIURL.
+	account *shopwareaccount.Client
 }
 
 // NewService creates a new Service.
 func NewService(pool *pgxpool.Pool, q *queries.Queries, cfg *config.Config) *Service {
 	return &Service{pool: pool, queries: q, cfg: cfg}
+}
+
+func (h *Service) accountClient() *shopwareaccount.Client {
+	if h.account != nil {
+		return h.account
+	}
+	return shopwareaccount.NewClient(h.cfg.ShopwareAPIURL, nil)
 }
 
 // Sync refreshes the requested names using the normal freshness checks.
@@ -159,7 +168,7 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 		return nil
 	}
 
-	client := shopwareaccount.NewClient(h.cfg.ShopwareAPIURL, nil)
+	client := h.accountClient()
 
 	// The store's pluginsByName endpoint is scoped to the requested Shopware
 	// version: it omits any plugin whose releases are all incompatible with that
@@ -171,6 +180,11 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	// (en + de), and each extension's catalog data is taken from the richest
 	// probe that returned it.
 	//
+	// Versions are probed sequentially (and locales within a version serially)
+	// so a rate-limit from the store is not amplified by fan-out. On 429 after
+	// client retries, remaining versions are aborted and the job returns an
+	// error for a later retry instead of burning through the rest of the list.
+	//
 	// compat[swv][name] is the compatible latest version the store reports for
 	// that Shopware version; best[name] is the plugin data used to build the
 	// shared catalog subtree, preferring the probe with the most changelog
@@ -178,10 +192,20 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	compat := make(map[string]map[string]string, len(swvs))
 	best := make(map[string]*storemodel.Data, len(needed))
 	anyProbeSucceeded := false
+	var rateLimitErr error
 
 	for _, swv := range swvs {
 		enPlugins, dePlugins, err := h.probeVersion(ctx, client, swv, needed)
 		if err != nil {
+			if shopwareaccount.IsRateLimited(err) {
+				// Stop probing further versions; continuing would only deepen the
+				// 429 burst. Partial progress (if any) is persisted below without
+				// advancing sync bookkeeping so the queue / next scrape retries.
+				slog.Warn("store rate limited, aborting remaining version probes",
+					"shopwareVersion", swv, "error", err)
+				rateLimitErr = err
+				break
+			}
 			// Skip this version; its missing compatibility rows re-trigger a sync
 			// from the next scrape of an environment running it.
 			slog.Warn("failed to probe store plugins", "shopwareVersion", swv, "error", err)
@@ -208,6 +232,9 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	if !anyProbeSucceeded {
 		// Bookkeeping is deliberately not updated so the queue retry (or the next
 		// scrape dispatch) tries again.
+		if rateLimitErr != nil {
+			return fmt.Errorf("store rate limited; all probes failed for %d version(s): %w", len(swvs), rateLimitErr)
+		}
 		return fmt.Errorf("all store probes failed for %d version(s)", len(swvs))
 	}
 
@@ -224,6 +251,15 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	}
 	span.SetAttributes(attribute.Int("extension.synced", synced))
 
+	if rateLimitErr != nil {
+		// Persist what we have but do not mark names fresh — missing compatibility
+		// rows and stale bookkeeping will re-dispatch, and the returned error lets
+		// the queue retry with its own backoff.
+		slog.Warn("synced store extensions partially before rate limit",
+			"requested", len(names), "fetched", len(needed), "found", synced)
+		return fmt.Errorf("store rate limited after probing %d/%d version(s): %w", len(compat), len(swvs), rateLimitErr)
+	}
+
 	if err := h.queries.UpsertStoreExtensionSyncStates(ctx, needed); err != nil {
 		return fmt.Errorf("upsert sync states: %w", err)
 	}
@@ -233,24 +269,20 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 }
 
 // probeVersion fetches the given names from the store in both locales scoped to
-// one Shopware version, concurrently. It returns an error only when both locale
-// calls fail; a single-locale failure is logged and its (nil) result is used.
+// one Shopware version, sequentially (en then de) to avoid doubling concurrent
+// pressure on the store API. It returns a rate-limit error immediately so the
+// caller can abort remaining versions. Otherwise it returns an error only when
+// both locale calls fail; a single-locale failure is logged and its (nil)
+// result is used.
 func (h *Service) probeVersion(ctx context.Context, client *shopwareaccount.Client, shopwareVersion string, names []string) ([]shopwareaccount.StorePlugin, []shopwareaccount.StorePlugin, error) {
-	var (
-		enPlugins, dePlugins []shopwareaccount.StorePlugin
-		enErr, deErr         error
-		wg                   sync.WaitGroup
-	)
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		enPlugins, enErr = client.PluginsByName(ctx, "en_GB", shopwareVersion, names)
-	}()
-	go func() {
-		defer wg.Done()
-		dePlugins, deErr = client.PluginsByName(ctx, "de_DE", shopwareVersion, names)
-	}()
-	wg.Wait()
+	enPlugins, enErr := client.PluginsByName(ctx, "en_GB", shopwareVersion, names)
+	if shopwareaccount.IsRateLimited(enErr) {
+		return nil, nil, enErr
+	}
+	dePlugins, deErr := client.PluginsByName(ctx, "de_DE", shopwareVersion, names)
+	if shopwareaccount.IsRateLimited(deErr) {
+		return nil, nil, deErr
+	}
 
 	if enErr != nil && deErr != nil {
 		return nil, nil, fmt.Errorf("en: %w, de: %v", enErr, deErr)

--- a/api/internal/catalog/sync/service_test.go
+++ b/api/internal/catalog/sync/service_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/maintenance"
+	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +38,19 @@ type mockStoreServer struct {
 	*httptest.Server
 	requests   atomic.Int64
 	extensions map[string]*mockExtension
+
+	mu sync.Mutex
+	// rateLimitedVersions, when set, causes pluginsByName for those Shopware
+	// versions to respond with HTTP 429.
+	rateLimitedVersions map[string]bool
+	// seen records locale@shopwareVersion hits in order.
+	seen []string
+	// inFlight tracks concurrent handlers; maxInFlight is the high-water mark.
+	inFlight    int
+	maxInFlight int
+	// handlerDelay, when > 0, holds each handler briefly so overlapping
+	// concurrent calls raise maxInFlight (used by the serialization test).
+	handlerDelay time.Duration
 }
 
 func newMockStoreServer(t *testing.T) *mockStoreServer {
@@ -46,6 +62,7 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 				changelogVersions:       []string{"1.2.0", "1.1.0", "1.0.0"},
 			},
 		},
+		rateLimitedVersions: map[string]bool{},
 	}
 
 	mux := http.NewServeMux()
@@ -53,6 +70,32 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 		m.requests.Add(1)
 		locale := r.URL.Query().Get("locale")
 		swv := r.URL.Query().Get("shopwareVersion")
+
+		m.mu.Lock()
+		m.seen = append(m.seen, locale+"@"+swv)
+		m.inFlight++
+		if m.inFlight > m.maxInFlight {
+			m.maxInFlight = m.inFlight
+		}
+		rateLimited := m.rateLimitedVersions[swv]
+		delay := m.handlerDelay
+		m.mu.Unlock()
+
+		defer func() {
+			m.mu.Lock()
+			m.inFlight--
+			m.mu.Unlock()
+		}()
+
+		if delay > 0 {
+			time.Sleep(delay)
+		}
+
+		if rateLimited {
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
 
 		var plugins []map[string]any
 		for _, name := range r.URL.Query()["technicalNames[]"] {
@@ -98,6 +141,28 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 	m.Server = httptest.NewServer(mux)
 	t.Cleanup(m.Close)
 	return m
+}
+
+func (m *mockStoreServer) seenLocales() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.seen))
+	copy(out, m.seen)
+	return out
+}
+
+func (m *mockStoreServer) maxConcurrent() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.maxInFlight
+}
+
+// fastStoreClient returns a client that fails 429s on the first attempt (no
+// real backoff sleep) so sync tests stay fast.
+func fastStoreClient(baseURL string) *shopwareaccount.Client {
+	client := shopwareaccount.NewClient(baseURL, nil)
+	client.ConfigureRetry(1, func(context.Context, time.Duration) error { return nil })
+	return client
 }
 
 // setupSyncTest returns a sync handler wired to a mock store server, with two
@@ -365,6 +430,76 @@ func TestNamesNeedingSyncCompatibilityGap(t *testing.T) {
 	needing, err = h.namesNeedingSync(ctx, []string{"FroshTools", "CustomPlugin"}, "6.7.0.0")
 	require.NoError(t, err, "namesNeedingSync")
 	assert.Equal(t, []string{"FroshTools"}, needing, "needing sync for new version")
+}
+
+// TestStoreExtensionSyncSerializesLocaleProbes: en and de for a version must
+// not run concurrently, otherwise catalog sync doubles store API pressure.
+func TestStoreExtensionSyncSerializesLocaleProbes(t *testing.T) {
+	h, _, store := setupSyncTest(t)
+	store.handlerDelay = 30 * time.Millisecond
+
+	require.NoError(t, h.SyncNames(context.Background(), []string{"FroshTools"}, "6.5.0.0", false))
+
+	assert.Equal(t, 1, store.maxConcurrent(), "locale/version probes must be serial")
+	assert.Equal(t, []string{
+		"en_GB@6.6.0.0", "de_DE@6.6.0.0",
+		"en_GB@6.5.0.0", "de_DE@6.5.0.0",
+	}, store.seenLocales(), "versions newest-first, locales en then de")
+}
+
+// TestStoreExtensionSyncAbortsRemainingVersionsOn429: once the store rate-limits
+// a version probe, SyncNames must stop probing further versions instead of
+// stomping through the rest of the list, leave sync bookkeeping untouched so a
+// retry can continue, and still persist any versions already probed.
+func TestStoreExtensionSyncAbortsRemainingVersionsOn429(t *testing.T) {
+	h, pool, store := setupSyncTest(t)
+	ctx := context.Background()
+
+	// Newest version (6.6.0.0) succeeds; older 6.5.0.0 is rate-limited. Probes
+	// run newest-first, so we get partial progress then abort.
+	store.rateLimitedVersions["6.5.0.0"] = true
+	h.account = fastStoreClient(store.URL)
+
+	err := h.SyncNames(ctx, []string{"FroshTools"}, "6.6.0.0", false)
+	require.Error(t, err)
+	assert.True(t, shopwareaccount.IsRateLimited(err), "expected rate-limit error, got %v", err)
+
+	// 6.6 en+de succeeded; 6.5 en hit 429 and aborted before de (and before any
+	// further versions, of which there are none).
+	assert.Equal(t, []string{
+		"en_GB@6.6.0.0", "de_DE@6.6.0.0",
+		"en_GB@6.5.0.0",
+	}, store.seenLocales())
+	assert.Equal(t, int64(3), store.requests.Load())
+
+	// Partial catalog for the successful version is kept.
+	assert.Equal(t, 1, countRows(t, pool, "store_extension"), "partial catalog persisted")
+	var latest66 *string
+	require.NoError(t, pool.QueryRow(ctx, `SELECT latest_version FROM store_extension_compatibility WHERE extension_name = 'FroshTools' AND shopware_version = '6.6.0.0'`).Scan(&latest66))
+	require.NotNil(t, latest66)
+	assert.Equal(t, "1.2.0", *latest66)
+
+	// No compatibility row for the aborted version, and sync bookkeeping must
+	// not be advanced (otherwise the hourly freshness gate would starve retries).
+	assert.Equal(t, 1, countRows(t, pool, "store_extension_compatibility"))
+	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"), "bookkeeping not marked fresh after rate limit")
+}
+
+// TestStoreExtensionSyncAllProbesRateLimited: when the first version is already
+// rate-limited, nothing is persisted and the error surfaces for job retry.
+func TestStoreExtensionSyncAllProbesRateLimited(t *testing.T) {
+	h, pool, store := setupSyncTest(t)
+	store.rateLimitedVersions["6.6.0.0"] = true
+	store.rateLimitedVersions["6.5.0.0"] = true
+	h.account = fastStoreClient(store.URL)
+
+	err := h.SyncNames(context.Background(), []string{"FroshTools"}, "6.6.0.0", false)
+	require.Error(t, err)
+	assert.True(t, shopwareaccount.IsRateLimited(err), "expected rate-limit error, got %v", err)
+
+	assert.Equal(t, []string{"en_GB@6.6.0.0"}, store.seenLocales(), "must not continue after first 429")
+	assert.Equal(t, 0, countRows(t, pool, "store_extension"))
+	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"))
 }
 
 // TestOldDataCleanupRetainsCatalog verifies the catalog itself — including its

--- a/api/internal/shopwareaccount/client.go
+++ b/api/internal/shopwareaccount/client.go
@@ -1,9 +1,7 @@
-// Package shopwareaccount provides a client for the Shopware account/store API
-// (api.shopware.com). This is distinct from internal/shopware, which talks to a
-// single shop's admin API.
 package shopwareaccount
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -18,6 +16,14 @@ const DefaultBaseURL = "https://api.shopware.com"
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
+
+	// Optional retry tuning for 429 responses. Zero values use defaults; tests
+	// set these to keep backoff fast and deterministic.
+	maxAttempts   int
+	baseBackoff   time.Duration
+	maxBackoff    time.Duration
+	maxRetryAfter time.Duration
+	sleepFn       func(context.Context, time.Duration) error
 }
 
 // NewClient creates a Client for the given base URL. If httpClient is nil a
@@ -33,4 +39,11 @@ func NewClient(baseURL string, httpClient *http.Client) *Client {
 		baseURL:    strings.TrimRight(baseURL, "/"),
 		httpClient: httpClient,
 	}
+}
+
+// ConfigureRetry overrides 429 retry behaviour. Intended for tests that need
+// deterministic, fast backoff; production callers should use NewClient defaults.
+func (c *Client) ConfigureRetry(maxAttempts int, sleep func(context.Context, time.Duration) error) {
+	c.maxAttempts = maxAttempts
+	c.sleepFn = sleep
 }

--- a/api/internal/shopwareaccount/retry.go
+++ b/api/internal/shopwareaccount/retry.go
@@ -1,0 +1,155 @@
+package shopwareaccount
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math/rand/v2"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultMaxAttempts   = 5
+	defaultBaseBackoff   = 500 * time.Millisecond
+	defaultMaxBackoff    = 30 * time.Second
+	defaultMaxRetryAfter = 60 * time.Second
+)
+
+// APIError is returned for non-2xx store API responses after any retries are
+// exhausted (or immediately for non-retryable statuses).
+type APIError struct {
+	StatusCode int
+}
+
+func (e *APIError) Error() string {
+	return fmt.Sprintf("store api returned status %d", e.StatusCode)
+}
+
+// IsRateLimited reports whether err is (or wraps) a store API 429 response.
+func IsRateLimited(err error) bool {
+	var apiErr *APIError
+	return errors.As(err, &apiErr) && apiErr.StatusCode == http.StatusTooManyRequests
+}
+
+func (c *Client) retryMaxAttempts() int {
+	if c.maxAttempts > 0 {
+		return c.maxAttempts
+	}
+	return defaultMaxAttempts
+}
+
+func (c *Client) retryBaseBackoff() time.Duration {
+	if c.baseBackoff > 0 {
+		return c.baseBackoff
+	}
+	return defaultBaseBackoff
+}
+
+func (c *Client) retryMaxBackoff() time.Duration {
+	if c.maxBackoff > 0 {
+		return c.maxBackoff
+	}
+	return defaultMaxBackoff
+}
+
+func (c *Client) retryMaxRetryAfter() time.Duration {
+	if c.maxRetryAfter > 0 {
+		return c.maxRetryAfter
+	}
+	return defaultMaxRetryAfter
+}
+
+func (c *Client) sleep(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	if c.sleepFn != nil {
+		return c.sleepFn(ctx, d)
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}
+
+// do performs req, retrying on HTTP 429 with Retry-After when present and
+// otherwise exponential backoff with jitter. Non-429 responses are returned
+// immediately (caller interprets the status). Context cancellation aborts waits.
+func (c *Client) do(req *http.Request) (*http.Response, error) {
+	attempts := c.retryMaxAttempts()
+	var lastStatus int
+
+	for attempt := 1; attempt <= attempts; attempt++ {
+		resp, err := c.httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode != http.StatusTooManyRequests {
+			return resp, nil
+		}
+
+		lastStatus = resp.StatusCode
+		retryAfter := parseRetryAfter(resp.Header.Get("Retry-After"))
+		// Drain and close so the connection can be reused on the next attempt.
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+
+		if attempt == attempts {
+			break
+		}
+
+		delay := c.backoffDelay(attempt, retryAfter)
+		if err := c.sleep(req.Context(), delay); err != nil {
+			return nil, fmt.Errorf("wait before retry: %w", err)
+		}
+	}
+
+	return nil, &APIError{StatusCode: lastStatus}
+}
+
+func (c *Client) backoffDelay(attempt int, retryAfter time.Duration) time.Duration {
+	if retryAfter > 0 {
+		if capAt := c.retryMaxRetryAfter(); retryAfter > capAt {
+			return capAt
+		}
+		return retryAfter
+	}
+
+	// attempt is 1-based for the failed request. Cap exponential growth and add
+	// full-jitter in [0, base].
+	base := c.retryBaseBackoff()
+	mult := 1 << min(attempt-1, 20)
+	exp := min(base*time.Duration(mult), c.retryMaxBackoff())
+	jitter := time.Duration(rand.Int64N(int64(base) + 1))
+	return exp + jitter
+}
+
+// parseRetryAfter parses a Retry-After header as delta-seconds or HTTP-date.
+// Returns 0 when the header is missing or unparseable.
+func parseRetryAfter(h string) time.Duration {
+	if h == "" {
+		return 0
+	}
+	if seconds, err := strconv.Atoi(h); err == nil {
+		if seconds < 0 {
+			return 0
+		}
+		return time.Duration(seconds) * time.Second
+	}
+	if t, err := http.ParseTime(h); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}

--- a/api/internal/shopwareaccount/retry_test.go
+++ b/api/internal/shopwareaccount/retry_test.go
@@ -1,0 +1,139 @@
+package shopwareaccount
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginsByNameRetries429WithRetryAfter(t *testing.T) {
+	var hits atomic.Int64
+	var slept []time.Duration
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n < 3 {
+			w.Header().Set("Retry-After", "2")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode([]map[string]any{
+			{"id": 1, "name": "FroshTools", "label": "Tools", "version": "1.0.0"},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, srv.Client())
+	client.maxAttempts = 5
+	client.sleepFn = func(_ context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}
+
+	plugins, err := client.PluginsByName(context.Background(), "en_GB", "6.6.0.0", []string{"FroshTools"})
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+	assert.Equal(t, "FroshTools", plugins[0].Name)
+	assert.Equal(t, int64(3), hits.Load(), "should retry until success")
+	require.Len(t, slept, 2)
+	assert.Equal(t, 2*time.Second, slept[0], "honor Retry-After")
+	assert.Equal(t, 2*time.Second, slept[1], "honor Retry-After on second wait")
+}
+
+func TestPluginsByNameRetries429WithExponentialBackoff(t *testing.T) {
+	var hits atomic.Int64
+	var slept []time.Duration
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := hits.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte("[]"))
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, srv.Client())
+	client.maxAttempts = 5
+	client.baseBackoff = 100 * time.Millisecond
+	client.maxBackoff = time.Second
+	client.sleepFn = func(_ context.Context, d time.Duration) error {
+		slept = append(slept, d)
+		return nil
+	}
+
+	_, err := client.PluginsByName(context.Background(), "en_GB", "6.6.0.0", []string{"FroshTools"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), hits.Load())
+	require.Len(t, slept, 2)
+	// Without Retry-After: base*2^(attempt-1) + jitter in [0, base].
+	assert.GreaterOrEqual(t, slept[0], 100*time.Millisecond)
+	assert.LessOrEqual(t, slept[0], 200*time.Millisecond)
+	assert.GreaterOrEqual(t, slept[1], 200*time.Millisecond)
+	assert.LessOrEqual(t, slept[1], 300*time.Millisecond)
+}
+
+func TestPluginsByNameExhausts429Retries(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Retry-After", "1")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, srv.Client())
+	client.maxAttempts = 3
+	client.sleepFn = func(context.Context, time.Duration) error { return nil }
+
+	_, err := client.PluginsByName(context.Background(), "en_GB", "6.6.0.0", []string{"FroshTools"})
+	require.Error(t, err)
+	assert.True(t, IsRateLimited(err), "error should be rate-limited: %v", err)
+	assert.Equal(t, int64(3), hits.Load())
+}
+
+func TestPluginsByNameDoesNotRetryNon429(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	t.Cleanup(srv.Close)
+
+	client := NewClient(srv.URL, srv.Client())
+	client.maxAttempts = 5
+	client.sleepFn = func(context.Context, time.Duration) error {
+		t.Fatal("should not sleep for non-429")
+		return nil
+	}
+
+	_, err := client.PluginsByName(context.Background(), "en_GB", "6.6.0.0", []string{"FroshTools"})
+	require.Error(t, err)
+	var apiErr *APIError
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusBadRequest, apiErr.StatusCode)
+	assert.False(t, IsRateLimited(err))
+	assert.Equal(t, int64(1), hits.Load())
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	assert.Equal(t, time.Duration(0), parseRetryAfter(""))
+	assert.Equal(t, 5*time.Second, parseRetryAfter("5"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("-1"))
+	assert.Equal(t, time.Duration(0), parseRetryAfter("not-a-date"))
+
+	future := time.Now().UTC().Add(3 * time.Second).Format(http.TimeFormat)
+	d := parseRetryAfter(future)
+	assert.Greater(t, d, time.Duration(0))
+	assert.LessOrEqual(t, d, 3*time.Second+time.Second)
+}

--- a/api/internal/shopwareaccount/store.go
+++ b/api/internal/shopwareaccount/store.go
@@ -98,14 +98,14 @@ func (c *Client) PluginsByName(ctx context.Context, locale, shopwareVersion stri
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 
-	resp, err := c.httpClient.Do(req)
+	resp, err := c.do(req)
 	if err != nil {
 		return nil, fmt.Errorf("fetch store plugins: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("store api returned status %d", resp.StatusCode)
+		return nil, &APIError{StatusCode: resp.StatusCode}
 	}
 
 	body, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Production `shopmon-worker` was bursting `api.shopware.com` during store-extension catalog sync:

1. **No 429 handling** in `shopwareaccount.PluginsByName` — any non-200 became an immediate error (`store api returned status 429`) with no `Retry-After` / backoff.
2. **Probe fan-out** in `catalog/sync`: every distinct in-use Shopware version was probed, and within each version **en_GB + de_DE ran concurrently**. On probe failure the sync logged a warn and **continued to the next version**, so a rate-limit did not stop the stomping — scrapes then redispatched sync for missing compatibility rows.

## Changes

### Store client (`api/internal/shopwareaccount`)
- Shared `do()` retries **HTTP 429 only** (other statuses are not blindly retried).
- Honors `Retry-After` (delta-seconds or HTTP-date), capped; otherwise exponential backoff with jitter.
- Caps attempts (default 5) and surfaces `APIError` / `IsRateLimited` when still failing.
- Unit tests cover Retry-After, exponential backoff, exhaustion, and non-429 no-retry.

### Catalog sync (`api/internal/catalog/sync`)
- Locale probes are **serialized** (en then de) instead of concurrent.
- On rate-limit after client retries: **abort remaining version probes**.
- Persist any successful probes, but **do not** advance sync bookkeeping; return a wrapped rate-limit error so the queue / next scrape can retry without marking names fresh.
- Tests for serialization, abort-after-429 (partial progress), and all-probes-429.

## Verification

- `mise run lint` — passed (API golangci-lint + frontend oxlint/tsc/oxfmt/vitest)
- `mise run test` — passed (`go test ./internal/...`)
- Also: `go test ./internal/shopwareaccount/ ./internal/catalog/sync/`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca6620ef-4a18-4e57-a92e-3c04ffd221e8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca6620ef-4a18-4e57-a92e-3c04ffd221e8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

