### PR TITLE
fix(otel): report API APM service as shopmon-api

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -207,7 +207,7 @@ Required only if you use the deployment tracking feature.
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | | OTLP endpoint for traces and logs |
 | `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | | Override for trace-specific endpoint |
 | `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | | Override for log-specific endpoint |
-| `OTEL_SERVICE_NAME` | `shopmon` | Service name in traces |
+| `OTEL_SERVICE_NAME` | `shopmon` | Base APM service name. The API reports as `${OTEL_SERVICE_NAME}-api` and the worker as `${OTEL_SERVICE_NAME}-worker` (defaults: `shopmon-api` / `shopmon-worker`) |
 | `OTEL_DEPLOYMENT_ENVIRONMENT` | `$DD_ENV` | Deployment environment reported as a resource attribute |
 | `OTEL_SERVICE_VERSION` | `$DD_VERSION`, else the build revision | Service version reported as a resource attribute |
 | `OTEL_TRACES_SAMPLER_RATIO` | `1` | Head sampling ratio, clamped to `[0, 1]` |

--- a/api/.env.example
+++ b/api/.env.example
@@ -54,6 +54,9 @@ PACKAGES_API_TOKEN=
 # generic endpoint; set OTEL_EXPORTER_OTLP_METRICS_ENDPOINT to override metrics
 # only, or leave all empty to disable exporters (no-op meters/tracers).
 OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318
