### PR TITLE
feat: OTLP metrics export for low-cardinality business outcomes

### DIFF
--- a/api/.env.example
+++ b/api/.env.example
@@ -50,7 +50,9 @@ APP_S3_REGION=auto
 PACKAGES_API_URL=
 PACKAGES_API_TOKEN=
 
-# OpenTelemetry (Jaeger)
+# OpenTelemetry (OTLP HTTP). Traces, logs, and metrics each fall back to this
+# generic endpoint; set OTEL_EXPORTER_OTLP_METRICS_ENDPOINT to override metrics
+# only, or leave all empty to disable exporters (no-op meters/tracers).
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
 OTEL_SERVICE_NAME=shopmon
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.34
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.107.0
 	github.com/aws/smithy-go v1.27.6
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/descope/virtualwebauthn v1.0.5
 	github.com/exaring/otelpgx v0.11.1
@@ -38,9 +39,12 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.70.0
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0
+	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0
+	go.opentelemetry.io/otel/metric v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
 	go.opentelemetry.io/otel/sdk/log v0.21.0
+	go.opentelemetry.io/otel/sdk/metric v1.45.0
 	go.opentelemetry.io/otel/trace v1.45.0
 	golang.org/x/crypto v0.54.0
 	golang.org/x/sync v0.22.0
@@ -69,7 +73,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.33.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.38.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.4 // indirect
-	github.com/caarlos0/env/v11 v11.4.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -149,7 +152,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 // indirect
 	go.opentelemetry.io/otel/log v0.21.0 // indirect
-	go.opentelemetry.io/otel/metric v1.45.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.11.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/api/go.sum
+++ b/api/go.sum
@@ -319,6 +319,8 @@ go.opentelemetry.io/otel v1.45.0 h1:pdrWmLHofpubmArBv1LgFSv1Z0Ie/ppdZzu+kUN5EeU=
 go.opentelemetry.io/otel v1.45.0/go.mod h1:XZxIqPapzEYnhNSScF5DIqXhm/rYi0FzCe2XddAwZfQ=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0 h1:fvNHGyo3CdRv/DQveXqhqBxnKTDyRaC5sMSQxilX/A0=
 go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.21.0/go.mod h1:zyGrjRKL2B/6+Jc/m4/otPoZqV2MY9ZjC/aBraRO7zc=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0 h1:pnxy6c/kvNBWdNNFzqpjuJLm9Hjhgk/Q0nY221rwuk0=
+go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0/go.mod h1:qw6YsFapotRwoDhXRZvljzaOvCQB7UfnafEJagpN2TA=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0 h1:QRefszxJmfPdjXUUm3j6iDzY03mTPXMjqErFqQ67vUg=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.45.0/go.mod h1:Tiz03lTBVBrm7eWZBOidzEaYaJa8tjwGUGv6d8mlTyk=
 go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0 h1:QBajQ2SrwQijzHyZbQlPsuIzpl/ll8DY6wPWsajeGcI=
@@ -327,6 +329,8 @@ go.opentelemetry.io/otel/log v0.21.0 h1:SLsVDGmtyBrdw8/a2Z0bOIxou/+bN4z56GebH7T0
 go.opentelemetry.io/otel/log v0.21.0/go.mod h1:iReetQrZL9Wyg84cCkOoCmqDHS5RCFfyxC7J+r8fn8g=
 go.opentelemetry.io/otel/metric v1.45.0 h1:7Eg1uH7CJ5cXv9is6tnBe1FI6rj1nwUdbFypRm3br/M=
 go.opentelemetry.io/otel/metric v1.45.0/go.mod h1:HAPbm1nd3p1PmFH7v2dR+6BjXxw+Lq4a2+pndMAm08s=
