### PR TITLE
fix: name outbound HTTP client spans METHOD host/path for Datadog

### DIFF
--- a/api/internal/httputil/client.go
+++ b/api/internal/httputil/client.go
@@ -99,8 +99,11 @@ func wrapTransport(base http.RoundTripper) http.RoundTripper {
 		base = http.DefaultTransport
 	}
 	return &userAgentTransport{
-		base: otelhttp.NewTransport(base),
-		ua:   UserAgentString(),
+		base: otelhttp.NewTransport(
+			base,
+			otelhttp.WithSpanNameFormatter(ClientSpanName),
+		),
+		ua: UserAgentString(),
 	}
 }
 

--- a/api/internal/httputil/client_span_name.go
+++ b/api/internal/httputil/client_span_name.go
@@ -4,14 +4,28 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"unicode"
 )
+
+// sharedSpanHosts are outbound peers with stable, deployment-wide cardinality.
+// Tenant shop domains, SSO IdPs, and other per-customer hosts are collapsed to
+// "{host}" so Datadog resources stay bounded while shared APIs remain readable
+// (e.g. "GET api.shopware.com/pluginStore/pluginsByName").
+var sharedSpanHosts = map[string]struct{}{
+	"api.shopware.com":          {},
+	"releases.shopware.com":     {},
+	"store.shopware.com":        {},
+	"raw.githubusercontent.com": {},
+}
 
 // ClientSpanName formats an outbound HTTP client span as "METHOD host/path".
 //
 // otelhttp's default transport formatter uses only the method ("HTTP GET"),
