### PR TITLE
fix(docker): arm64 image contained x86-64 binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,31 +36,6 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern=release-{{version}}
 
-      - name: Verify binary architecture per platform
-        # Reads the ELF e_machine field (offset 18, 2 bytes LE):
-        # 0x003e (3e 00) = x86-64, 0x00b7 (b7 00) = aarch64.
-        # This works without emulation, unlike running the image (#788).
-        run: |
-          set -euo pipefail
-          for arch in amd64 arm64; do
-            docker buildx build \
-              --platform "linux/${arch}" \
-              --output "type=local,dest=/tmp/verify-${arch}" \
-              .
-            bin="/tmp/verify-${arch}/usr/local/bin/shopmon"
-            mach=$(od -An -tx1 -j18 -N2 "$bin" | tr -d ' \n')
-            case "${arch}-${mach}" in
-              amd64-3e00|arm64-b700)
-                echo "linux/${arch}: ELF e_machine=${mach} OK"
-                ;;
-              *)
-                echo "::error::linux/${arch} image contains wrong binary architecture (ELF e_machine=${mach})"
-                exit 1
-                ;;
-            esac
-            rm -rf "/tmp/verify-${arch}"
-          done
-
       - name: Build and push image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,31 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern=release-{{version}}
 
+      - name: Verify binary architecture per platform
+        # Reads the ELF e_machine field (offset 18, 2 bytes LE):
+        # 0x003e (3e 00) = x86-64, 0x00b7 (b7 00) = aarch64.
+        # This works without emulation, unlike running the image (#788).
+        run: |
+          set -euo pipefail
+          for arch in amd64 arm64; do
+            docker buildx build \
+              --platform "linux/${arch}" \
+              --output "type=local,dest=/tmp/verify-${arch}" \
+              .
+            bin="/tmp/verify-${arch}/usr/local/bin/shopmon"
+            mach=$(od -An -tx1 -j18 -N2 "$bin" | tr -d ' \n')
+            case "${arch}-${mach}" in
+              amd64-3e00|arm64-b700)
+                echo "linux/${arch}: ELF e_machine=${mach} OK"
+                ;;
+              *)
+                echo "::error::linux/${arch} image contains wrong binary architecture (ELF e_machine=${mach})"
+                exit 1
+                ;;
+            esac
+            rm -rf "/tmp/verify-${arch}"
+          done
+
       - name: Build and push image
         uses: docker/build-push-action@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,5 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BUILDPLATFORM=linux/amd64
-ARG TARGETPLATFORM=linux/amd64
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
-ARG TARGETVARIANT
-
 FROM --platform=$BUILDPLATFORM node:26-alpine AS frontend-build
 
 WORKDIR /src/frontend


### PR DESCRIPTION
## Summary

Fixes #788 (regression of #770).

The arm64 image of 1.0.12 still contained an x86-64 binary and died with `exec format error` on native ARM hosts.

### Root cause

The Dockerfile declared BuildKit's built-in args globally **with defaults**:

```dockerfile
ARG TARGETPLATFORM=linux/amd64
ARG TARGETOS=linux
ARG TARGETARCH=amd64
```

The `ARG TARGETOS` / `ARG TARGETARCH` lines inside the `api-build` stage inherit those *global values* instead of the per-platform built-ins BuildKit normally injects. So `go build` always ran with `GOARCH=amd64`, while the final stage still resolved `--platform=$TARGETPLATFORM` to the arm64 base image → arm64-labelled image with an amd64 payload.

This does **not** reproduce on Apple Silicon / Docker Desktop (Rosetta/binfmt happily runs the x86-64 binary), which is why the earlier fix #771 looked verified.

### Changes

- **`Dockerfile`**: remove the global `ARG ...=...` declarations so BuildKit supplies the correct per-platform values for `TARGETOS`/`TARGETARCH`/`BUILDPLATFORM`/`TARGETPLATFORM`.

### Verification

Built both platforms locally and checked the ELF header:

| platform | e_machine | result |
|---|---|---|
| `linux/arm64` (new Dockerfile) | `b7 00` | ✅ AArch64 |
| `linux/amd64` (new Dockerfile) | `3e 00` | ✅ x86-64 |
| `linux/arm64` (old Dockerfile, repro) | `3e 00` | ❌ reproduces #788 |

Also verified `go build ./...`, `go vet ./...` and `go test ./internal/...` pass.