+go.opentelemetry.io/otel/metric/x v0.67.0 h1:PcicCNZFkZ4bXfSooXdo3WN7RBOVOtjVdo1wD358Uns=
+go.opentelemetry.io/otel/metric/x v0.67.0/go.mod h1:FBjCWZe6wgcqxcMtjdGiClDKXb2YxxXii0CXftE4QtI=
 go.opentelemetry.io/otel/sdk v1.45.0 h1:4VVSMgQ83dUgW2aoX5f6JgLvHwIvzcuLnF9lUdCSpCw=
 go.opentelemetry.io/otel/sdk v1.45.0/go.mod h1:Sr40LgXV7DsKMMJMKOhUWOgMWTfAaqvm2kF0g7ilwuA=
 go.opentelemetry.io/otel/sdk/log v0.21.0 h1:QsE7XSR0ktQdKmRKGnR+f1ObGF32WG+7MER/P9KgmYc=

--- a/api/internal/catalog/sync/service.go
+++ b/api/internal/catalog/sync/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/catalog/storemodel"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	"github.com/friendsofshopware/shopmon/api/internal/version"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -140,12 +141,27 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 			attribute.Bool("sync.force", force),
 		),
 	)
+	// recordOutcome stays false for the "nothing to sync" early return so
+	// no-op freshness checks do not inflate shopmon.store_sync.outcome ok.
+	recordOutcome := true
 	defer func() {
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 		}
 		span.End()
+		if !recordOutcome {
+			return
+		}
+		outcome := metrics.OutcomeOK
+		if err != nil {
+			if shopwareaccount.IsRateLimited(err) {
+				outcome = metrics.OutcomeRateLimited
+			} else {
+				outcome = metrics.OutcomeError
+			}
+		}
+		metrics.RecordStoreSyncOutcome(ctx, outcome)
 	}()
 
 	needed := names
@@ -156,6 +172,7 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 		}
 	}
 	if len(needed) == 0 {
+		recordOutcome = false
 		return nil
 	}
 	span.SetAttributes(attribute.Int("extension.needed", len(needed)))

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	// unified service tagging variables.
 	OtelTraceEndpoint  string  `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
 	OtelLogEndpoint    string  `env:"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
