### PR TITLE
fix: use sqlc query names for otelpgx/Datadog DB span resources

### DIFF
--- a/api/internal/database/db.go
+++ b/api/internal/database/db.go
@@ -21,9 +21,14 @@ func NewPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	config.MaxConnIdleTime = 30 * time.Minute
 	config.ConnConfig.ConnectTimeout = 10 * time.Second
 	// WithTrimSQLInSpanName keeps the full statement in span attributes (for
-	// Datadog's SQL obfuscation) but trims it out of the span name, so the
-	// trace resource column shows the operation instead of the whole query.
-	config.ConnConfig.Tracer = otelpgx.NewTracer(otelpgx.WithTrimSQLInSpanName())
+	// Datadog's SQL obfuscation) but uses a short operation for the span name.
+	// sqlc prefixes generated SQL with `-- name: Foo ...`; otelpgx's default
+	// first-word trim treats `--` as the operation (Datadog: `query --`).
+	// SQLSpanName prefers the sqlc query name, else the first SQL keyword.
+	config.ConnConfig.Tracer = otelpgx.NewTracer(
+		otelpgx.WithTrimSQLInSpanName(),
+		otelpgx.WithSpanNameFunc(SQLSpanName),
+	)
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)
 	if err != nil {

--- a/api/internal/database/span_name.go
+++ b/api/internal/database/span_name.go
@@ -1,0 +1,74 @@
+package database
+
+import (
+	"strings"
+	"unicode"
+)
+
+const sqlOperationUnknown = "UNKNOWN"
+
+// SQLSpanName returns a low-cardinality operation name for an OpenTelemetry DB
+// span. sqlc embeds a leading `-- name: <Name> ...` comment in generated SQL;
+// otelpgx's default first-word trim treats that `--` as the operation, which
+// collapses Datadog resources to `query --`. Prefer the sqlc query name when
+// present; otherwise fall back to the first SQL keyword.
+func SQLSpanName(stmt string) string {
+	for _, line := range strings.Split(stmt, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if name, ok := sqlcQueryName(line); ok {
+			return name
+		}
+		if strings.HasPrefix(line, "--") {
+			continue
+		}
+		return firstSQLKeyword(line)
+	}
+	return sqlOperationUnknown
+}
+
+// sqlcQueryName extracts the query name from a single sqlc annotation line
+// (`-- name: Foo :exec`). The line must already be trimmed.
+func sqlcQueryName(line string) (string, bool) {
+	const prefix = "-- name:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if rest == "" {
+		return "", false
+	}
+	name := rest
+	if i := strings.IndexFunc(rest, unicode.IsSpace); i >= 0 {
+		name = rest[:i]
+	}
+	if name == "" || !isSQLCQueryName(name) {
+		return "", false
+	}
+	return name, true
+}
+
+func firstSQLKeyword(line string) string {
+	for _, field := range strings.Fields(line) {
+		return strings.ToUpper(field)
+	}
+	return sqlOperationUnknown
+}
+
+// isSQLCQueryName keeps span names low-cardinality by accepting only identifier-
+// like sqlc names (letters, digits, underscore). Rejects anything that looks
+// like SQL body text.
+func isSQLCQueryName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/api/internal/database/span_name_test.go
+++ b/api/internal/database/span_name_test.go
@@ -1,0 +1,108 @@
+package database
+
+import "testing"
+
+func TestSQLSpanName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		stmt string
+		want string
+	}{
+		{
+			name: "sqlc named insert",
+			stmt: `-- name: UpsertEnvironmentExtension :exec
+INSERT INTO environment_extension (id) VALUES ($1)
+`,
+			want: "UpsertEnvironmentExtension",
+		},
+		{
+			name: "sqlc named select",
+			stmt: `-- name: GetEnvironmentByID :one
+SELECT * FROM environment WHERE id = $1
+`,
+			want: "GetEnvironmentByID",
+		},
+		{
+			name: "sqlc named update",
+			stmt: `-- name: UpdateEnvironmentName :exec
+UPDATE environment SET name = $1 WHERE id = $2
+`,
+			want: "UpdateEnvironmentName",
+		},
+		{
+			name: "sqlc named delete",
+			stmt: `-- name: DeleteEnvironment :exec
+DELETE FROM environment WHERE id = $1
+`,
+			want: "DeleteEnvironment",
+		},
+		{
+			name: "plain select without sqlc comment",
+			stmt: `SELECT id FROM environment WHERE id = $1`,
+			want: "SELECT",
+		},
+		{
+			name: "plain insert without sqlc comment",
+			stmt: `INSERT INTO environment (name) VALUES ($1)`,
+			want: "INSERT",
+		},
+		{
+			name: "plain with query",
+			stmt: `WITH recent AS (SELECT 1) SELECT * FROM recent`,
+			want: "WITH",
+		},
+		{
+			name: "leading whitespace before sqlc name",
+			stmt: `
+  -- name: ListEnvironmentsByOrganization :many
+SELECT id FROM environment
+`,
+			want: "ListEnvironmentsByOrganization",
+		},
+		{
+			name: "leading whitespace before plain sql",
+			stmt: `
+
+		UPDATE environment SET name = $1 WHERE id = $2
+`,
+			want: "UPDATE",
+		},
+		{
+			name: "multiple non-sqlc comments before statement",
+			stmt: `-- skip vacuum during maintenance
+-- caller holds advisory lock
+DELETE FROM environment_check WHERE environment_id = $1
+`,
+			want: "DELETE",
+		},
+		{
+			name: "non-sqlc comments then sqlc name",
+			stmt: `-- prepared for scrape
+-- name: CreateEnvironment :one
+INSERT INTO environment (name) VALUES ($1) RETURNING id
+`,
+			want: "CreateEnvironment",
+		},
+		{
+			name: "empty statement",
+			stmt: "   \n\t  ",
+			want: "UNKNOWN",
+		},
+		{
+			name: "only comments",
+			stmt: "-- just a comment\n-- another",
+			want: "UNKNOWN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := SQLSpanName(tt.stmt); got != tt.want {
+				t.Fatalf("SQLSpanName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Datadog production, ~1M worker spans / 6h collapsed to `resource_name:query --` with `db.operation.name: --`. The full SQL remained in `db.statement.text` / `db.query.text`, so the statements themselves were fine — only the resource/operation name was wrong.

## Root cause

sqlc embeds a leading annotation in generated SQL constants:

```sql
-- name: UpsertEnvironmentExtension :exec
INSERT INTO ...
```

`NewPool` configured otelpgx with `WithTrimSQLInSpanName()`, whose default span-name func takes the first whitespace-delimited word of the statement. For sqlc SQL that first “word” is `--`, so spans become `query --`.

## Fix

- Add `database.SQLSpanName`, which:
  - Prefer the sqlc query name when a `-- name: <Name> ...` comment is present (e.g. `UpsertEnvironmentExtension`)
  - Otherwise skip leading whitespace / non-sqlc `--` comments and use the first SQL keyword (`SELECT` / `INSERT` / …)
  - Never uses the full SQL body (keeps cardinality low)
- Wire it with `otelpgx.WithSpanNameFunc(SQLSpanName)` alongside the existing `WithTrimSQLInSpanName()` so span names and `db.operation.name` both use the helper
- Unit-test named INSERT/SELECT/UPDATE/DELETE, plain SQL, and leading whitespace / multi-comment cases

No query semantics, pool settings, or unrelated telemetry changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d5812455-fedc-4e75-ac9a-553cefd6c5cf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d5812455-fedc-4e75-ac9a-553cefd6c5cf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