-// which Datadog collapses to a bare GET/POST resource. Including host + path
-// (without query string) keeps cardinality low while making worker traces
-// actionable — e.g. "GET api.shopware.com/pluginStore/pluginsByName".
+// which Datadog collapses to a bare GET/POST resource. This formatter keeps
+// cardinality low by:
+//   - stripping query strings
+//   - keeping only known shared hosts literal; other hosts become "{host}"
+//   - replacing UUID / numeric / long-hex path segments with "{id}"
 //
 // The operation argument is ignored; otelhttp's client transport always passes "".
 func ClientSpanName(_ string, r *http.Request) string {
@@ -24,8 +38,8 @@ func ClientSpanName(_ string, r *http.Request) string {
 		method = http.MethodGet
 	}
 
-	host := requestHost(r)
-	path := requestPath(r)
+	host := spanHost(requestHost(r))
+	path := spanPath(requestPath(r))
 
 	if host == "" {
 		return method + " " + path
@@ -76,4 +90,101 @@ func hostnameOnly(hostport string) string {
 		return hostport
 	}
 	return host
+}
+
+func spanHost(host string) string {
+	if host == "" {
+		return ""
+	}
+	host = strings.ToLower(host)
+	if _, ok := sharedSpanHosts[host]; ok {
+		return host
+	}
+	return "{host}"
+}
+
+func spanPath(path string) string {
+	if path == "" || path == "/" {
+		return "/"
+	}
+
+	leading := strings.HasPrefix(path, "/")
+	parts := strings.Split(path, "/")
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+		if isHighCardinalityPathSegment(part) {
+			parts[i] = "{id}"
+		}
+	}
+	out := strings.Join(parts, "/")
+	if leading && !strings.HasPrefix(out, "/") {
+		return "/" + out
+	}
+	return out
+}
+
+func isHighCardinalityPathSegment(seg string) bool {
+	if isUUIDSegment(seg) {
+		return true
+	}
+	if isAllDigits(seg) {
+		return true
+	}
+	// Long hex tokens (OAuth-ish / opaque IDs), but not short version-like
+	// fragments such as "v1".
+	if len(seg) >= 16 && isAllHex(seg) {
+		return true
+	}
+	return false
+}
+
+func isUUIDSegment(seg string) bool {
+	// 8-4-4-4-12 dashed UUID.
+	if len(seg) == 36 {
+		for i, r := range seg {
+			switch i {
+			case 8, 13, 18, 23:
+				if r != '-' {
+					return false
+				}
+			default:
+				if !isHexRune(r) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	// 32-char hex UUID without dashes.
+	return len(seg) == 32 && isAllHex(seg)
+}
+
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isAllHex(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !isHexRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isHexRune(r rune) bool {
+	return unicode.IsDigit(r) || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
 }

--- a/api/internal/httputil/client_span_name.go
+++ b/api/internal/httputil/client_span_name.go
@@ -1,0 +1,79 @@
+package httputil
+
+import (
+	"net"
+	"net/http"
+	"strings"
+)
+
+// ClientSpanName formats an outbound HTTP client span as "METHOD host/path".
+//
+// otelhttp's default transport formatter uses only the method ("HTTP GET"),
+// which Datadog collapses to a bare GET/POST resource. Including host + path
+// (without query string) keeps cardinality low while making worker traces
+// actionable — e.g. "GET api.shopware.com/pluginStore/pluginsByName".
+//
+// The operation argument is ignored; otelhttp's client transport always passes "".
+func ClientSpanName(_ string, r *http.Request) string {
+	if r == nil {
+		return http.MethodGet
+	}
+
+	method := r.Method
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	host := requestHost(r)
+	path := requestPath(r)
+
+	if host == "" {
+		return method + " " + path
+	}
+	if strings.HasPrefix(path, "/") {
+		return method + " " + host + path
+	}
+	return method + " " + host + "/" + path
+}
+
+func requestHost(r *http.Request) string {
+	if r.URL != nil {
+		if host := r.URL.Hostname(); host != "" {
+			return host
+		}
+		if host := hostnameOnly(r.URL.Host); host != "" {
+			return host
+		}
+	}
+	return hostnameOnly(r.Host)
+}
+
+func requestPath(r *http.Request) string {
+	if r.URL == nil {
+		return "/"
+	}
+	// EscapedPath omits the query string; fall back to Path, then "/".
+	path := r.URL.EscapedPath()
+	if path == "" {
+		path = r.URL.Path
+	}
+	if path == "" {
+		return "/"
+	}
+	return path
+}
+
+func hostnameOnly(hostport string) string {
+	if hostport == "" {
+		return ""
+	}
+	// Strip brackets from IPv6 literals without a port: "[::1]".
+	if strings.HasPrefix(hostport, "[") && strings.HasSuffix(hostport, "]") {
+		return hostport[1 : len(hostport)-1]
+	}
+	host, _, err := net.SplitHostPort(hostport)
+	if err != nil {
+		return hostport
+	}
+	return host
+}

--- a/api/internal/httputil/client_span_name_test.go
+++ b/api/internal/httputil/client_span_name_test.go
@@ -1,0 +1,91 @@
+package httputil
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestClientSpanName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		method string
+		rawURL string
+		host   string // optional Request.Host override when URL has no host
+		want   string
+	}{
+		{
+			name:   "host and path",
+			method: http.MethodGet,
+			rawURL: "https://api.shopware.com/pluginStore/pluginsByName",
+			want:   "GET api.shopware.com/pluginStore/pluginsByName",
+		},
+		{
+			name:   "query string stripped",
+			method: http.MethodGet,
+			rawURL: "https://api.shopware.com/pluginStore/pluginsByName?locale=en-GB&shopId=abc",
+			want:   "GET api.shopware.com/pluginStore/pluginsByName",
+		},
+		{
+			name:   "missing host falls back to path",
+			method: http.MethodPost,
+			rawURL: "/swplatform/autoupdate",
+			want:   "POST /swplatform/autoupdate",
+		},
+		{
+			name:   "empty path",
+			method: http.MethodGet,
+			rawURL: "https://api.shopware.com",
+			want:   "GET api.shopware.com/",
+		},
+		{
+			name:   "empty path with trailing slash equivalent",
+			method: http.MethodHead,
+			rawURL: "https://example.com/",
+			want:   "HEAD example.com/",
+		},
+		{
+			name:   "host from Request.Host when URL host empty",
+			method: http.MethodPut,
+			rawURL: "/api/oauth/token",
+			host:   "shop.example:443",
+			want:   "PUT shop.example/api/oauth/token",
+		},
+		{
+			name:   "port stripped from URL host",
+			method: http.MethodGet,
+			rawURL: "http://127.0.0.1:8080/_info/config",
+			want:   "GET 127.0.0.1/_info/config",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			u, err := url.Parse(tt.rawURL)
+			if err != nil {
+				t.Fatalf("parse URL: %v", err)
+			}
+			req := &http.Request{
+				Method: tt.method,
+				URL:    u,
+				Host:   tt.host,
+			}
+
+			got := ClientSpanName("", req)
+			if got != tt.want {
+				t.Fatalf("ClientSpanName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientSpanName_NilRequest(t *testing.T) {
+	t.Parallel()
+	if got := ClientSpanName("", nil); got != http.MethodGet {
+		t.Fatalf("ClientSpanName(nil) = %q, want %q", got, http.MethodGet)
+	}
+}

--- a/api/internal/httputil/client_span_name_test.go
+++ b/api/internal/httputil/client_span_name_test.go
@@ -17,7 +17,7 @@ func TestClientSpanName(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "host and path",
+			name:   "shared host and path",
 			method: http.MethodGet,
 			rawURL: "https://api.shopware.com/pluginStore/pluginsByName",
 			want:   "GET api.shopware.com/pluginStore/pluginsByName",
@@ -35,29 +35,53 @@ func TestClientSpanName(t *testing.T) {
 			want:   "POST /swplatform/autoupdate",
 		},
 		{
-			name:   "empty path",
+			name:   "empty path on shared host",
 			method: http.MethodGet,
 			rawURL: "https://api.shopware.com",
 			want:   "GET api.shopware.com/",
 		},
 		{
-			name:   "empty path with trailing slash equivalent",
+			name:   "tenant host collapsed",
 			method: http.MethodHead,
-			rawURL: "https://example.com/",
-			want:   "HEAD example.com/",
+			rawURL: "https://shop.example.com/",
+			want:   "HEAD {host}/",
 		},
 		{
 			name:   "host from Request.Host when URL host empty",
 			method: http.MethodPut,
 			rawURL: "/api/oauth/token",
 			host:   "shop.example:443",
-			want:   "PUT shop.example/api/oauth/token",
+			want:   "PUT {host}/api/oauth/token",
 		},
 		{
-			name:   "port stripped from URL host",
+			name:   "non-shared IP host collapsed and port stripped",
 			method: http.MethodGet,
 			rawURL: "http://127.0.0.1:8080/_info/config",
-			want:   "GET 127.0.0.1/_info/config",
+			want:   "GET {host}/_info/config",
+		},
+		{
+			name:   "uuid path segment grouped",
+			method: http.MethodPatch,
+			rawURL: "https://shop.example.com/api/scheduled-task/550e8400-e29b-41d4-a716-446655440000",
+			want:   "PATCH {host}/api/scheduled-task/{id}",
+		},
+		{
+			name:   "numeric path segment grouped",
+			method: http.MethodGet,
+			rawURL: "https://sitespeed.internal/api/result/42",
+			want:   "GET {host}/api/result/{id}",
+		},
+		{
+			name:   "long hex path segment grouped",
+			method: http.MethodGet,
+			rawURL: "https://shop.example.com/api/token/0123456789abcdef0123456789abcdef",
+			want:   "GET {host}/api/token/{id}",
+		},
+		{
+			name:   "shared github host kept literal",
+			method: http.MethodGet,
+			rawURL: "https://raw.githubusercontent.com/FriendsOfShopware/shopware-static-data/main/data/security.json",
+			want:   "GET raw.githubusercontent.com/FriendsOfShopware/shopware-static-data/main/data/security.json",
 		},
 	}
 
@@ -87,5 +111,26 @@ func TestClientSpanName_NilRequest(t *testing.T) {
 	t.Parallel()
 	if got := ClientSpanName("", nil); got != http.MethodGet {
 		t.Fatalf("ClientSpanName(nil) = %q, want %q", got, http.MethodGet)
+	}
+}
+
+func TestSpanPath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"", "/"},
+		{"/", "/"},
+		{"/pluginStore/pluginsByName", "/pluginStore/pluginsByName"},
+		{"/api/result/99", "/api/result/{id}"},
+		{"/api/scheduled-task/550e8400-e29b-41d4-a716-446655440000/run", "/api/scheduled-task/{id}/run"},
+		{"/_info/config", "/_info/config"},
+	}
+	for _, tt := range tests {
+		if got := spanPath(tt.in); got != tt.want {
+			t.Fatalf("spanPath(%q) = %q, want %q", tt.in, got, tt.want)
+		}
 	}
 }

--- a/api/internal/shopware/client.go
+++ b/api/internal/shopware/client.go
@@ -12,10 +12,6 @@ import (
 	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 )
 
@@ -169,21 +165,12 @@ func (c *Client) Authenticate(ctx context.Context) error {
 	return err
 }
 
-var tracer = otel.Tracer("shopmon/shopware")
-
+// request performs an authenticated Admin API call. HTTP client tracing comes
+// from httputil's otelhttp transport (span name METHOD host/path); we do not
+// create a second Internal span that would duplicate that client span in Datadog.
 func (c *Client) request(ctx context.Context, method, path string, body interface{}, retry bool) ([]byte, error) {
-	ctx, span := tracer.Start(ctx, method+" "+path,
-		trace.WithAttributes(
-			attribute.String("http.method", method),
-			attribute.String("http.url", c.baseURL+"/api"+path),
-		),
-	)
-	defer span.End()
-
 	token, err := c.getToken(ctx)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -211,13 +198,9 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		span.RecordError(err)
-		span.SetStatus(codes.Error, err.Error())
 		return nil, fmt.Errorf("request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-
-	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 
 	if resp.StatusCode == 301 || resp.StatusCode == 302 {
 		return nil, &ApiError{StatusCode: resp.StatusCode, Body: "redirect detected"}
@@ -234,10 +217,7 @@ func (c *Client) request(ctx context.Context, method, path string, body interfac
 	}
 
 	if resp.StatusCode >= 400 {
-		apiErr := &ApiError{StatusCode: resp.StatusCode, Body: string(respBody)}
-		span.RecordError(apiErr)
-		span.SetStatus(codes.Error, apiErr.Error())
-		return nil, apiErr
+		return nil, &ApiError{StatusCode: resp.StatusCode, Body: string(respBody)}
 	}
 
 	return respBody, nil


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In Datadog production, ~520k+ worker spans / 6h collapse to `resource_name:GET` (and similarly bare `POST`). Useful low-cardinality data is already on the spans as `http.host` + `http.path_group` (e.g. host `api.shopware.com`, path `/pluginStore/pluginsByName`), but Datadog’s resource name comes from the span name — and otelhttp’s default client formatter is effectively just the HTTP method.

## Root cause

`httputil.wrapTransport` wrapped outbound clients with `otelhttp.NewTransport(base)` and no `WithSpanNameFormatter`. The library default names client spans from the method alone (`HTTP GET` → Datadog resource `GET`).

Separately, the Shopware Admin client started a manual Internal span named `method+" "+path` around each request. That duplicated the otelhttp client span and still showed up poorly in Datadog as a bare GET resource.

## Fix

- Add `httputil.ClientSpanName` and wire it via `otelhttp.WithSpanNameFormatter` so outbound client spans are named `METHOD host/path`
  - Strips query strings (tokens / shop IDs in query never enter the resource)
  - Keeps only known shared hosts literal (`api.shopware.com`, `releases.shopware.com`, `store.shopware.com`, `raw.githubusercontent.com`); other peers (per-shop Admin API, SSO IdPs, etc.) collapse to `{host}`
  - Replaces UUID / numeric / long-hex path segments with `{id}`
  - Falls back to `METHOD /path` when host is missing; empty path becomes `/`
- Remove the redundant Shopware Admin Internal HTTP span so each request has one clear otelhttp client span
- Unit-test the formatter (shared host, tenant host collapse, query strip, empty path, UUID/numeric/hex path grouping)

`server.address` is already set by otelhttp’s client semconv — no extra attributes added.

No HTTP behavior, timeout, SSRF, or User-Agent changes. No metrics-exporter work (separate task). DB span naming from #791 is untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e563e0b3-b701-4c25-b888-be33e43ce202?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e563e0b3-b701-4c25-b888-be33e43ce202&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

