### PR TITLE
fix: disable otelpgx pool.acquire spans in Datadog

### DIFF
--- a/api/internal/database/db.go
+++ b/api/internal/database/db.go
@@ -25,9 +25,12 @@ func NewPool(ctx context.Context, databaseURL string) (*pgxpool.Pool, error) {
 	// sqlc prefixes generated SQL with `-- name: Foo ...`; otelpgx's default
 	// first-word trim treats `--` as the operation (Datadog: `query --`).
 	// SQLSpanName prefers the sqlc query name, else the first SQL keyword.
+	// WithDisableAcquireTracer drops pool.acquire / client.request spans: they
+	// are high-volume and low-signal in Datadog compared to query/exec/prepare.
 	config.ConnConfig.Tracer = otelpgx.NewTracer(
 		otelpgx.WithTrimSQLInSpanName(),
 		otelpgx.WithSpanNameFunc(SQLSpanName),
+		otelpgx.WithDisableAcquireTracer(),
 	)
 
 	pool, err := pgxpool.NewWithConfig(ctx, config)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Disable otelpgx connection-pool acquire tracing via `WithDisableAcquireTracer()` when constructing the tracer in `NewPool`.
- Keeps query/exec/prepare spans and the existing sqlc `SpanNameFunc` naming from #791.
- No change to pool sizing, timeouts, or connection behavior.

## Why
Prod emits high volumes of low-signal `pool.acquire` / `client.request` spans that add little monitoring value in Datadog.

## Test plan
- [x] `mise run lint`
- [x] `mise run test`
- [ ] Confirm in Datadog APM that `pool.acquire` / related client.request noise drops while named DB query spans remain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f1ee5910-a5ec-4d04-9516-fcdd73959015?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f1ee5910-a5ec-4d04-9516-fcdd73959015&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