+	// OTEL_EXPORTER_OTLP_METRICS_ENDPOINT selects the OTLP HTTP metrics
+	// exporter. When empty (and the generic OTEL_EXPORTER_OTLP_ENDPOINT is
+	// also empty), metrics stay disabled and MeterProvider remains a no-op.
+	OtelMetricEndpoint string  `env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
 	OtelServiceName    string  `env:"OTEL_SERVICE_NAME" envDefault:"shopmon"`
 	OtelDeploymentEnv  string  `env:"OTEL_DEPLOYMENT_ENVIRONMENT,expand" envDefault:"${DD_ENV}"`
 	OtelServiceVersion string  `env:"OTEL_SERVICE_VERSION,expand" envDefault:"${DD_VERSION}"`

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -253,31 +253,37 @@ func TestOtelEndpointsFallBackToGenericEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
 
 	cfg, err := Load()
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://collector:4318", cfg.OtelTraceEndpoint)
 	assert.Equal(t, "http://collector:4318", cfg.OtelLogEndpoint)
+	assert.Equal(t, "http://collector:4318", cfg.OtelMetricEndpoint)
 	assert.True(t, cfg.OtelEnabled)
 
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces:4318")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "http://metrics:4318")
 
 	cfg, err = Load()
 	require.NoError(t, err)
 
 	assert.Equal(t, "http://traces:4318", cfg.OtelTraceEndpoint)
 	assert.Equal(t, "http://collector:4318", cfg.OtelLogEndpoint)
+	assert.Equal(t, "http://metrics:4318", cfg.OtelMetricEndpoint)
 }
 
 func TestOtelDisabledWithoutEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")
+	t.Setenv("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT", "")
 
 	cfg, err := Load()
 	require.NoError(t, err)
 
 	assert.Empty(t, cfg.OtelTraceEndpoint)
+	assert.Empty(t, cfg.OtelMetricEndpoint)
 	assert.False(t, cfg.OtelEnabled)
 }
 

--- a/api/internal/mail/mail.go
+++ b/api/internal/mail/mail.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/url"
 
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	gomailer "github.com/shyim/go-mailer"
 	"github.com/shyim/go-mailer/middleware"
 	"github.com/shyim/go-mailer/middleware/otelmw"
@@ -170,8 +171,11 @@ func (s *Service) Send(ctx context.Context, to string, email Email) error {
 	// A nil envelope derives the sender and recipients from the message
 	// headers set above.
 	if err := s.mailer.Send(ctx, msg, nil); err != nil {
+		// Outcome only — never label with recipient addresses (SES 451 etc.).
+		metrics.RecordMailSend(ctx, metrics.OutcomeError)
 		return fmt.Errorf("send mail: %w", err)
 	}
+	metrics.RecordMailSend(ctx, metrics.OutcomeOK)
 	return nil
 }
 

--- a/api/internal/metrics/metrics.go
+++ b/api/internal/metrics/metrics.go
@@ -1,0 +1,205 @@
+// Package metrics exposes low-cardinality business-outcome counters for
+// Datadog monitors. Instruments are registered after telemetry.Setup installs
+// a MeterProvider; until then Record* calls are no-ops.
+//
+// Attribute sets are intentionally tiny enums. Never add environment URLs,
+// shop URLs, email addresses, or extension name lists as attributes.
+package metrics
+
+import (
+	"context"
+	"sync"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const meterName = "shopmon"
+
+// Outcome values shared across counters. Keep this set small so Datadog
+// monitors stay cheap and cardinality cannot explode.
+const (
+	OutcomeOK             = "ok"
+	OutcomeError          = "error"
+	OutcomeAuthError      = "auth_error"
+	OutcomeDataFetchError = "data_fetch_error"
+	OutcomeRateLimited    = "rate_limited"
+	OutcomeSkipped        = "skipped"
+	OutcomeUnknown        = "unknown"
+)
+
+// Channel values for notify delivery. Matches notify.ChannelName.
+const (
+	ChannelEmail = "email"
+	ChannelInApp = "in_app"
+)
+
+var (
+	mu               sync.RWMutex
+	scrapeOutcome    metric.Int64Counter
+	storeSyncOutcome metric.Int64Counter
+	sitespeedOutcome metric.Int64Counter
+	mailSend         metric.Int64Counter
+	notifyDelivery   metric.Int64Counter
+)
+
+// Register creates the shopmon outcome instruments on the global MeterProvider.
+// Call it from telemetry.Setup after otel.SetMeterProvider so counters bind to
+// the real exporter rather than the default no-op provider.
+func Register() {
+	m := otel.Meter(meterName)
+
+	scrape, _ := m.Int64Counter("shopmon.scrape.outcome",
+		metric.WithDescription("Environment scrape business outcomes"),
+		metric.WithUnit("{scrape}"),
+	)
+	storeSync, _ := m.Int64Counter("shopmon.store_sync.outcome",
+		metric.WithDescription("Shopware Store API catalog sync outcomes"),
+		metric.WithUnit("{sync}"),
+	)
+	sitespeed, _ := m.Int64Counter("shopmon.sitespeed.outcome",
+		metric.WithDescription("Sitespeed scrape outcomes"),
+		metric.WithUnit("{scrape}"),
+	)
+	mail, _ := m.Int64Counter("shopmon.mail.send",
+		metric.WithDescription("Outbound email send attempts"),
+		metric.WithUnit("{email}"),
+	)
+	notify, _ := m.Int64Counter("shopmon.notify.delivery",
+		metric.WithDescription("Notification channel delivery attempts"),
+		metric.WithUnit("{delivery}"),
+	)
+
+	mu.Lock()
+	defer mu.Unlock()
+	scrapeOutcome = scrape
+	storeSyncOutcome = storeSync
+	sitespeedOutcome = sitespeed
+	mailSend = mail
+	notifyDelivery = notify
+}
+
+// RecordScrapeOutcome increments shopmon.scrape.outcome.
+// Allowed outcomes: ok, error, auth_error, data_fetch_error.
+func RecordScrapeOutcome(ctx context.Context, outcome string) {
+	add(ctx, scrapeCounter(), "outcome", NormalizeScrapeOutcome(outcome))
+}
+
+// RecordStoreSyncOutcome increments shopmon.store_sync.outcome.
+// Allowed outcomes: ok, rate_limited, error.
+func RecordStoreSyncOutcome(ctx context.Context, outcome string) {
+	add(ctx, storeSyncCounter(), "outcome", NormalizeStoreSyncOutcome(outcome))
+}
+
+// RecordSitespeedOutcome increments shopmon.sitespeed.outcome.
+// Allowed outcomes: ok, error, skipped.
+func RecordSitespeedOutcome(ctx context.Context, outcome string) {
+	add(ctx, sitespeedCounter(), "outcome", NormalizeSitespeedOutcome(outcome))
+}
+
+// RecordMailSend increments shopmon.mail.send.
+// Allowed outcomes: ok, error. Never label with recipient addresses.
+func RecordMailSend(ctx context.Context, outcome string) {
+	add(ctx, mailCounter(), "outcome", NormalizeMailOutcome(outcome))
+}
+
+// RecordNotifyDelivery increments shopmon.notify.delivery.
+// Allowed outcomes: ok, error. Channel must be a tiny enum (email, in_app).
+func RecordNotifyDelivery(ctx context.Context, outcome, channel string) {
+	c := notifyCounter()
+	if c == nil {
+		return
+	}
+	c.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("outcome", NormalizeMailOutcome(outcome)),
+		attribute.String("channel", NormalizeNotifyChannel(channel)),
+	))
+}
+
+// NormalizeScrapeOutcome maps arbitrary strings onto the scrape outcome enum.
+func NormalizeScrapeOutcome(outcome string) string {
+	switch outcome {
+	case OutcomeOK, OutcomeError, OutcomeAuthError, OutcomeDataFetchError:
+		return outcome
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// NormalizeStoreSyncOutcome maps arbitrary strings onto the store sync enum.
+func NormalizeStoreSyncOutcome(outcome string) string {
+	switch outcome {
+	case OutcomeOK, OutcomeError, OutcomeRateLimited:
+		return outcome
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// NormalizeSitespeedOutcome maps arbitrary strings onto the sitespeed enum.
+func NormalizeSitespeedOutcome(outcome string) string {
+	switch outcome {
+	case OutcomeOK, OutcomeError, OutcomeSkipped:
+		return outcome
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// NormalizeMailOutcome maps arbitrary strings onto ok|error|unknown.
+func NormalizeMailOutcome(outcome string) string {
+	switch outcome {
+	case OutcomeOK, OutcomeError:
+		return outcome
+	default:
+		return OutcomeUnknown
+	}
+}
+
+// NormalizeNotifyChannel maps arbitrary strings onto email|in_app|unknown.
+func NormalizeNotifyChannel(channel string) string {
+	switch channel {
+	case ChannelEmail, ChannelInApp:
+		return channel
+	default:
+		return OutcomeUnknown
+	}
+}
+
+func add(ctx context.Context, c metric.Int64Counter, key, value string) {
+	if c == nil {
+		return
+	}
+	c.Add(ctx, 1, metric.WithAttributes(attribute.String(key, value)))
+}
+
+func scrapeCounter() metric.Int64Counter {
+	mu.RLock()
+	defer mu.RUnlock()
+	return scrapeOutcome
+}
+
+func storeSyncCounter() metric.Int64Counter {
+	mu.RLock()
+	defer mu.RUnlock()
+	return storeSyncOutcome
+}
+
+func sitespeedCounter() metric.Int64Counter {
+	mu.RLock()
+	defer mu.RUnlock()
+	return sitespeedOutcome
+}
+
+func mailCounter() metric.Int64Counter {
+	mu.RLock()
+	defer mu.RUnlock()
+	return mailSend
+}
+
+func notifyCounter() metric.Int64Counter {
+	mu.RLock()
+	defer mu.RUnlock()
+	return notifyDelivery
+}

--- a/api/internal/metrics/metrics_test.go
+++ b/api/internal/metrics/metrics_test.go
@@ -1,0 +1,106 @@
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestNormalizeOutcomes(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, OutcomeOK, NormalizeScrapeOutcome(OutcomeOK))
+	assert.Equal(t, OutcomeAuthError, NormalizeScrapeOutcome(OutcomeAuthError))
+	assert.Equal(t, OutcomeDataFetchError, NormalizeScrapeOutcome(OutcomeDataFetchError))
+	assert.Equal(t, OutcomeUnknown, NormalizeScrapeOutcome("https://shop.example/admin"))
+	assert.Equal(t, OutcomeUnknown, NormalizeScrapeOutcome("user@example.com"))
+
+	assert.Equal(t, OutcomeRateLimited, NormalizeStoreSyncOutcome(OutcomeRateLimited))
+	assert.Equal(t, OutcomeUnknown, NormalizeStoreSyncOutcome("SwagPayPal"))
+
+	assert.Equal(t, OutcomeSkipped, NormalizeSitespeedOutcome(OutcomeSkipped))
+	assert.Equal(t, OutcomeUnknown, NormalizeSitespeedOutcome("5xx"))
+
+	assert.Equal(t, OutcomeOK, NormalizeMailOutcome(OutcomeOK))
+	assert.Equal(t, OutcomeUnknown, NormalizeMailOutcome("bounce"))
+
+	assert.Equal(t, ChannelEmail, NormalizeNotifyChannel(ChannelEmail))
+	assert.Equal(t, ChannelInApp, NormalizeNotifyChannel(ChannelInApp))
+	assert.Equal(t, OutcomeUnknown, NormalizeNotifyChannel("webhook"))
+}
+
+func TestRecordHelpersEmitLowCardinalityAttributes(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		_ = mp.Shutdown(context.Background())
+	})
+
+	Register()
+
+	ctx := context.Background()
+	RecordScrapeOutcome(ctx, OutcomeOK)
+	RecordScrapeOutcome(ctx, "https://evil.example") // coerced to unknown
+	RecordStoreSyncOutcome(ctx, OutcomeRateLimited)
+	RecordSitespeedOutcome(ctx, OutcomeError)
+	RecordMailSend(ctx, OutcomeOK)
+	RecordNotifyDelivery(ctx, OutcomeError, ChannelEmail)
+
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(ctx, &rm))
+
+	counts := collectSumCounts(t, rm)
+	assert.Equal(t, int64(1), counts["shopmon.scrape.outcome|outcome=ok"])
+	assert.Equal(t, int64(1), counts["shopmon.scrape.outcome|outcome=unknown"])
+	assert.Equal(t, int64(1), counts["shopmon.store_sync.outcome|outcome=rate_limited"])
+	assert.Equal(t, int64(1), counts["shopmon.sitespeed.outcome|outcome=error"])
+	assert.Equal(t, int64(1), counts["shopmon.mail.send|outcome=ok"])
+	// Attribute iteration is sorted by key, so channel precedes outcome.
+	assert.Equal(t, int64(1), counts["shopmon.notify.delivery|channel=email|outcome=error"])
+}
+
+func TestRecordWithoutRegisterIsNoop(t *testing.T) {
+	// Isolate from other tests that may have registered instruments.
+	mu.Lock()
+	scrapeOutcome = nil
+	storeSyncOutcome = nil
+	sitespeedOutcome = nil
+	mailSend = nil
+	notifyDelivery = nil
+	mu.Unlock()
+
+	assert.NotPanics(t, func() {
+		RecordScrapeOutcome(context.Background(), OutcomeOK)
+		RecordStoreSyncOutcome(context.Background(), OutcomeError)
+		RecordSitespeedOutcome(context.Background(), OutcomeSkipped)
+		RecordMailSend(context.Background(), OutcomeError)
+		RecordNotifyDelivery(context.Background(), OutcomeOK, ChannelInApp)
+	})
+}
+
+func collectSumCounts(t *testing.T, rm metricdata.ResourceMetrics) map[string]int64 {
+	t.Helper()
+	out := make(map[string]int64)
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			sum, ok := m.Data.(metricdata.Sum[int64])
+			require.Truef(t, ok, "expected int64 sum for %s", m.Name)
+			for _, dp := range sum.DataPoints {
+				key := m.Name
+				for _, attr := range dp.Attributes.ToSlice() {
+					key += "|" + string(attr.Key) + "=" + attr.Value.AsString()
+				}
+				out[key] = dp.Value
+			}
+		}
+	}
+	return out
+}

--- a/api/internal/monitoring/scrape/service.go
+++ b/api/internal/monitoring/scrape/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/environment"
 	"github.com/friendsofshopware/shopmon/api/internal/mail"
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/notify"
 	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
@@ -77,6 +78,7 @@ func (h *Service) Scrape(ctx context.Context, environmentID int32) error {
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
+		metrics.RecordScrapeOutcome(ctx, metrics.OutcomeError)
 		return fmt.Errorf("environment %d not found: %w", environmentID, err)
 	}
 
@@ -92,7 +94,7 @@ func (h *Service) Scrape(ctx context.Context, environmentID int32) error {
 }
 
 // scrapeEnvironment performs the full scrape flow for a single environment.
-func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvironmentsRow) error {
+func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvironmentsRow) (err error) {
 	ctx, span := tracer.Start(ctx, "environment.scrape.environment",
 		trace.WithAttributes(
 			attribute.Int("environment.id", int(env.ID)),
@@ -101,6 +103,14 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		),
 	)
 	defer span.End()
+
+	outcome := metrics.OutcomeOK
+	defer func() {
+		if err != nil {
+			outcome = metrics.OutcomeError
+		}
+		metrics.RecordScrapeOutcome(ctx, outcome)
+	}()
 
 	log := slog.With("environmentId", env.ID, "name", env.Name)
 
@@ -129,6 +139,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 			}); err != nil {
 				slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
 			}
+			outcome = metrics.OutcomeAuthError
 			return nil
 		}
 	}
@@ -191,6 +202,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		}); err != nil {
 			slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
 		}
+		outcome = metrics.OutcomeDataFetchError
 		return nil
 	}
 

--- a/api/internal/monitoring/sitespeed/service.go
+++ b/api/internal/monitoring/sitespeed/service.go
@@ -14,6 +14,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 )
 
 type Service struct {
@@ -25,9 +26,10 @@ func NewService(q *queries.Queries, cfg *config.Config) *Service {
 	return &Service{queries: q, cfg: cfg}
 }
 
-func (s *Service) Scrape(ctx context.Context, environmentID int32) error {
+func (s *Service) Scrape(ctx context.Context, environmentID int32) (err error) {
 	environments, err := s.queries.GetEnvironmentsWithSitespeedEnabled(ctx)
 	if err != nil {
+		metrics.RecordSitespeedOutcome(ctx, metrics.OutcomeError)
 		return fmt.Errorf("list sitespeed-enabled environments: %w", err)
 	}
 
@@ -37,16 +39,26 @@ func (s *Service) Scrape(ctx context.Context, environmentID int32) error {
 		}
 	}
 
+	metrics.RecordSitespeedOutcome(ctx, metrics.OutcomeError)
 	return fmt.Errorf("environment %d not found or sitespeed not enabled", environmentID)
 }
 
-func (s *Service) scrapeEnvironment(ctx context.Context, env queries.GetEnvironmentsWithSitespeedEnabledRow) error {
+func (s *Service) scrapeEnvironment(ctx context.Context, env queries.GetEnvironmentsWithSitespeedEnabledRow) (err error) {
 	log := slog.With("environmentId", env.ID)
 
 	if s.cfg.SitespeedEndpoint == "" || s.cfg.SitespeedAPIKey == "" {
 		log.Info("sitespeed not configured, skipping")
+		metrics.RecordSitespeedOutcome(ctx, metrics.OutcomeSkipped)
 		return nil
 	}
+
+	defer func() {
+		if err != nil {
+			metrics.RecordSitespeedOutcome(ctx, metrics.OutcomeError)
+			return
+		}
+		metrics.RecordSitespeedOutcome(ctx, metrics.OutcomeOK)
+	}()
 
 	// Get URLs to test - default is the environment URL
 	var urls []string

--- a/api/internal/notify/dispatcher.go
+++ b/api/internal/notify/dispatcher.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/mail"
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 )
 
 // Dispatcher resolves recipients' channel preferences, renders each event into
@@ -77,7 +78,10 @@ func (d *Dispatcher) Dispatch(ctx context.Context, ev Event, recipients []Recipi
 			if err := ch.Send(ctx, r, ev, msg); err != nil {
 				slog.Warn("notify: channel delivery failed",
 					"channel", name, "event", ev.Type, "userId", r.ID, "error", err)
+				metrics.RecordNotifyDelivery(ctx, metrics.OutcomeError, string(name))
+				continue
 			}
+			metrics.RecordNotifyDelivery(ctx, metrics.OutcomeOK, string(name))
 		}
 	}
 }

--- a/api/internal/telemetry/telemetry.go
+++ b/api/internal/telemetry/telemetry.go
@@ -1,4 +1,4 @@
-// Package telemetry sets up OpenTelemetry tracing and logging.
+// Package telemetry sets up OpenTelemetry tracing, metrics, and logging.
 package telemetry
 
 import (
@@ -9,13 +9,16 @@ import (
 	"os"
 	"time"
 
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"go.opentelemetry.io/contrib/bridges/otelslog"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
+	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/log"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -28,19 +31,23 @@ type Config struct {
 	DeploymentEnv string
 	TraceEndpoint string
 	LogEndpoint   string
+	// MetricEndpoint is the OTLP HTTP metrics URL. Empty disables metrics
+	// (global MeterProvider stays a no-op).
+	MetricEndpoint string
 	// SamplerRatio is the head sampling ratio in [0, 1]; 1 samples everything.
 	SamplerRatio float64
 }
 
-// Setup initializes OpenTelemetry tracing and logging with OTLP HTTP exporters.
-// It sets slog's default logger to a handler that sends logs via OTLP and also
-// writes to stderr. Returns a shutdown function that should be called on application exit.
-// If both endpoints are empty, telemetry is disabled and a no-op shutdown is returned.
+// Setup initializes OpenTelemetry tracing, metrics, and logging with OTLP HTTP
+// exporters. It sets slog's default logger to a handler that sends logs via
+// OTLP and also writes to stderr. Returns a shutdown function that should be
+// called on application exit. If all endpoints are empty, telemetry is disabled
+// and a no-op shutdown is returned.
 func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) error) {
 	serviceName, version, deploymentEnv := cfg.ServiceName, cfg.Version, cfg.DeploymentEnv
-	traceEndpoint, logEndpoint := cfg.TraceEndpoint, cfg.LogEndpoint
+	traceEndpoint, logEndpoint, metricEndpoint := cfg.TraceEndpoint, cfg.LogEndpoint, cfg.MetricEndpoint
 
-	if traceEndpoint == "" && logEndpoint == "" {
+	if traceEndpoint == "" && logEndpoint == "" && metricEndpoint == "" {
 		return func(context.Context) error { return nil }
 	}
 
@@ -89,6 +96,27 @@ func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) erro
 			))
 			shutdownFuncs = append(shutdownFuncs, tp.Shutdown)
 			slog.Info("OpenTelemetry tracing enabled", "endpoint", traceEndpoint, "service", serviceName)
+		}
+	}
+
+	// Metrics
+	if metricEndpoint != "" {
+		metricExporter, err := otlpmetrichttp.New(setupCtx,
+			otlpmetrichttp.WithEndpointURL(ensurePath(metricEndpoint, "/v1/metrics")),
+		)
+		if err != nil {
+			slog.Error("failed to create OTLP metric exporter", "error", err)
+		} else {
+			mp := sdkmetric.NewMeterProvider(
+				sdkmetric.WithResource(res),
+				sdkmetric.WithReader(sdkmetric.NewPeriodicReader(metricExporter)),
+			)
+			otel.SetMeterProvider(mp)
+			// Bind business-outcome instruments to this provider (not the
+			// default no-op that was active at package init).
+			metrics.Register()
+			shutdownFuncs = append(shutdownFuncs, mp.Shutdown)
+			slog.Info("OpenTelemetry metrics enabled", "endpoint", metricEndpoint, "service", serviceName)
 		}
 	}
 

--- a/api/telemetry.go
+++ b/api/telemetry.go
@@ -10,11 +10,12 @@ import (
 // reports under its own name.
 func telemetryConfig(cfg *config.Config, serviceName string) telemetry.Config {
 	return telemetry.Config{
-		ServiceName:   serviceName,
-		Version:       cfg.OtelServiceVersion,
-		DeploymentEnv: cfg.OtelDeploymentEnv,
-		TraceEndpoint: cfg.OtelTraceEndpoint,
-		LogEndpoint:   cfg.OtelLogEndpoint,
-		SamplerRatio:  cfg.OtelSamplerRatio,
+		ServiceName:    serviceName,
+		Version:        cfg.OtelServiceVersion,
+		DeploymentEnv:  cfg.OtelDeploymentEnv,
+		TraceEndpoint:  cfg.OtelTraceEndpoint,
+		LogEndpoint:    cfg.OtelLogEndpoint,
+		MetricEndpoint: cfg.OtelMetricEndpoint,
+		SamplerRatio:   cfg.OtelSamplerRatio,
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Datadog monitors that scan millions of APM spans for SES 451s, Store API 429s, scrape failures, or Sitespeed errors are expensive and noisy. Cheap OTLP **outcome counters** with tiny enum labels let us alert on business results without high-cardinality span queries.

## What

- Extend telemetry setup with an optional OTLP HTTP **MeterProvider** (`OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`, falling back to `OTEL_EXPORTER_OTLP_ENDPOINT` like traces/logs). Empty endpoint keeps metrics disabled (no-op meters).
- Add `api/internal/metrics` helpers that register instruments **after** the MeterProvider is installed, and coerce unexpected attribute values to `unknown` so cardinality stays bounded.
- Instrument natural success/failure points (existing spans unchanged):

| Metric | Labels | Outcomes |
| --- | --- | --- |
| `shopmon.scrape.outcome` | `outcome` | `ok`, `error`, `auth_error`, `data_fetch_error` |
| `shopmon.store_sync.outcome` | `outcome` | `ok`, `rate_limited`, `error` (no-op freshness skips not counted) |
| `shopmon.sitespeed.outcome` | `outcome` | `ok`, `error`, `skipped` |
| `shopmon.mail.send` | `outcome` | `ok`, `error` (no recipient addresses) |
| `shopmon.notify.delivery` | `outcome`, `channel` | `ok`/`error` × `email`/`in_app` |

## Config

```bash
# Generic fallback for all signals:
OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318

# Optional per-signal overrides (same pattern as traces/logs):
OTEL_EXPORTER_OTLP_METRICS_ENDPOINT=...
```

## Out of scope

HTTP span renaming (separate PR).

## Test plan

- [x] Unit tests for attribute normalization + ManualReader emission
- [x] `mise run lint` (API + frontend)
- [x] `mise run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cffd2dbd-6751-41cc-95ba-e12c70402d85?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cffd2dbd-6751-41cc-95ba-e12c70402d85&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