+# Base APM service name shared by server and worker. The API process reports as
+# ${OTEL_SERVICE_NAME}-api and the worker as ${OTEL_SERVICE_NAME}-worker
+# (defaults: shopmon-api / shopmon-worker).
 OTEL_SERVICE_NAME=shopmon
 
 # Auth rate limit: requests per IP per minute on auth routes (default 20).

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -75,12 +75,15 @@ type Config struct {
 	// The OTLP signal endpoints fall back to the generic
 	// OTEL_EXPORTER_OTLP_ENDPOINT, and service env/version to the Datadog
 	// unified service tagging variables.
-	OtelTraceEndpoint  string  `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
-	OtelLogEndpoint    string  `env:"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
+	OtelTraceEndpoint string `env:"OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
+	OtelLogEndpoint   string `env:"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
 	// OTEL_EXPORTER_OTLP_METRICS_ENDPOINT selects the OTLP HTTP metrics
 	// exporter. When empty (and the generic OTEL_EXPORTER_OTLP_ENDPOINT is
 	// also empty), metrics stay disabled and MeterProvider remains a no-op.
-	OtelMetricEndpoint string  `env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
+	OtelMetricEndpoint string `env:"OTEL_EXPORTER_OTLP_METRICS_ENDPOINT,expand" envDefault:"${OTEL_EXPORTER_OTLP_ENDPOINT}"`
+	// OtelServiceName is the shared base APM service name. The HTTP server
+	// reports as ${OTEL_SERVICE_NAME}-api and the worker as
+	// ${OTEL_SERVICE_NAME}-worker (see api/server.go and api/worker.go).
 	OtelServiceName    string  `env:"OTEL_SERVICE_NAME" envDefault:"shopmon"`
 	OtelDeploymentEnv  string  `env:"OTEL_DEPLOYMENT_ENVIRONMENT,expand" envDefault:"${DD_ENV}"`
 	OtelServiceVersion string  `env:"OTEL_SERVICE_VERSION,expand" envDefault:"${DD_VERSION}"`

--- a/api/internal/config/config_test.go
+++ b/api/internal/config/config_test.go
@@ -249,6 +249,16 @@ func TestMailDSN(t *testing.T) {
 	}
 }
 
+func TestOtelServiceNameDefaultsToShopmon(t *testing.T) {
+	t.Setenv("OTEL_SERVICE_NAME", "")
+
+	cfg, err := Load()
+	require.NoError(t, err)
+
+	// Base name only — server/worker append -api / -worker at process start.
+	assert.Equal(t, "shopmon", cfg.OtelServiceName)
+}
+
 func TestOtelEndpointsFallBackToGenericEndpoint(t *testing.T) {
 	t.Setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
 	t.Setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "")

--- a/api/server.go
+++ b/api/server.go
@@ -84,8 +84,8 @@ func runServer(cmd *cobra.Command, args []string) error {
 	ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	// OpenTelemetry
-	otelShutdown := telemetry.Setup(ctx, telemetryConfig(cfg, cfg.OtelServiceName))
+	// OpenTelemetry — API reports as ${OTEL_SERVICE_NAME}-api (worker appends -worker).
+	otelShutdown := telemetry.Setup(ctx, telemetryConfig(cfg, cfg.OtelServiceName+"-api"))
 	defer func() {
 		if err := otelShutdown(context.Background()); err != nil {
 			slog.Error("otel shutdown error", "error", err)

--- a/api/telemetry.go
+++ b/api/telemetry.go
@@ -6,8 +6,9 @@ import (
 )
 
 // telemetryConfig translates the OTel environment configuration into the
-// telemetry setup config. The service name is passed in because the worker
-// reports under its own name.
+// telemetry setup config. serviceName is the process-specific APM name:
+// the HTTP server uses ${OTEL_SERVICE_NAME}-api and the worker uses
+// ${OTEL_SERVICE_NAME}-worker so both can share one base env value.
 func telemetryConfig(cfg *config.Config, serviceName string) telemetry.Config {
 	return telemetry.Config{
 		ServiceName:    serviceName,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The HTTP API currently reports OpenTelemetry/Datadog APM spans under service `shopmon`, while the worker already uses `shopmon-worker`. Ops/docs commonly expect the API as `shopmon-api`.

This change makes the API append `-api` to the shared base `OTEL_SERVICE_NAME`, matching the worker’s existing `-worker` suffix. Server and worker already share one ConfigMap/env in-repo (`k8s/preview`), so treating `OTEL_SERVICE_NAME` as a **base** name (default `shopmon`) is the least surprising approach:

| Process | Before | After |
| --- | --- | --- |
| API (`shopmon server`) | `shopmon` | `shopmon-api` |
| Worker (`shopmon worker`) | `shopmon-worker` | `shopmon-worker` (unchanged) |

`OTEL_SERVICE_NAME` remains the override lever for the base; docs in `.env.example` and `SELF_HOSTING.md` spell out the suffixes.

### Why not change the env default to `shopmon-api`?

Setting `OTEL_SERVICE_NAME=shopmon-api` while the worker still does `base + "-worker"` would produce `shopmon-api-worker`. In-repo deploy manifests do not set a dedicated API-only service name.

## Datadog migration note

**This creates a new APM service (`shopmon-api`). Existing dashboards/monitors keyed on `service:shopmon` will stop seeing API traffic until updated.**

Confirmed in Datadog today:
- Service catalog: `shopmon`, `shopmon-worker` (no `shopmon-api` yet)
- Dashboard [Shopmon Overview](https://app.datadoghq.com/dashboard/pr9-sjk-usc) widgets filter `service:shopmon` for HTTP metrics and list template values `shopmon` / `shopmon-worker`
- Existing `shopmon` monitors found via search are synthetics/infra, not APM `service:shopmon` queries — still re-check any saved views/notebooks

**Before/after deploy checklist**
1. Update dashboard/monitor queries from `service:shopmon` → `service:shopmon-api` (worker stays `service:shopmon-worker`)
2. Optionally keep a temporary dual filter (`service:(shopmon OR shopmon-api)`) during rollout
3. After traffic moves, retire the old `shopmon` service references

### In-repo `service:shopmon` grep

No in-repo hits for `service:shopmon` (monitors/dashboards live in Datadog, not this repo).

## Test plan

- [x] Config default still `OTEL_SERVICE_NAME=shopmon`
- [x] `mise run lint`
- [x] `mise run test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b00991c-f0d1-4c75-bf9a-0a3a4b97ffd8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b00991c-f0d1-4c75-bf9a-0a3a4b97ffd8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

