### PR TITLE
feat(api): advisory endpoints, read models, and suppressions

### DIFF
--- a/api/internal/api/server.gen.go
+++ b/api/internal/api/server.gen.go
@@ -19,6 +19,105 @@ const (
 	BearerAuthScopes bearerAuthContextKey = "bearerAuth.Scopes"
 )
 
+// Defines values for SeverityLevel.
+const (
+	SeverityLevelCritical SeverityLevel = "critical"
+	SeverityLevelHigh     SeverityLevel = "high"
+	SeverityLevelLow      SeverityLevel = "low"
+	SeverityLevelMedium   SeverityLevel = "medium"
+	SeverityLevelNone     SeverityLevel = "none"
+)
+
+// Valid indicates whether the value is a known member of the SeverityLevel enum.
+func (e SeverityLevel) Valid() bool {
+	switch e {
+	case SeverityLevelCritical:
+		return true
+	case SeverityLevelHigh:
+		return true
+	case SeverityLevelLow:
+		return true
+	case SeverityLevelMedium:
+		return true
+	case SeverityLevelNone:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AdvisoryScope.
+const (
+	AdvisoryScopeAffected   AdvisoryScope = "affected"
+	AdvisoryScopeAll        AdvisoryScope = "all"
+	AdvisoryScopeSuppressed AdvisoryScope = "suppressed"
+)
+
+// Valid indicates whether the value is a known member of the AdvisoryScope enum.
+func (e AdvisoryScope) Valid() bool {
+	switch e {
+	case AdvisoryScopeAffected:
+		return true
+	case AdvisoryScopeAll:
+		return true
+	case AdvisoryScopeSuppressed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AdvisorySeverity.
+const (
+	AdvisorySeverityCritical AdvisorySeverity = "critical"
+	AdvisorySeverityHigh     AdvisorySeverity = "high"
+	AdvisorySeverityLow      AdvisorySeverity = "low"
+	AdvisorySeverityMedium   AdvisorySeverity = "medium"
+	AdvisorySeverityNone     AdvisorySeverity = "none"
+)
+
+// Valid indicates whether the value is a known member of the AdvisorySeverity enum.
+func (e AdvisorySeverity) Valid() bool {
+	switch e {
+	case AdvisorySeverityCritical:
+		return true
+	case AdvisorySeverityHigh:
+		return true
+	case AdvisorySeverityLow:
+		return true
+	case AdvisorySeverityMedium:
+		return true
+	case AdvisorySeverityNone:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AdvisorySort.
+const (
+	AdvisorySortAffected AdvisorySort = "affected"
+	AdvisorySortCvss     AdvisorySort = "cvss"
+	AdvisorySortReported AdvisorySort = "reported"
+	AdvisorySortSeverity AdvisorySort = "severity"
+)
+
+// Valid indicates whether the value is a known member of the AdvisorySort enum.
+func (e AdvisorySort) Valid() bool {
+	switch e {
+	case AdvisorySortAffected:
+		return true
+	case AdvisorySortCvss:
+		return true
+	case AdvisorySortReported:
+		return true
+	case AdvisorySortSeverity:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for LanguageParam.
 const (
 	LanguageParamDe LanguageParam = "de"
@@ -67,6 +166,33 @@ func (e GetAccountExtensionParamsLanguage) Valid() bool {
 	case GetAccountExtensionParamsLanguageDe:
 		return true
 	case GetAccountExtensionParamsLanguageEn:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AdminListAdvisoriesParamsSeverity.
+const (
+	AdminListAdvisoriesParamsSeverityCritical AdminListAdvisoriesParamsSeverity = "critical"
+	AdminListAdvisoriesParamsSeverityHigh     AdminListAdvisoriesParamsSeverity = "high"
+	AdminListAdvisoriesParamsSeverityLow      AdminListAdvisoriesParamsSeverity = "low"
+	AdminListAdvisoriesParamsSeverityMedium   AdminListAdvisoriesParamsSeverity = "medium"
+	AdminListAdvisoriesParamsSeverityNone     AdminListAdvisoriesParamsSeverity = "none"
+)
+
+// Valid indicates whether the value is a known member of the AdminListAdvisoriesParamsSeverity enum.
+func (e AdminListAdvisoriesParamsSeverity) Valid() bool {
+	switch e {
+	case AdminListAdvisoriesParamsSeverityCritical:
+		return true
+	case AdminListAdvisoriesParamsSeverityHigh:
+		return true
+	case AdminListAdvisoriesParamsSeverityLow:
+		return true
+	case AdminListAdvisoriesParamsSeverityMedium:
+		return true
+	case AdminListAdvisoriesParamsSeverityNone:
 		return true
 	default:
 		return false
@@ -127,6 +253,78 @@ func (e AdminGetOrganizationsParamsSortDirection) Valid() bool {
 	case AdminGetOrganizationsParamsSortDirectionAsc:
 		return true
 	case AdminGetOrganizationsParamsSortDirectionDesc:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListAdvisoriesParamsSeverity.
+const (
+	ListAdvisoriesParamsSeverityCritical ListAdvisoriesParamsSeverity = "critical"
+	ListAdvisoriesParamsSeverityHigh     ListAdvisoriesParamsSeverity = "high"
+	ListAdvisoriesParamsSeverityLow      ListAdvisoriesParamsSeverity = "low"
+	ListAdvisoriesParamsSeverityMedium   ListAdvisoriesParamsSeverity = "medium"
+	ListAdvisoriesParamsSeverityNone     ListAdvisoriesParamsSeverity = "none"
+)
+
+// Valid indicates whether the value is a known member of the ListAdvisoriesParamsSeverity enum.
+func (e ListAdvisoriesParamsSeverity) Valid() bool {
+	switch e {
+	case ListAdvisoriesParamsSeverityCritical:
+		return true
+	case ListAdvisoriesParamsSeverityHigh:
+		return true
+	case ListAdvisoriesParamsSeverityLow:
+		return true
+	case ListAdvisoriesParamsSeverityMedium:
+		return true
+	case ListAdvisoriesParamsSeverityNone:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListAdvisoriesParamsScope.
+const (
+	ListAdvisoriesParamsScopeAffected   ListAdvisoriesParamsScope = "affected"
+	ListAdvisoriesParamsScopeAll        ListAdvisoriesParamsScope = "all"
+	ListAdvisoriesParamsScopeSuppressed ListAdvisoriesParamsScope = "suppressed"
+)
+
+// Valid indicates whether the value is a known member of the ListAdvisoriesParamsScope enum.
+func (e ListAdvisoriesParamsScope) Valid() bool {
+	switch e {
+	case ListAdvisoriesParamsScopeAffected:
+		return true
+	case ListAdvisoriesParamsScopeAll:
+		return true
+	case ListAdvisoriesParamsScopeSuppressed:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for ListAdvisoriesParamsSort.
+const (
+	ListAdvisoriesParamsSortAffected ListAdvisoriesParamsSort = "affected"
+	ListAdvisoriesParamsSortCvss     ListAdvisoriesParamsSort = "cvss"
+	ListAdvisoriesParamsSortReported ListAdvisoriesParamsSort = "reported"
+	ListAdvisoriesParamsSortSeverity ListAdvisoriesParamsSort = "severity"
+)
+
+// Valid indicates whether the value is a known member of the ListAdvisoriesParamsSort enum.
+func (e ListAdvisoriesParamsSort) Valid() bool {
+	switch e {
+	case ListAdvisoriesParamsSortAffected:
+		return true
+	case ListAdvisoriesParamsSortCvss:
+		return true
+	case ListAdvisoriesParamsSortReported:
+		return true
+	case ListAdvisoriesParamsSortSeverity:
 		return true
 	default:
 		return false
@@ -255,6 +453,80 @@ type AccountShop struct {
 	Name                 string  `json:"name"`
 	OrganizationId       string  `json:"organizationId"`
 	OrganizationName     string  `json:"organizationName"`
+}
+
+// AdminAdvisory defines model for AdminAdvisory.
+type AdminAdvisory struct {
+	// AdvisoryId Canonical id (CVE, else GHSA, else Packagist PKSA)
+	AdvisoryId         string   `json:"advisoryId"`
+	AffectedComponents []string `json:"affectedComponents"`
+
+	// AffectedEnvironmentCount Number of the caller's environments whose Composer package inventory matches this advisory and that are not suppressed. Null when no SBOM data has been collected.
+	AffectedEnvironmentCount *int           `json:"affectedEnvironmentCount,omitempty"`
+	ComposerRepository       *string        `json:"composerRepository,omitempty"`
+	CreatedAt                time.Time      `json:"createdAt"`
+	Cve                      *string        `json:"cve,omitempty"`
+	CvssScore                *float64       `json:"cvssScore,omitempty"`
+	CvssVector               *string        `json:"cvssVector,omitempty"`
+	Cwes                     *[]AdvisoryCWE `json:"cwes,omitempty"`
+
+	// Description Full advisory write-up in Markdown (source form)
+	Description *string `json:"description,omitempty"`
+
+	// DescriptionHtml description rendered as HTML for safe display after client sanitization
+	DescriptionHtml *string `json:"descriptionHtml,omitempty"`
+
+	// DetailsSource Where disclosure details were loaded from (e.g. github)
+	DetailsSource     *string        `json:"detailsSource,omitempty"`
+	EffectiveSeverity *SeverityLevel `json:"effectiveSeverity"`
+	EnrichedAt        *time.Time     `json:"enrichedAt,omitempty"`
+	EnrichedBy        *string        `json:"enrichedBy,omitempty"`
+
+	// ExternalReferences External reference URLs (GHSA page, commits, etc.)
+	ExternalReferences *[]string `json:"externalReferences,omitempty"`
+
+	// FirstPatchedVersions First Shopware release per line that closes this advisory, e.g. {"6.7": "6.7.10.1"}. Machine-derived from the GitHub advisory.
+	FirstPatchedVersions *map[string]string `json:"firstPatchedVersions,omitempty"`
+	GhsaId               *string            `json:"ghsaId,omitempty"`
+	IsVisible            bool               `json:"isVisible"`
+	Link                 *string            `json:"link,omitempty"`
+	NotesInternal        *string            `json:"notesInternal,omitempty"`
+	NotesPublic          *string            `json:"notesPublic,omitempty"`
+
+	// Packages Affected Composer packages (one CVE may span multiple packages)
+	Packages           []AdvisoryAffectedPackage `json:"packages"`
+	RecommendedUpgrade *string                   `json:"recommendedUpgrade,omitempty"`
+	RemediationSummary *string                   `json:"remediationSummary,omitempty"`
+	RemediationUrl     *string                   `json:"remediationUrl,omitempty"`
+	ReportedAt         *time.Time                `json:"reportedAt,omitempty"`
+
+	// SecurityPluginFixes Which SwagPlatformSecurity releases backport this advisory, per branch. Empty when it is not backportable or not yet derived.
+	SecurityPluginFixes   *[]AdvisorySecurityPluginFix `json:"securityPluginFixes,omitempty"`
+	Severity              *SeverityLevel               `json:"severity,omitempty"`
+	SeverityOverride      *SeverityLevel               `json:"severityOverride,omitempty"`
+	ShopwareImpactSummary *string                      `json:"shopwareImpactSummary,omitempty"`
+	Sources               []AdvisorySource             `json:"sources"`
+
+	// Summary Short summary from the disclosure source (e.g. GitHub Advisory)
+	Summary *string `json:"summary,omitempty"`
+
+	// SuppressedEnvironmentCount Number of the caller's environments where this advisory has been acknowledged via an active suppression.
+	SuppressedEnvironmentCount *int      `json:"suppressedEnvironmentCount,omitempty"`
+	SyncedAt                   time.Time `json:"syncedAt"`
+	Tags                       []string  `json:"tags"`
+	Title                      string    `json:"title"`
+	UpdatedAt                  time.Time `json:"updatedAt"`
+}
+
+// AdminAdvisoryListResponse defines model for AdminAdvisoryListResponse.
+type AdminAdvisoryListResponse struct {
+	Advisories []AdminAdvisory `json:"advisories"`
+	Total      int             `json:"total"`
+}
+
+// AdminAdvisorySyncResponse defines model for AdminAdvisorySyncResponse.
+type AdminAdvisorySyncResponse struct {
+	Enqueued bool `json:"enqueued"`
 }
 
 // AdminAuditLogEntry defines model for AdminAuditLogEntry.
@@ -447,6 +719,186 @@ type AdminStats struct {
 	TotalUsers         int `json:"totalUsers"`
 }
 
+// Advisory defines model for Advisory.
+type Advisory struct {
+	// AdvisoryId Canonical id (CVE, else GHSA, else Packagist PKSA)
+	AdvisoryId         string   `json:"advisoryId"`
+	AffectedComponents []string `json:"affectedComponents"`
+
+	// AffectedEnvironmentCount Number of the caller's environments whose Composer package inventory matches this advisory and that are not suppressed. Null when no SBOM data has been collected.
+	AffectedEnvironmentCount *int           `json:"affectedEnvironmentCount,omitempty"`
+	ComposerRepository       *string        `json:"composerRepository,omitempty"`
+	CreatedAt                time.Time      `json:"createdAt"`
+	Cve                      *string        `json:"cve,omitempty"`
+	CvssScore                *float64       `json:"cvssScore,omitempty"`
+	CvssVector               *string        `json:"cvssVector,omitempty"`
+	Cwes                     *[]AdvisoryCWE `json:"cwes,omitempty"`
+
+	// Description Full advisory write-up in Markdown (source form)
+	Description *string `json:"description,omitempty"`
+
+	// DescriptionHtml description rendered as HTML for safe display after client sanitization
+	DescriptionHtml *string `json:"descriptionHtml,omitempty"`
+
+	// DetailsSource Where disclosure details were loaded from (e.g. github)
+	DetailsSource     *string        `json:"detailsSource,omitempty"`
+	EffectiveSeverity *SeverityLevel `json:"effectiveSeverity"`
+
+	// ExternalReferences External reference URLs (GHSA page, commits, etc.)
+	ExternalReferences *[]string `json:"externalReferences,omitempty"`
+
+	// FirstPatchedVersions First Shopware release per line that closes this advisory, e.g. {"6.7": "6.7.10.1"}. Machine-derived from the GitHub advisory.
+	FirstPatchedVersions *map[string]string `json:"firstPatchedVersions,omitempty"`
+	GhsaId               *string            `json:"ghsaId,omitempty"`
+	IsVisible            bool               `json:"isVisible"`
+	Link                 *string            `json:"link,omitempty"`
+	NotesPublic          *string            `json:"notesPublic,omitempty"`
+
+	// Packages Affected Composer packages (one CVE may span multiple packages)
+	Packages           []AdvisoryAffectedPackage `json:"packages"`
+	RecommendedUpgrade *string                   `json:"recommendedUpgrade,omitempty"`
+	RemediationSummary *string                   `json:"remediationSummary,omitempty"`
+	RemediationUrl     *string                   `json:"remediationUrl,omitempty"`
+	ReportedAt         *time.Time                `json:"reportedAt,omitempty"`
+
+	// SecurityPluginFixes Which SwagPlatformSecurity releases backport this advisory, per branch. Empty when it is not backportable or not yet derived.
+	SecurityPluginFixes   *[]AdvisorySecurityPluginFix `json:"securityPluginFixes,omitempty"`
+	Severity              *SeverityLevel               `json:"severity,omitempty"`
+	SeverityOverride      *SeverityLevel               `json:"severityOverride,omitempty"`
+	ShopwareImpactSummary *string                      `json:"shopwareImpactSummary,omitempty"`
+	Sources               []AdvisorySource             `json:"sources"`
+
+	// Summary Short summary from the disclosure source (e.g. GitHub Advisory)
+	Summary *string `json:"summary,omitempty"`
+
+	// SuppressedEnvironmentCount Number of the caller's environments where this advisory has been acknowledged via an active suppression.
+	SuppressedEnvironmentCount *int      `json:"suppressedEnvironmentCount,omitempty"`
+	SyncedAt                   time.Time `json:"syncedAt"`
+	Tags                       []string  `json:"tags"`
+	Title                      string    `json:"title"`
+	UpdatedAt                  time.Time `json:"updatedAt"`
+}
+
+// AdvisoryAffectedEnvironment defines model for AdvisoryAffectedEnvironment.
+type AdvisoryAffectedEnvironment struct {
+	// AffectedVersions The advisory constraint the installed version falls into
+	AffectedVersions  string    `json:"affectedVersions"`
+	EnvironmentId     int       `json:"environmentId"`
+	EnvironmentName   string    `json:"environmentName"`
+	EnvironmentStatus string    `json:"environmentStatus"`
+	InstalledVersion  string    `json:"installedVersion"`
+	MatchedAt         time.Time `json:"matchedAt"`
+	OrganizationId    string    `json:"organizationId"`
+	OrganizationName  string    `json:"organizationName"`
+
+	// PackageName Installed Composer package that matched the advisory
+	PackageName     string  `json:"packageName"`
+	ShopId          int     `json:"shopId"`
+	ShopName        string  `json:"shopName"`
+	ShopwareVersion *string `json:"shopwareVersion,omitempty"`
+
+	// Suppressed Whether an active suppression covers this environment
+	Suppressed bool `json:"suppressed"`
+}
+
+// AdvisoryAffectedPackage defines model for AdvisoryAffectedPackage.
+type AdvisoryAffectedPackage struct {
+	// AffectedVersions Composer constraint for this package
+	AffectedVersions string `json:"affectedVersions"`
+
+	// PackageName Composer package name (e.g. shopware/core)
+	PackageName string `json:"packageName"`
+
+	// PackagistAdvisoryId Original Packagist PKSA id for this package row
+	PackagistAdvisoryId string `json:"packagistAdvisoryId"`
+}
+
+// AdvisoryAffectedResponse defines model for AdvisoryAffectedResponse.
+type AdvisoryAffectedResponse struct {
+	// Environments Affected environments within the caller's organizations
+	Environments []AdvisoryAffectedEnvironment `json:"environments"`
+
+	// GlobalTotal Fleet-wide affected environment count; admins only
+	GlobalTotal *int `json:"globalTotal,omitempty"`
+
+	// Total Number of affected environments visible to the caller
+	Total int `json:"total"`
+}
+
+// AdvisoryCWE defines model for AdvisoryCWE.
+type AdvisoryCWE struct {
+	// Id CWE identifier, e.g. CWE-918
+	Id   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// AdvisoryListResponse defines model for AdvisoryListResponse.
+type AdvisoryListResponse struct {
+	Advisories []Advisory `json:"advisories"`
+
+	// ScopeCounts Totals per scope, ignoring the scope filter, for tab badges
+	ScopeCounts *AdvisoryScopeCounts `json:"scopeCounts,omitempty"`
+
+	// Total Advisories matching the current scope and filters
+	Total int `json:"total"`
+}
+
+// AdvisoryScopeCounts defines model for AdvisoryScopeCounts.
+type AdvisoryScopeCounts struct {
+	// Affected Of those, how many affect the caller's environments and are not suppressed
+	Affected int `json:"affected"`
+
+	// All All visible advisories matching the non-scope filters
+	All int `json:"all"`
+
+	// Suppressed Of those, how many the caller has acknowledged
+	Suppressed int `json:"suppressed"`
+}
+
+// AdvisorySecurityPluginFix defines model for AdvisorySecurityPluginFix.
+type AdvisorySecurityPluginFix struct {
+	// PluginBranch SwagPlatformSecurity major version, e.g. "4"
+	PluginBranch string `json:"pluginBranch"`
+
+	// PluginVersion Lowest plugin version on this branch that backports the fix
+	PluginVersion string `json:"pluginVersion"`
+
+	// ShopwareBranch Shopware line this branch serves, e.g. "6.7"
+	ShopwareBranch string `json:"shopwareBranch"`
+}
+
+// AdvisorySource defines model for AdvisorySource.
+type AdvisorySource struct {
+	Name     string `json:"name"`
+	RemoteId string `json:"remoteId"`
+}
+
+// AdvisorySuppression defines model for AdvisorySuppression.
+type AdvisorySuppression struct {
+	AdvisoryId    string    `json:"advisoryId"`
+	CreatedAt     time.Time `json:"createdAt"`
+	CreatedBy     *string   `json:"createdBy,omitempty"`
+	CreatedByName *string   `json:"createdByName,omitempty"`
+
+	// EnvironmentId Null means every environment of the shop
+	EnvironmentId   *int    `json:"environmentId,omitempty"`
+	EnvironmentName *string `json:"environmentName,omitempty"`
+
+	// ExpiresAt Null means the suppression does not expire
+	ExpiresAt      *time.Time `json:"expiresAt,omitempty"`
+	Id             int64      `json:"id"`
+	OrganizationId string     `json:"organizationId"`
+	Reason         string     `json:"reason"`
+	RevokedAt      *time.Time `json:"revokedAt,omitempty"`
+	ShopId         int        `json:"shopId"`
+	ShopName       string     `json:"shopName"`
+}
+
+// AdvisorySuppressionListResponse defines model for AdvisorySuppressionListResponse.
+type AdvisorySuppressionListResponse struct {
+	Suppressions []AdvisorySuppression `json:"suppressions"`
+}
+
 // ApiKey defines model for ApiKey.
 type ApiKey struct {
 	CreatedAt  time.Time  `json:"createdAt"`
@@ -469,6 +921,19 @@ type CacheInfo struct {
 	Environment  *string `json:"environment,omitempty"`
 	HttpCache    *bool   `json:"httpCache,omitempty"`
 	Id           *int    `json:"id,omitempty"`
+}
+
+// CreateAdvisorySuppressionRequest defines model for CreateAdvisorySuppressionRequest.
+type CreateAdvisorySuppressionRequest struct {
+	// EnvironmentId Omit to suppress across every environment of the shop
+	EnvironmentId *int `json:"environmentId,omitempty"`
+
+	// ExpiresAt Omit for a suppression that does not expire
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
+
+	// Reason Why the advisory is accepted or how it is mitigated
+	Reason string `json:"reason"`
+	ShopId int    `json:"shopId"`
 }
 
 // CreateApiKeyRequest defines model for CreateApiKeyRequest.
@@ -805,6 +1270,9 @@ type ScheduledTask struct {
 	Status            string     `json:"status"`
 }
 
+// SeverityLevel defines model for SeverityLevel.
+type SeverityLevel string
+
 // Shop defines model for Shop.
 type Shop struct {
 	DefaultEnvironmentId *int    `json:"defaultEnvironmentId"`
@@ -898,6 +1366,20 @@ type SubscribedEnvironment struct {
 	ShopName *string `json:"shopName,omitempty"`
 }
 
+// UpdateAdvisoryEnrichmentRequest defines model for UpdateAdvisoryEnrichmentRequest.
+type UpdateAdvisoryEnrichmentRequest struct {
+	AffectedComponents    *[]string      `json:"affectedComponents,omitempty"`
+	IsVisible             *bool          `json:"isVisible,omitempty"`
+	NotesInternal         *string        `json:"notesInternal,omitempty"`
+	NotesPublic           *string        `json:"notesPublic,omitempty"`
+	RecommendedUpgrade    *string        `json:"recommendedUpgrade,omitempty"`
+	RemediationSummary    *string        `json:"remediationSummary,omitempty"`
+	RemediationUrl        *string        `json:"remediationUrl,omitempty"`
+	SeverityOverride      *SeverityLevel `json:"severityOverride,omitempty"`
+	ShopwareImpactSummary *string        `json:"shopwareImpactSummary,omitempty"`
+	Tags                  *[]string      `json:"tags,omitempty"`
+}
+
 // UpdateEnvironmentRequest defines model for UpdateEnvironmentRequest.
 type UpdateEnvironmentRequest struct {
 	ClientId     *string   `json:"clientId,omitempty"`
@@ -937,6 +1419,33 @@ type UserProfile struct {
 	// Locale The user's preferred language, used to localize notification emails.
 	Locale string `json:"locale"`
 }
+
+// AdvisoryId defines model for AdvisoryId.
+type AdvisoryId = string
+
+// AdvisoryLimit defines model for AdvisoryLimit.
+type AdvisoryLimit = int
+
+// AdvisoryOffset defines model for AdvisoryOffset.
+type AdvisoryOffset = int
+
+// AdvisoryPackage defines model for AdvisoryPackage.
+type AdvisoryPackage = string
+
+// AdvisoryScope defines model for AdvisoryScope.
+type AdvisoryScope string
+
+// AdvisorySearch defines model for AdvisorySearch.
+type AdvisorySearch = string
+
+// AdvisorySeverity defines model for AdvisorySeverity.
+type AdvisorySeverity string
+
+// AdvisorySort defines model for AdvisorySort.
+type AdvisorySort string
+
+// AdvisoryTag defines model for AdvisoryTag.
+type AdvisoryTag = string
 
 // DeploymentId defines model for DeploymentId.
 type DeploymentId = int
@@ -1015,6 +1524,30 @@ type DeleteNotificationPreferenceParams struct {
 	Channel   string  `form:"channel" json:"channel"`
 }
 
+// AdminListAdvisoriesParams defines parameters for AdminListAdvisories.
+type AdminListAdvisoriesParams struct {
+	Limit  *AdvisoryLimit  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *AdvisoryOffset `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Package Filter by Composer package name (e.g. shopware/core)
+	Package *AdvisoryPackage `form:"package,omitempty" json:"package,omitempty"`
+
+	// Severity Filter by effective severity
+	Severity *AdminListAdvisoriesParamsSeverity `form:"severity,omitempty" json:"severity,omitempty"`
+
+	// Tag Filter by admin tag
+	Tag *AdvisoryTag `form:"tag,omitempty" json:"tag,omitempty"`
+
+	// Q Search title, CVE, GHSA, package, or advisory ID
+	Q *AdvisorySearch `form:"q,omitempty" json:"q,omitempty"`
+
+	// Visible When set, filter by visibility
+	Visible *bool `form:"visible,omitempty" json:"visible,omitempty"`
+}
+
+// AdminListAdvisoriesParamsSeverity defines parameters for AdminListAdvisories.
+type AdminListAdvisoriesParamsSeverity string
+
 // AdminGetAuditLogParams defines parameters for AdminGetAuditLog.
 type AdminGetAuditLogParams struct {
 	Limit        *int    `form:"limit,omitempty" json:"limit,omitempty"`
@@ -1061,6 +1594,39 @@ type AdminGetOrganizationsParamsSortBy string
 // AdminGetOrganizationsParamsSortDirection defines parameters for AdminGetOrganizations.
 type AdminGetOrganizationsParamsSortDirection string
 
+// ListAdvisoriesParams defines parameters for ListAdvisories.
+type ListAdvisoriesParams struct {
+	Limit  *AdvisoryLimit  `form:"limit,omitempty" json:"limit,omitempty"`
+	Offset *AdvisoryOffset `form:"offset,omitempty" json:"offset,omitempty"`
+
+	// Package Filter by Composer package name (e.g. shopware/core)
+	Package *AdvisoryPackage `form:"package,omitempty" json:"package,omitempty"`
+
+	// Severity Filter by effective severity
+	Severity *ListAdvisoriesParamsSeverity `form:"severity,omitempty" json:"severity,omitempty"`
+
+	// Tag Filter by admin tag
+	Tag *AdvisoryTag `form:"tag,omitempty" json:"tag,omitempty"`
+
+	// Q Search title, CVE, GHSA, package, or advisory ID
+	Q *AdvisorySearch `form:"q,omitempty" json:"q,omitempty"`
+
+	// Scope "affected" limits results to advisories matching the Composer inventory of the caller's own environments, excluding suppressed ones; "suppressed" returns only those the caller has acknowledged; "all" returns the full catalog.
+	Scope *ListAdvisoriesParamsScope `form:"scope,omitempty" json:"scope,omitempty"`
+
+	// Sort Sort order: "reported" newest first, "severity" most severe first, "affected" most affected environments first, "cvss" highest score first.
+	Sort *ListAdvisoriesParamsSort `form:"sort,omitempty" json:"sort,omitempty"`
+}
+
+// ListAdvisoriesParamsSeverity defines parameters for ListAdvisories.
+type ListAdvisoriesParamsSeverity string
+
+// ListAdvisoriesParamsScope defines parameters for ListAdvisories.
+type ListAdvisoriesParamsScope string
+
+// ListAdvisoriesParamsSort defines parameters for ListAdvisories.
+type ListAdvisoriesParamsSort string
+
 // GetEnvironmentParams defines parameters for GetEnvironment.
 type GetEnvironmentParams struct {
 	// Language Language for localized store text (label, description, manual, changelog). Falls back to English.
@@ -1093,11 +1659,23 @@ type DiscoverSsoParams struct {
 	Issuer string `form:"issuer" json:"issuer"`
 }
 
+// ListSuppressionsParams defines parameters for ListSuppressions.
+type ListSuppressionsParams struct {
+	// IncludeInactive Include revoked and expired suppressions
+	IncludeInactive *bool `form:"includeInactive,omitempty" json:"includeInactive,omitempty"`
+}
+
 // UpdateAccountMeJSONRequestBody defines body for UpdateAccountMe for application/json ContentType.
 type UpdateAccountMeJSONRequestBody UpdateAccountMeJSONBody
 
 // SetNotificationPreferenceJSONRequestBody defines body for SetNotificationPreference for application/json ContentType.
 type SetNotificationPreferenceJSONRequestBody = NotificationPreferenceInput
+
+// AdminUpdateAdvisoryJSONRequestBody defines body for AdminUpdateAdvisory for application/json ContentType.
+type AdminUpdateAdvisoryJSONRequestBody = UpdateAdvisoryEnrichmentRequest
+
+// CreateAdvisorySuppressionJSONRequestBody defines body for CreateAdvisorySuppression for application/json ContentType.
+type CreateAdvisorySuppressionJSONRequestBody = CreateAdvisorySuppressionRequest
 
 // CreateCliDeploymentJSONRequestBody defines body for CreateCliDeployment for application/json ContentType.
 type CreateCliDeploymentJSONRequestBody = CreateCliDeploymentRequest
@@ -1170,6 +1748,18 @@ type ServerInterface interface {
 	// Get environments the user is subscribed to for notifications
 	// (GET /account/subscribed-environments)
 	GetAccountSubscribedEnvironments(w http.ResponseWriter, r *http.Request)
+	// List all Composer advisories including hidden ones (admin only)
+	// (GET /admin/advisories)
+	AdminListAdvisories(w http.ResponseWriter, r *http.Request, params AdminListAdvisoriesParams)
+	// Enqueue a Packagist advisory sync job
+	// (POST /admin/advisories/sync)
+	AdminSyncAdvisories(w http.ResponseWriter, r *http.Request)
+	// Get a single advisory with internal notes (admin only)
+	// (GET /admin/advisories/{advisoryId})
+	AdminGetAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId)
+	// Update Shopmon enrichment fields for an advisory
+	// (PATCH /admin/advisories/{advisoryId})
+	AdminUpdateAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId)
 	// List audit log entries (admin only)
 	// (GET /admin/audit-log)
 	AdminGetAuditLog(w http.ResponseWriter, r *http.Request, params AdminGetAuditLogParams)
@@ -1197,6 +1787,21 @@ type ServerInterface interface {
 	// Get admin dashboard statistics
 	// (GET /admin/stats)
 	AdminGetStats(w http.ResponseWriter, r *http.Request)
+	// List visible Composer security advisories for Shopware packages
+	// (GET /advisories)
+	ListAdvisories(w http.ResponseWriter, r *http.Request, params ListAdvisoriesParams)
+	// List package names that have visible advisories
+	// (GET /advisories/packages)
+	ListAdvisoryPackages(w http.ResponseWriter, r *http.Request)
+	// Get a visible advisory by Packagist advisory ID
+	// (GET /advisories/{advisoryId})
+	GetAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId)
+	// List the caller's environments affected by an advisory
+	// (GET /advisories/{advisoryId}/affected)
+	ListAdvisoryAffectedEnvironments(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId)
+	// Record that an advisory is accepted or mitigated for a shop
+	// (POST /advisories/{advisoryId}/suppressions)
+	CreateAdvisorySuppression(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId)
 	// Get available API key scopes
 	// (GET /api-key-scopes)
 	GetApiKeyScopes(w http.ResponseWriter, r *http.Request)
@@ -1329,6 +1934,12 @@ type ServerInterface interface {
 	// Discover OIDC configuration from an issuer URL
 	// (GET /sso/discover)
 	DiscoverSso(w http.ResponseWriter, r *http.Request, params DiscoverSsoParams)
+	// List advisory suppressions for the caller's organizations
+	// (GET /suppressions)
+	ListSuppressions(w http.ResponseWriter, r *http.Request, params ListSuppressionsParams)
+	// Revoke a suppression so the advisory resurfaces
+	// (DELETE /suppressions/{suppressionId})
+	RevokeAdvisorySuppression(w http.ResponseWriter, r *http.Request, suppressionId int64)
 }
 
 // Unimplemented server implementation that returns http.StatusNotImplemented for each endpoint.
@@ -1407,6 +2018,30 @@ func (_ Unimplemented) GetAccountSubscribedEnvironments(w http.ResponseWriter, r
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
+// List all Composer advisories including hidden ones (admin only)
+// (GET /admin/advisories)
+func (_ Unimplemented) AdminListAdvisories(w http.ResponseWriter, r *http.Request, params AdminListAdvisoriesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Enqueue a Packagist advisory sync job
+// (POST /admin/advisories/sync)
+func (_ Unimplemented) AdminSyncAdvisories(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get a single advisory with internal notes (admin only)
+// (GET /admin/advisories/{advisoryId})
+func (_ Unimplemented) AdminGetAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Update Shopmon enrichment fields for an advisory
+// (PATCH /admin/advisories/{advisoryId})
+func (_ Unimplemented) AdminUpdateAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
 // List audit log entries (admin only)
 // (GET /admin/audit-log)
 func (_ Unimplemented) AdminGetAuditLog(w http.ResponseWriter, r *http.Request, params AdminGetAuditLogParams) {
@@ -1458,6 +2093,36 @@ func (_ Unimplemented) AdminGetShopwareVersions(w http.ResponseWriter, r *http.R
 // Get admin dashboard statistics
 // (GET /admin/stats)
 func (_ Unimplemented) AdminGetStats(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List visible Composer security advisories for Shopware packages
+// (GET /advisories)
+func (_ Unimplemented) ListAdvisories(w http.ResponseWriter, r *http.Request, params ListAdvisoriesParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List package names that have visible advisories
+// (GET /advisories/packages)
+func (_ Unimplemented) ListAdvisoryPackages(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Get a visible advisory by Packagist advisory ID
+// (GET /advisories/{advisoryId})
+func (_ Unimplemented) GetAdvisory(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List the caller's environments affected by an advisory
+// (GET /advisories/{advisoryId}/affected)
+func (_ Unimplemented) ListAdvisoryAffectedEnvironments(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Record that an advisory is accepted or mitigated for a shop
+// (POST /advisories/{advisoryId}/suppressions)
+func (_ Unimplemented) CreateAdvisorySuppression(w http.ResponseWriter, r *http.Request, advisoryId AdvisoryId) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -1722,6 +2387,18 @@ func (_ Unimplemented) GetPackagesTokenConfiguration(w http.ResponseWriter, r *h
 // Discover OIDC configuration from an issuer URL
 // (GET /sso/discover)
 func (_ Unimplemented) DiscoverSso(w http.ResponseWriter, r *http.Request, params DiscoverSsoParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// List advisory suppressions for the caller's organizations
+// (GET /suppressions)
+func (_ Unimplemented) ListSuppressions(w http.ResponseWriter, r *http.Request, params ListSuppressionsParams) {
+	w.WriteHeader(http.StatusNotImplemented)
+}
+
+// Revoke a suppression so the advisory resurfaces
+// (DELETE /suppressions/{suppressionId})
+func (_ Unimplemented) RevokeAdvisorySuppression(w http.ResponseWriter, r *http.Request, suppressionId int64) {
 	w.WriteHeader(http.StatusNotImplemented)
 }
 
@@ -2070,6 +2747,207 @@ func (siw *ServerInterfaceWrapper) GetAccountSubscribedEnvironments(w http.Respo
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetAccountSubscribedEnvironments(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminListAdvisories operation middleware
+func (siw *ServerInterfaceWrapper) AdminListAdvisories(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params AdminListAdvisoriesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", r.URL.Query(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "offset"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "package" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "package", r.URL.Query(), &params.Package, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "package"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "package", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "severity" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "severity", r.URL.Query(), &params.Severity, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "severity"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "severity", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tag" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag", r.URL.Query(), &params.Tag, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "visible" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "visible", r.URL.Query(), &params.Visible, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "visible"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "visible", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminListAdvisories(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminSyncAdvisories operation middleware
+func (siw *ServerInterfaceWrapper) AdminSyncAdvisories(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminSyncAdvisories(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminGetAdvisory operation middleware
+func (siw *ServerInterfaceWrapper) AdminGetAdvisory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "advisoryId" -------------
+	var advisoryId AdvisoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "advisoryId", chi.URLParam(r, "advisoryId"), &advisoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "advisoryId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminGetAdvisory(w, r, advisoryId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// AdminUpdateAdvisory operation middleware
+func (siw *ServerInterfaceWrapper) AdminUpdateAdvisory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "advisoryId" -------------
+	var advisoryId AdvisoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "advisoryId", chi.URLParam(r, "advisoryId"), &advisoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "advisoryId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.AdminUpdateAdvisory(w, r, advisoryId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -2617,6 +3495,252 @@ func (siw *ServerInterfaceWrapper) AdminGetStats(w http.ResponseWriter, r *http.
 
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.AdminGetStats(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAdvisories operation middleware
+func (siw *ServerInterfaceWrapper) ListAdvisories(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListAdvisoriesParams
+
+	// ------------- Optional query parameter "limit" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "limit", r.URL.Query(), &params.Limit, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "limit"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "limit", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "offset" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "offset", r.URL.Query(), &params.Offset, runtime.BindQueryParameterOptions{Type: "integer", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "offset"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "offset", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "package" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "package", r.URL.Query(), &params.Package, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "package"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "package", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "severity" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "severity", r.URL.Query(), &params.Severity, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "severity"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "severity", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "tag" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "tag", r.URL.Query(), &params.Tag, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "tag"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "tag", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "q" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "q", r.URL.Query(), &params.Q, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "q"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "q", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "scope" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "scope", r.URL.Query(), &params.Scope, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "scope"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "scope", Err: err})
+		}
+		return
+	}
+
+	// ------------- Optional query parameter "sort" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "sort", r.URL.Query(), &params.Sort, runtime.BindQueryParameterOptions{Type: "string", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "sort"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "sort", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAdvisories(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAdvisoryPackages operation middleware
+func (siw *ServerInterfaceWrapper) ListAdvisoryPackages(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAdvisoryPackages(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAdvisory operation middleware
+func (siw *ServerInterfaceWrapper) GetAdvisory(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "advisoryId" -------------
+	var advisoryId AdvisoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "advisoryId", chi.URLParam(r, "advisoryId"), &advisoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "advisoryId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAdvisory(w, r, advisoryId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// ListAdvisoryAffectedEnvironments operation middleware
+func (siw *ServerInterfaceWrapper) ListAdvisoryAffectedEnvironments(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "advisoryId" -------------
+	var advisoryId AdvisoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "advisoryId", chi.URLParam(r, "advisoryId"), &advisoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "advisoryId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListAdvisoryAffectedEnvironments(w, r, advisoryId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// CreateAdvisorySuppression operation middleware
+func (siw *ServerInterfaceWrapper) CreateAdvisorySuppression(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "advisoryId" -------------
+	var advisoryId AdvisoryId
+
+	err = runtime.BindStyledParameterWithOptions("simple", "advisoryId", chi.URLParam(r, "advisoryId"), &advisoryId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "advisoryId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.CreateAdvisorySuppression(w, r, advisoryId)
 	}))
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -4082,6 +5206,77 @@ func (siw *ServerInterfaceWrapper) DiscoverSso(w http.ResponseWriter, r *http.Re
 	handler.ServeHTTP(w, r)
 }
 
+// ListSuppressions operation middleware
+func (siw *ServerInterfaceWrapper) ListSuppressions(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	// Parameter object where we will unmarshal all parameters from the context
+	var params ListSuppressionsParams
+
+	// ------------- Optional query parameter "includeInactive" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "includeInactive", r.URL.Query(), &params.IncludeInactive, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "includeInactive"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "includeInactive", Err: err})
+		}
+		return
+	}
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListSuppressions(w, r, params)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// RevokeAdvisorySuppression operation middleware
+func (siw *ServerInterfaceWrapper) RevokeAdvisorySuppression(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	_ = err
+
+	// ------------- Path parameter "suppressionId" -------------
+	var suppressionId int64
+
+	err = runtime.BindStyledParameterWithOptions("simple", "suppressionId", chi.URLParam(r, "suppressionId"), &suppressionId, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "integer", Format: "int64"})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "suppressionId", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.RevokeAdvisorySuppression(w, r, suppressionId)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
 type UnescapedCookieParamError struct {
 	ParamName string
 	Err       error
@@ -4232,6 +5427,18 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 		r.Get(options.BaseURL+"/account/subscribed-environments", wrapper.GetAccountSubscribedEnvironments)
 	})
 	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/admin/advisories", wrapper.AdminListAdvisories)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/admin/advisories/sync", wrapper.AdminSyncAdvisories)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/admin/advisories/{advisoryId}", wrapper.AdminGetAdvisory)
+	})
+	r.Group(func(r chi.Router) {
+		r.Patch(options.BaseURL+"/admin/advisories/{advisoryId}", wrapper.AdminUpdateAdvisory)
+	})
+	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/admin/audit-log", wrapper.AdminGetAuditLog)
 	})
 	r.Group(func(r chi.Router) {
@@ -4257,6 +5464,21 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/admin/stats", wrapper.AdminGetStats)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/advisories", wrapper.ListAdvisories)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/advisories/packages", wrapper.ListAdvisoryPackages)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/advisories/{advisoryId}", wrapper.GetAdvisory)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/advisories/{advisoryId}/affected", wrapper.ListAdvisoryAffectedEnvironments)
+	})
+	r.Group(func(r chi.Router) {
+		r.Post(options.BaseURL+"/advisories/{advisoryId}/suppressions", wrapper.CreateAdvisorySuppression)
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/api-key-scopes", wrapper.GetApiKeyScopes)
@@ -4389,6 +5611,12 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	})
 	r.Group(func(r chi.Router) {
 		r.Get(options.BaseURL+"/sso/discover", wrapper.DiscoverSso)
+	})
+	r.Group(func(r chi.Router) {
+		r.Get(options.BaseURL+"/suppressions", wrapper.ListSuppressions)
+	})
+	r.Group(func(r chi.Router) {
+		r.Delete(options.BaseURL+"/suppressions/{suppressionId}", wrapper.RevokeAdvisorySuppression)
 	})
 
 	return r

--- a/api/internal/architecture/dependencies_test.go
+++ b/api/internal/architecture/dependencies_test.go
@@ -62,6 +62,7 @@ func TestCapabilityCoreDoesNotImportTransportOrPersistence(t *testing.T) {
 		"internal/notification",
 		"internal/organization",
 		"internal/packagesmirror",
+		"internal/suppression",
 	} {
 		// Only inspect files in the capability root. Infrastructure adapters and
 		// specialized worker implementations intentionally live below it.
@@ -88,6 +89,7 @@ func TestCapabilitiesDoNotImportHTTPTransport(t *testing.T) {
 		"internal/organization",
 		"internal/packagesmirror",
 		"internal/readmodel",
+		"internal/suppression",
 	} {
 		assertNoForbiddenImports(t, root, directory, true, forbidden)
 	}

--- a/api/internal/handler/advisory.go
+++ b/api/internal/handler/advisory.go
@@ -1,0 +1,368 @@
+package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+	advisoryread "github.com/friendsofshopware/shopmon/api/internal/readmodel/advisory"
+)
+
+func (h *Handler) ListAdvisories(w http.ResponseWriter, r *http.Request, params api.ListAdvisoriesParams) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	orgIDs, err := h.advisories.OrganizationIDsForUser(r.Context(), user.ID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to load user organizations", "userId", user.ID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisories")
+		return
+	}
+
+	// Default to the affected scope: the catalog is large and mostly irrelevant
+	// to any single tenant, so "what hits my shops" is the useful landing view.
+	// An unknown scope value falls back to the same default rather than
+	// silently widening to the whole catalog.
+	scope := api.ListAdvisoriesParamsScopeAffected
+	if params.Scope != nil && params.Scope.Valid() {
+		scope = *params.Scope
+	}
+	onlyAffected := scope == api.ListAdvisoriesParamsScopeAffected
+	onlySuppressed := scope == api.ListAdvisoriesParamsScopeSuppressed
+
+	sort := "reported"
+	if params.Sort != nil {
+		sort = string(*params.Sort)
+	}
+
+	rows, counts, err := h.advisories.ListScoped(r.Context(), advisoryread.ScopedListParams{
+		Limit:           int32(ptrIntOr(params.Limit, 25)),
+		Offset:          int32(ptrIntOr(params.Offset, 0)),
+		OrganizationIDs: orgIDs,
+		OnlyAffected:    onlyAffected,
+		OnlySuppressed:  onlySuppressed,
+		Sort:            sort,
+		PackageName:     params.Package,
+		Severity:        severityParamString(params.Severity),
+		Tag:             params.Tag,
+		Search:          params.Q,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to list advisories", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisories")
+		return
+	}
+
+	items := make([]api.Advisory, 0, len(rows))
+	for _, view := range rows {
+		item, err := advisoryread.ToUserAdvisory(view)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "failed to map advisory", "advisoryId", view.Advisory.AdvisoryID, "error", err)
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisories")
+			return
+		}
+		items = append(items, item)
+	}
+
+	total := counts.All
+	switch {
+	case onlyAffected:
+		total = counts.Affected
+	case onlySuppressed:
+		total = counts.Suppressed
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, api.AdvisoryListResponse{
+		Advisories: items,
+		Total:      total,
+		ScopeCounts: &api.AdvisoryScopeCounts{
+			All:        counts.All,
+			Affected:   counts.Affected,
+			Suppressed: counts.Suppressed,
+		},
+	})
+}
+
+// annotateAffectedCounts fills in how many of the user's own environments each
+// advisory affects. A failure here degrades the response to counts-unknown
+// rather than failing the whole listing.
+func (h *Handler) annotateAffectedCounts(r *http.Request, userID string, views []advisoryread.AdvisoryView) {
+	if len(views) == 0 {
+		return
+	}
+
+	orgIDs, err := h.advisories.OrganizationIDsForUser(r.Context(), userID)
+	if err != nil {
+		slog.WarnContext(r.Context(), "failed to load organizations for advisory counts", "userId", userID, "error", err)
+		return
+	}
+	if len(orgIDs) == 0 {
+		return
+	}
+
+	ids := make([]string, 0, len(views))
+	for _, v := range views {
+		ids = append(ids, v.Advisory.AdvisoryID)
+	}
+
+	counts, err := h.advisories.AffectedCounts(r.Context(), ids, orgIDs)
+	if err != nil {
+		slog.WarnContext(r.Context(), "failed to count affected environments", "error", err)
+		return
+	}
+
+	for i := range views {
+		count := counts[views[i].Advisory.AdvisoryID]
+		views[i].AffectedEnvironments = &count
+	}
+}
+
+func (h *Handler) GetAdvisory(w http.ResponseWriter, r *http.Request, advisoryID api.AdvisoryId) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	view, err := h.advisories.Get(r.Context(), advisoryID, true)
+	if err != nil {
+		if errors.Is(err, advisoryread.ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "advisory not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to get advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get advisory")
+		return
+	}
+
+	views := []advisoryread.AdvisoryView{view}
+	h.annotateAffectedCounts(r, user.ID, views)
+
+	item, err := advisoryread.ToUserAdvisory(views[0])
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to map advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get advisory")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, item)
+}
+
+func (h *Handler) ListAdvisoryPackages(w http.ResponseWriter, r *http.Request) {
+	if h.requireUser(w, r) == nil {
+		return
+	}
+
+	names, err := h.advisories.ListPackages(r.Context(), true)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to list advisory packages", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisory packages")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, names)
+}
+
+// ListAdvisoryAffectedEnvironments reports which of the caller's environments
+// ship a package version covered by the advisory. Admins additionally get a
+// fleet-wide count.
+func (h *Handler) ListAdvisoryAffectedEnvironments(w http.ResponseWriter, r *http.Request, advisoryID api.AdvisoryId) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	// Resolve the advisory first so an unknown id is a 404 rather than an empty
+	// list, and so hidden advisories stay hidden from non-admins.
+	if _, err := h.advisories.Get(r.Context(), advisoryID, user.Role != "admin"); err != nil {
+		if errors.Is(err, advisoryread.ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "advisory not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to get advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load advisory")
+		return
+	}
+
+	orgIDs, err := h.advisories.OrganizationIDsForUser(r.Context(), user.ID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to load user organizations", "userId", user.ID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load affected environments")
+		return
+	}
+
+	result, err := h.advisories.ListAffected(r.Context(), advisoryID, orgIDs, user.Role == "admin")
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to list affected environments", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to load affected environments")
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, api.AdvisoryAffectedResponse{
+		Environments: result.Environments,
+		Total:        result.Total,
+		GlobalTotal:  result.GlobalTotal,
+	})
+}
+
+func (h *Handler) AdminListAdvisories(w http.ResponseWriter, r *http.Request, params api.AdminListAdvisoriesParams) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	rows, total, err := h.advisories.List(r.Context(), advisoryread.ListParams{
+		Limit:       int32(ptrIntOr(params.Limit, 25)),
+		Offset:      int32(ptrIntOr(params.Offset, 0)),
+		PackageName: params.Package,
+		Severity:    adminSeverityParamString(params.Severity),
+		Tag:         params.Tag,
+		Search:      params.Q,
+		IsVisible:   params.Visible,
+	})
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to list admin advisories", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisories")
+		return
+	}
+
+	items := make([]api.AdminAdvisory, 0, len(rows))
+	for _, view := range rows {
+		item, err := advisoryread.ToAdminAdvisory(view)
+		if err != nil {
+			slog.ErrorContext(r.Context(), "failed to map admin advisory", "advisoryId", view.Advisory.AdvisoryID, "error", err)
+			httputil.WriteError(w, http.StatusInternalServerError, "failed to list advisories")
+			return
+		}
+		items = append(items, item)
+	}
+
+	httputil.WriteJSON(w, http.StatusOK, api.AdminAdvisoryListResponse{
+		Advisories: items,
+		Total:      int(total),
+	})
+}
+
+func (h *Handler) AdminGetAdvisory(w http.ResponseWriter, r *http.Request, advisoryID api.AdvisoryId) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+
+	view, err := h.advisories.Get(r.Context(), advisoryID, false)
+	if err != nil {
+		if errors.Is(err, advisoryread.ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "advisory not found")
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to get admin advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get advisory")
+		return
+	}
+
+	item, err := advisoryread.ToAdminAdvisory(view)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to map admin advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to get advisory")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, item)
+}
+
+func (h *Handler) AdminUpdateAdvisory(w http.ResponseWriter, r *http.Request, advisoryID api.AdvisoryId) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+	if user.Role != "admin" {
+		httputil.WriteError(w, http.StatusForbidden, httputil.MsgAdminRequired)
+		return
+	}
+
+	var body api.UpdateAdvisoryEnrichmentRequest
+	if err := httputil.DecodeBody(r, &body); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var severityOverride *string
+	if body.SeverityOverride != nil {
+		s := string(*body.SeverityOverride)
+		severityOverride = &s
+	}
+
+	view, err := h.advisories.UpdateEnrichment(r.Context(), advisoryID, advisoryread.EnrichmentUpdate{
+		SeverityOverride:      severityOverride,
+		IsVisible:             body.IsVisible,
+		NotesPublic:           body.NotesPublic,
+		NotesInternal:         body.NotesInternal,
+		RemediationSummary:    body.RemediationSummary,
+		RemediationUrl:        body.RemediationUrl,
+		RecommendedUpgrade:    body.RecommendedUpgrade,
+		ShopwareImpactSummary: body.ShopwareImpactSummary,
+		AffectedComponents:    body.AffectedComponents,
+		Tags:                  body.Tags,
+		EnrichedBy:            user.ID,
+	})
+	if err != nil {
+		if errors.Is(err, advisoryread.ErrNotFound) {
+			httputil.WriteError(w, http.StatusNotFound, "advisory not found")
+			return
+		}
+		if errors.Is(err, advisoryread.ErrInvalidInput) {
+			httputil.WriteError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		slog.ErrorContext(r.Context(), "failed to update advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update advisory")
+		return
+	}
+
+	item, err := advisoryread.ToAdminAdvisory(view)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to map admin advisory", "advisoryId", advisoryID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to update advisory")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusOK, item)
+}
+
+func (h *Handler) AdminSyncAdvisories(w http.ResponseWriter, r *http.Request) {
+	if !h.requireAdmin(w, r) {
+		return
+	}
+	if h.advisorySync == nil {
+		httputil.WriteError(w, http.StatusServiceUnavailable, "advisory sync is not available")
+		return
+	}
+	if err := h.advisorySync.EnqueueComposerAdvisorySync(r.Context()); err != nil {
+		slog.ErrorContext(r.Context(), "failed to enqueue advisory sync", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to enqueue advisory sync")
+		return
+	}
+	httputil.WriteJSON(w, http.StatusAccepted, api.AdminAdvisorySyncResponse{Enqueued: true})
+}
+
+func ptrIntOr(v *int, fallback int) int {
+	if v == nil {
+		return fallback
+	}
+	return *v
+}
+
+// A severity outside the enum is ignored rather than forwarded: the query
+// would match nothing, turning a typo into a misleading empty page.
+func severityParamString(s *api.ListAdvisoriesParamsSeverity) *string {
+	if s == nil || !s.Valid() {
+		return nil
+	}
+	v := string(*s)
+	return &v
+}
+
+func adminSeverityParamString(s *api.AdminListAdvisoriesParamsSeverity) *string {
+	if s == nil || !s.Valid() {
+		return nil
+	}
+	v := string(*s)
+	return &v
+}

--- a/api/internal/handler/advisory_suppression.go
+++ b/api/internal/handler/advisory_suppression.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+	"github.com/friendsofshopware/shopmon/api/internal/suppression"
+)
+
+// CreateAdvisorySuppression records that an advisory is accepted or mitigated
+// for a shop, removing it from the "affecting my shops" list and silencing its
+// alerts.
+func (h *Handler) CreateAdvisorySuppression(w http.ResponseWriter, r *http.Request, advisoryID api.AdvisoryId) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	var req api.CreateAdvisorySuppressionRequest
+	if err := httputil.DecodeBody(r, &req); err != nil {
+		httputil.WriteError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	var environmentID *int32
+	if req.EnvironmentId != nil {
+		id := int32(*req.EnvironmentId)
+		environmentID = &id
+	}
+
+	created, err := h.suppressions.Create(r.Context(), suppression.CreateCommand{
+		UserID:        user.ID,
+		ShopID:        int32(req.ShopId),
+		EnvironmentID: environmentID,
+		AdvisoryID:    advisoryID,
+		Reason:        req.Reason,
+		ExpiresAt:     req.ExpiresAt,
+	})
+	if err != nil {
+		writeSuppressionError(w, r, err)
+		return
+	}
+
+	httputil.WriteJSON(w, http.StatusCreated, toAPISuppression(created))
+}
+
+// RevokeAdvisorySuppression lifts a suppression so the advisory resurfaces. The
+// row is soft-deleted, preserving who accepted the risk and why.
+func (h *Handler) RevokeAdvisorySuppression(w http.ResponseWriter, r *http.Request, suppressionID int64) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	orgIDs, err := h.advisories.OrganizationIDsForUser(r.Context(), user.ID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to load user organizations", "userId", user.ID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to revoke suppression")
+		return
+	}
+
+	if _, err := h.suppressions.Revoke(r.Context(), suppressionID, user.ID, orgIDs); err != nil {
+		writeSuppressionError(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ListSuppressions returns the suppressions across the caller's organizations.
+func (h *Handler) ListSuppressions(w http.ResponseWriter, r *http.Request, params api.ListSuppressionsParams) {
+	user := h.requireUser(w, r)
+	if user == nil {
+		return
+	}
+
+	orgIDs, err := h.advisories.OrganizationIDsForUser(r.Context(), user.ID)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to load user organizations", "userId", user.ID, "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list suppressions")
+		return
+	}
+
+	includeInactive := params.IncludeInactive != nil && *params.IncludeInactive
+	records, err := h.suppressions.List(r.Context(), orgIDs, includeInactive)
+	if err != nil {
+		slog.ErrorContext(r.Context(), "failed to list suppressions", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to list suppressions")
+		return
+	}
+
+	items := make([]api.AdvisorySuppression, 0, len(records))
+	for _, record := range records {
+		items = append(items, toAPISuppression(record))
+	}
+	httputil.WriteJSON(w, http.StatusOK, api.AdvisorySuppressionListResponse{Suppressions: items})
+}
+
+func toAPISuppression(record suppression.Suppression) api.AdvisorySuppression {
+	item := api.AdvisorySuppression{
+		Id:             record.ID,
+		AdvisoryId:     record.AdvisoryID,
+		OrganizationId: record.OrganizationID,
+		ShopId:         int(record.ShopID),
+		ShopName:       record.ShopName,
+		Reason:         record.Reason,
+		ExpiresAt:      record.ExpiresAt,
+		CreatedBy:      record.CreatedBy,
+		CreatedAt:      record.CreatedAt,
+		RevokedAt:      record.RevokedAt,
+	}
+	if record.EnvironmentID != nil {
+		id := int(*record.EnvironmentID)
+		item.EnvironmentId = &id
+	}
+	if record.EnvironmentName != nil && *record.EnvironmentName != "" {
+		item.EnvironmentName = record.EnvironmentName
+	}
+	if record.CreatedByName != nil && *record.CreatedByName != "" {
+		item.CreatedByName = record.CreatedByName
+	}
+	return item
+}
+
+// writeSuppressionError maps capability errors onto transport status codes.
+// A duplicate is a 409 rather than a silent overwrite, which is the behaviour
+// the legacy whole-array ignores PATCH could not offer.
+func writeSuppressionError(w http.ResponseWriter, r *http.Request, err error) {
+	switch {
+	case errors.Is(err, suppression.ErrReasonRequired):
+		httputil.WriteError(w, http.StatusBadRequest, "a reason is required")
+	case errors.Is(err, suppression.ErrExpiryInPast):
+		httputil.WriteError(w, http.StatusBadRequest, "expiry must be in the future")
+	case errors.Is(err, suppression.ErrEnvironmentScope):
+		httputil.WriteError(w, http.StatusBadRequest, "environment does not belong to shop")
+	case errors.Is(err, suppression.ErrNotAuthorized):
+		httputil.WriteError(w, http.StatusForbidden, "not authorized to suppress for this shop")
+	case errors.Is(err, suppression.ErrShopNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "shop not found")
+	case errors.Is(err, suppression.ErrAdvisoryNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "advisory not found")
+	case errors.Is(err, suppression.ErrNotFound):
+		httputil.WriteError(w, http.StatusNotFound, "suppression not found")
+	case errors.Is(err, suppression.ErrAlreadySuppressed):
+		httputil.WriteError(w, http.StatusConflict, "an active suppression already covers this scope")
+	default:
+		slog.ErrorContext(r.Context(), "suppression request failed", "error", err)
+		httputil.WriteError(w, http.StatusInternalServerError, "failed to process suppression")
+	}
+}

--- a/api/internal/handler/advisory_test.go
+++ b/api/internal/handler/advisory_test.go
@@ -1,0 +1,537 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/testutil"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func seedAdvisory(t *testing.T, q *queries.Queries, id string, packages []string, visible bool, notesInternal *string) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, q.UpsertComposerAdvisory(ctx, queries.UpsertComposerAdvisoryParams{
+		AdvisoryID: id,
+		Title:      "Seeded advisory " + id,
+		Link:       ptrStr("https://example.com/" + id),
+		Cve:        ptrStr(id),
+		GhsaID:     ptrStr("GHSA-" + id),
+		Severity:   ptrStr("medium"),
+		Sources:    []byte(`[{"name":"GitHub","remoteId":"GHSA-` + id + `"}]`),
+		ReportedAt: pgtype.Timestamp{Time: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC), Valid: true},
+	}))
+	for i, pkg := range packages {
+		require.NoError(t, q.UpsertComposerAdvisoryPackage(ctx, queries.UpsertComposerAdvisoryPackageParams{
+			AdvisoryID:          id,
+			PackageName:         pkg,
+			PackagistAdvisoryID: fmt.Sprintf("PKSA-%s-%d", id, i),
+			AffectedVersions:    ">=6.7.0.0,<6.7.10.1",
+		}))
+	}
+	if !visible || notesInternal != nil {
+		_, err := q.UpdateComposerAdvisoryEnrichment(ctx, queries.UpdateComposerAdvisoryEnrichmentParams{
+			AdvisoryID:         id,
+			IsVisible:          visible,
+			NotesInternal:      notesInternal,
+			AffectedComponents: []string{},
+			Tags:               []string{"seed"},
+			EnrichedBy:         ptrStr("test"),
+		})
+		require.NoError(t, err)
+	}
+}
+
+func ptrStr(s string) *string { return &s }
+
+func TestListAdvisoriesHidesInvisibleAndInternalNotes(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-VISIBLE", []string{"shopware/core", "shopware/platform"}, true, ptrStr("secret-internal"))
+	seedAdvisory(t, env.Queries, "CVE-HIDDEN", []string{"shopware/core"}, false, ptrStr("hidden-internal"))
+
+	token := env.SeedUser(t, "user-1", "Regular User", "user@example.com", "user")
+
+	// scope=all: this asserts visibility filtering, independent of whether any
+	// shop inventory matches (the default scope is "affected").
+	req := testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories?scope=all", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Advisories []map[string]any `json:"advisories"`
+		Total      int              `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	require.Equal(t, 1, body.Total)
+	require.Len(t, body.Advisories, 1)
+	assert.Equal(t, "CVE-VISIBLE", body.Advisories[0]["advisoryId"])
+	pkgs, ok := body.Advisories[0]["packages"].([]any)
+	require.True(t, ok)
+	assert.Len(t, pkgs, 2)
+	_, hasInternal := body.Advisories[0]["notesInternal"]
+	assert.False(t, hasInternal)
+
+	req = testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories/CVE-HIDDEN", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestAdminCanUpdateEnrichmentAndSeeHidden(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-ADMIN", []string{"shopware/core"}, true, nil)
+
+	adminToken := env.SeedUser(t, "admin-1", "Admin User", "admin@example.com", "admin")
+
+	payload := map[string]any{
+		"severityOverride":   "critical",
+		"isVisible":          false,
+		"notesPublic":        "Public note",
+		"notesInternal":      "Internal note",
+		"remediationSummary": "Upgrade now",
+		"recommendedUpgrade": "6.7.10.1",
+		"tags":               []string{"critical", "core"},
+		"affectedComponents": []string{"admin"},
+	}
+	body, _ := json.Marshal(payload)
+	req := testutil.NewRequest(t, "PATCH", env.Server.URL+"/api/admin/advisories/CVE-ADMIN", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var updated map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	assert.Equal(t, "critical", updated["severityOverride"])
+	assert.Equal(t, false, updated["isVisible"])
+	assert.Equal(t, "Internal note", updated["notesInternal"])
+
+	userToken := env.SeedUser(t, "user-2", "Regular User", "user2@example.com", "user")
+	req = testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories/CVE-ADMIN", nil)
+	req.Header.Set("Authorization", "Bearer "+userToken)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+func TestAdminAdvisoryRequiresAdmin(t *testing.T) {
+	env := testutil.Setup(t)
+	token := env.SeedUser(t, "user-1", "Regular User", "user@example.com", "user")
+
+	req := testutil.NewRequest(t, "GET", env.Server.URL+"/api/admin/advisories", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// seedAdvisoryMatch links an advisory to an environment as if a scrape had
+// matched it against the environment's SBOM.
+func seedAdvisoryMatch(t *testing.T, q *queries.Queries, environmentID int32, advisoryID, pkg, installed string) {
+	t.Helper()
+	require.NoError(t, q.UpsertEnvironmentAdvisoryMatch(context.Background(), queries.UpsertEnvironmentAdvisoryMatchParams{
+		EnvironmentID:    environmentID,
+		AdvisoryID:       advisoryID,
+		PackageName:      pkg,
+		InstalledVersion: installed,
+		AffectedVersions: ">=6.7.0.0,<6.7.10.1",
+	}))
+}
+
+func TestListAdvisoriesScopeAndCounts(t *testing.T) {
+	env := testutil.Setup(t)
+
+	seedAdvisory(t, env.Queries, "CVE-HITS-ME", []string{"shopware/core"}, true, nil)
+	seedAdvisory(t, env.Queries, "CVE-NOT-MINE", []string{"other/package"}, true, nil)
+
+	token := env.SeedUser(t, "user-1", "Regular User", "user@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+	envID := env.SeedEnvironment(t, "org-1", shopID, "Production", "https://shop.example.com")
+	seedAdvisoryMatch(t, env.Queries, int32(envID), "CVE-HITS-ME", "shopware/core", "6.7.8.2")
+
+	get := func(query string) (int, []map[string]any, map[string]any) {
+		t.Helper()
+		req := testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories"+query, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body struct {
+			Advisories  []map[string]any `json:"advisories"`
+			Total       int              `json:"total"`
+			ScopeCounts map[string]any   `json:"scopeCounts"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		return body.Total, body.Advisories, body.ScopeCounts
+	}
+
+	// Default scope is "affected": only the advisory matching this org's shop.
+	total, items, counts := get("")
+	assert.Equal(t, 1, total)
+	require.Len(t, items, 1)
+	assert.Equal(t, "CVE-HITS-ME", items[0]["advisoryId"])
+	assert.Equal(t, float64(1), items[0]["affectedEnvironmentCount"])
+	// Tab badges report both scopes regardless of the active one.
+	assert.Equal(t, float64(2), counts["all"])
+	assert.Equal(t, float64(1), counts["affected"])
+
+	// scope=all returns the full visible catalog.
+	total, items, _ = get("?scope=all")
+	assert.Equal(t, 2, total)
+	assert.Len(t, items, 2)
+
+	// Sorting by affected puts the matched advisory first even in "all".
+	_, items, _ = get("?scope=all&sort=affected")
+	require.Len(t, items, 2)
+	assert.Equal(t, "CVE-HITS-ME", items[0]["advisoryId"])
+
+	// Non-scope filters still apply within a scope.
+	total, _, _ = get("?scope=affected&package=other/package")
+	assert.Equal(t, 0, total)
+}
+
+// A user who belongs to no organization can have no matches, so the affected
+// scope is empty while the catalog count still guides them to "all".
+func TestListAdvisoriesAffectedScopeEmptyWithoutOrganizations(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-SOMETHING", []string{"shopware/core"}, true, nil)
+	token := env.SeedUser(t, "user-1", "Regular User", "user@example.com", "user")
+
+	req := testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		Advisories  []map[string]any `json:"advisories"`
+		Total       int              `json:"total"`
+		ScopeCounts map[string]any   `json:"scopeCounts"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, 0, body.Total)
+	assert.Empty(t, body.Advisories)
+	assert.Equal(t, float64(1), body.ScopeCounts["all"])
+	assert.Equal(t, float64(0), body.ScopeCounts["affected"])
+}
+
+// Suppressing an advisory moves it out of the "affecting my shops" scope and
+// into the suppressed scope, for every environment of the shop at once.
+func TestSuppressAdvisoryMovesItBetweenScopes(t *testing.T) {
+	env := testutil.Setup(t)
+
+	seedAdvisory(t, env.Queries, "CVE-SUPPRESS-ME", []string{"shopware/core"}, true, nil)
+	seedAdvisory(t, env.Queries, "CVE-STAYS", []string{"shopware/core"}, true, nil)
+
+	token := env.SeedUser(t, "user-1", "Owner User", "owner@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+	prodID := env.SeedEnvironment(t, "org-1", shopID, "Production", "https://prod.example.com")
+	stagingID := env.SeedEnvironment(t, "org-1", shopID, "Staging", "https://staging.example.com")
+
+	for _, envID := range []int{prodID, stagingID} {
+		seedAdvisoryMatch(t, env.Queries, int32(envID), "CVE-SUPPRESS-ME", "shopware/core", "6.7.8.2")
+		seedAdvisoryMatch(t, env.Queries, int32(envID), "CVE-STAYS", "shopware/core", "6.7.8.2")
+	}
+
+	counts := func(scope string) (int, map[string]any) {
+		t.Helper()
+		req := testutil.NewRequest(t, "GET", env.Server.URL+"/api/advisories?scope="+scope, nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var body struct {
+			Advisories  []map[string]any `json:"advisories"`
+			Total       int              `json:"total"`
+			ScopeCounts map[string]any   `json:"scopeCounts"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+		// The tab badge must agree with the list it labels.
+		assert.Len(t, body.Advisories, body.Total)
+		return body.Total, body.ScopeCounts
+	}
+
+	affected, sc := counts("affected")
+	assert.Equal(t, 2, affected)
+	assert.Equal(t, float64(0), sc["suppressed"])
+
+	payload, _ := json.Marshal(map[string]any{
+		"shopId": shopID,
+		"reason": "Mitigated by WAF rule",
+	})
+	req := testutil.NewRequest(t, "POST", env.Server.URL+"/api/advisories/CVE-SUPPRESS-ME/suppressions", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	var created map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.Equal(t, "Mitigated by WAF rule", created["reason"])
+
+	// One shop-level suppression covers both environments.
+	affected, sc = counts("affected")
+	assert.Equal(t, 1, affected)
+	assert.Equal(t, float64(1), sc["affected"])
+	assert.Equal(t, float64(1), sc["suppressed"])
+
+	suppressed, _ := counts("suppressed")
+	assert.Equal(t, 1, suppressed)
+
+	// Revoking brings it back.
+	suppressionID, ok := created["id"].(float64)
+	require.True(t, ok)
+	req = testutil.NewRequest(t, "DELETE", fmt.Sprintf("%s/api/suppressions/%d", env.Server.URL, int64(suppressionID)), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	affected, _ = counts("affected")
+	assert.Equal(t, 2, affected)
+}
+
+// A duplicate suppression is a 409, not a silent overwrite -- the failure mode
+// the legacy whole-array ignores PATCH could not avoid.
+func TestSuppressAdvisoryRejectsDuplicateAndEmptyReason(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-DUP", []string{"shopware/core"}, true, nil)
+
+	token := env.SeedUser(t, "user-1", "Owner User", "owner@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+
+	post := func(body map[string]any) int {
+		t.Helper()
+		payload, _ := json.Marshal(body)
+		req := testutil.NewRequest(t, "POST", env.Server.URL+"/api/advisories/CVE-DUP/suppressions", bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusBadRequest, post(map[string]any{"shopId": shopID, "reason": "   "}))
+	assert.Equal(t, http.StatusCreated, post(map[string]any{"shopId": shopID, "reason": "accepted"}))
+	assert.Equal(t, http.StatusConflict, post(map[string]any{"shopId": shopID, "reason": "accepted again"}))
+}
+
+// An expired suppression is inactive on every read path, so it must not block
+// re-suppressing the same scope: the stale row is retired and a fresh one
+// created, instead of a permanent 409.
+func TestSuppressAdvisoryRenewableAfterExpiry(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+	seedAdvisory(t, env.Queries, "CVE-EXPIRED", []string{"shopware/core"}, true, nil)
+
+	token := env.SeedUser(t, "user-1", "Owner User", "owner@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+
+	// Seed an already-expired, unrevoked suppression directly: the API itself
+	// rejects a past expiresAt, which is exactly why this state only arises
+	// from the passage of time.
+	_, err := env.Pool.Exec(ctx, `
+		INSERT INTO advisory_suppression (organization_id, shop_id, advisory_id, reason, expires_at, created_by, created_at)
+		VALUES ('org-1', $1, 'CVE-EXPIRED', 'temporary', NOW() - INTERVAL '1 day', 'user-1', NOW() - INTERVAL '31 days')
+	`, shopID)
+	require.NoError(t, err)
+
+	payload, _ := json.Marshal(map[string]any{"shopId": shopID, "reason": "still accepted"})
+	req := testutil.NewRequest(t, "POST", env.Server.URL+"/api/advisories/CVE-EXPIRED/suppressions", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusCreated, resp.StatusCode)
+
+	// The contract declares shopName required on the created suppression.
+	var created struct {
+		ShopName string `json:"shopName"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	assert.Equal(t, "Shop One", created.ShopName)
+
+	// The expired row is retired, not deleted: the audit trail survives.
+	var revoked int
+	require.NoError(t, env.Pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM advisory_suppression WHERE advisory_id = 'CVE-EXPIRED' AND revoked_at IS NOT NULL`,
+	).Scan(&revoked))
+	assert.Equal(t, 1, revoked)
+}
+
+// Revoking carries the same role requirement as creating. A member who could
+// never have accepted a shop-wide risk must not be able to withdraw that
+// acceptance either — otherwise the audit trail records an end to a decision
+// nobody with the authority to make it chose to end.
+func TestRevokeShopWideSuppressionRequiresElevatedRole(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+	seedAdvisory(t, env.Queries, "CVE-REVOKE", []string{"shopware/core"}, true, nil)
+
+	ownerToken := env.SeedUser(t, "user-1", "Owner User", "owner@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+
+	memberToken := env.SeedUser(t, "user-2", "Member User", "member@example.com", "user")
+	env.SeedMember(t, "org-1", "user-2", "member")
+
+	// Owner creates a shop-wide suppression (member could not have).
+	payload, _ := json.Marshal(map[string]any{"shopId": shopID, "reason": "accepted"})
+	req := testutil.NewRequest(t, "POST", env.Server.URL+"/api/advisories/CVE-REVOKE/suppressions", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	var created struct {
+		ID int64 `json:"id"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&created))
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.NotZero(t, created.ID)
+
+	revoke := func(token string) int {
+		t.Helper()
+		req := testutil.NewRequest(t, "DELETE",
+			fmt.Sprintf("%s/api/suppressions/%d", env.Server.URL, created.ID), nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer func() { _ = resp.Body.Close() }()
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusForbidden, revoke(memberToken),
+		"a member must not revoke a shop-wide suppression")
+
+	var revokedAt *time.Time
+	require.NoError(t, env.Pool.QueryRow(ctx,
+		`SELECT revoked_at FROM advisory_suppression WHERE id = $1`, created.ID).Scan(&revokedAt))
+	assert.Nil(t, revokedAt, "the suppression must still be active after the denied revoke")
+
+	assert.Equal(t, http.StatusNoContent, revoke(ownerToken))
+}
+
+// A member of another organization must not be able to suppress for this shop.
+func TestSuppressAdvisoryRejectsForeignOrganization(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-FOREIGN", []string{"shopware/core"}, true, nil)
+
+	env.SeedUser(t, "user-1", "Owner User", "owner@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Org One", "org-one", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Shop One")
+
+	outsiderToken := env.SeedUser(t, "user-2", "Outsider", "outsider@example.com", "user")
+
+	payload, _ := json.Marshal(map[string]any{"shopId": shopID, "reason": "not mine"})
+	req := testutil.NewRequest(t, "POST", env.Server.URL+"/api/advisories/CVE-FOREIGN/suppressions", bytes.NewReader(payload))
+	req.Header.Set("Authorization", "Bearer "+outsiderToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+// The admin update endpoint is a PATCH with every field optional, so a body
+// that sets one field must not clear the others — and must never republish an
+// advisory an admin deliberately hid.
+func TestAdminUpdateAdvisoryPreservesOmittedFields(t *testing.T) {
+	env := testutil.Setup(t)
+	seedAdvisory(t, env.Queries, "CVE-PATCH", []string{"shopware/core"}, true, nil)
+
+	token := env.SeedUser(t, "admin-1", "Admin", "admin@example.com", "admin")
+
+	patch := func(body map[string]any) *http.Response {
+		t.Helper()
+		payload, _ := json.Marshal(body)
+		req := testutil.NewRequest(t, "PATCH", env.Server.URL+"/api/admin/advisories/CVE-PATCH", bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		return resp
+	}
+
+	// Full enrichment, including hiding the advisory.
+	resp := patch(map[string]any{
+		"isVisible":     false,
+		"notesInternal": "under investigation",
+		"notesPublic":   "mitigated upstream",
+		"tags":          []string{"ssrf"},
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	_ = resp.Body.Close()
+
+	// A partial follow-up touching only tags.
+	resp = patch(map[string]any{"tags": []string{"ssrf", "triaged"}})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var updated struct {
+		IsVisible     bool     `json:"isVisible"`
+		NotesInternal *string  `json:"notesInternal"`
+		NotesPublic   *string  `json:"notesPublic"`
+		Tags          []string `json:"tags"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&updated))
+	_ = resp.Body.Close()
+
+	assert.False(t, updated.IsVisible, "omitting isVisible must not republish a hidden advisory")
+	require.NotNil(t, updated.NotesInternal)
+	assert.Equal(t, "under investigation", *updated.NotesInternal)
+	require.NotNil(t, updated.NotesPublic)
+	assert.Equal(t, "mitigated upstream", *updated.NotesPublic)
+	assert.Equal(t, []string{"ssrf", "triaged"}, updated.Tags)
+
+	// An explicit empty string still clears a field. Decoded into a fresh
+	// struct: reusing `updated` would keep the previous value for a field the
+	// response omits, hiding exactly what this asserts.
+	resp = patch(map[string]any{"notesPublic": ""})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var cleared struct {
+		NotesPublic   *string `json:"notesPublic"`
+		NotesInternal *string `json:"notesInternal"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&cleared))
+	_ = resp.Body.Close()
+	assert.Nil(t, cleared.NotesPublic, "an explicit empty value must clear the column")
+	require.NotNil(t, cleared.NotesInternal, "clearing one field must not clear its neighbours")
+	assert.Equal(t, "under investigation", *cleared.NotesInternal)
+
+	// An out-of-enum severity is rejected rather than stored and silently
+	// dropped on read.
+	resp = patch(map[string]any{"severityOverride": "catastrophic"})
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	_ = resp.Body.Close()
+}

--- a/api/internal/handler/handler.go
+++ b/api/internal/handler/handler.go
@@ -15,8 +15,15 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/packagesmirror"
 	accountread "github.com/friendsofshopware/shopmon/api/internal/readmodel/account"
 	adminread "github.com/friendsofshopware/shopmon/api/internal/readmodel/admin"
+	advisoryread "github.com/friendsofshopware/shopmon/api/internal/readmodel/advisory"
 	environmentread "github.com/friendsofshopware/shopmon/api/internal/readmodel/environment"
+	"github.com/friendsofshopware/shopmon/api/internal/suppression"
 )
+
+// AdvisorySyncDispatcher enqueues a Packagist advisory sync job.
+type AdvisorySyncDispatcher interface {
+	EnqueueComposerAdvisorySync(ctx context.Context) error
+}
 
 // Ensure Handler implements ServerInterface at compile time.
 var _ api.ServerInterface = (*Handler)(nil)
@@ -50,6 +57,9 @@ type Dependencies struct {
 	Account       *accountread.Service
 	Admin         *adminread.Service
 	Environments  *environmentread.Service
+	Advisories    *advisoryread.Service
+	AdvisorySync  AdvisorySyncDispatcher
+	Suppressions  *suppression.Service
 }
 
 type Handler struct {
@@ -64,6 +74,9 @@ type Handler struct {
 	account       *accountread.Service
 	admin         *adminread.Service
 	environments  *environmentread.Service
+	advisories    *advisoryread.Service
+	advisorySync  AdvisorySyncDispatcher
+	suppressions  *suppression.Service
 }
 
 func New(dependencies Dependencies) *Handler {
@@ -79,6 +92,9 @@ func New(dependencies Dependencies) *Handler {
 		account:       dependencies.Account,
 		admin:         dependencies.Admin,
 		environments:  dependencies.Environments,
+		advisories:    dependencies.Advisories,
+		advisorySync:  dependencies.AdvisorySync,
+		suppressions:  dependencies.Suppressions,
 	}
 }
 

--- a/api/internal/readmodel/advisory/affected.go
+++ b/api/internal/readmodel/advisory/affected.go
@@ -1,0 +1,278 @@
+package advisory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+)
+
+// AffectedResult is the org-scoped list of environments matching an advisory,
+// optionally accompanied by a fleet-wide count for admins.
+type AffectedResult struct {
+	Environments []api.AdvisoryAffectedEnvironment
+	Total        int
+	GlobalTotal  *int
+}
+
+// OrganizationIDsForUser returns the organizations the user belongs to, used to
+// scope advisory exposure to the caller's own shops.
+func (s *Service) OrganizationIDsForUser(ctx context.Context, userID string) ([]string, error) {
+	orgs, err := s.queries.GetUserOrganizations(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("get user organizations: %w", err)
+	}
+	out := make([]string, 0, len(orgs))
+	for _, org := range orgs {
+		out = append(out, org.ID)
+	}
+	return out, nil
+}
+
+// ListAffected returns the environments affected by an advisory.
+//
+// organizationIDs restricts the result to the caller's tenants: advisories are
+// global data, but which shops are exposed is not. Passing includeGlobalTotal
+// (admins only) additionally reports the fleet-wide affected count without
+// leaking any other tenant's shop names.
+func (s *Service) ListAffected(ctx context.Context, advisoryID string, organizationIDs []string, includeGlobalTotal bool) (AffectedResult, error) {
+	var result AffectedResult
+
+	if len(organizationIDs) > 0 {
+		rows, err := s.queries.ListAffectedEnvironmentsForAdvisory(ctx, queries.ListAffectedEnvironmentsForAdvisoryParams{
+			AdvisoryID: advisoryID,
+			Column2:    organizationIDs,
+		})
+		if err != nil {
+			return result, fmt.Errorf("list affected environments: %w", err)
+		}
+
+		envIDs := make(map[int32]bool, len(rows))
+		result.Environments = make([]api.AdvisoryAffectedEnvironment, 0, len(rows))
+		for _, row := range rows {
+			envIDs[row.EnvironmentID] = true
+			result.Environments = append(result.Environments, api.AdvisoryAffectedEnvironment{
+				EnvironmentId:     int(row.EnvironmentID),
+				EnvironmentName:   row.EnvironmentName,
+				EnvironmentStatus: row.EnvironmentStatus,
+				ShopId:            int(row.ShopID),
+				ShopName:          row.ShopName,
+				OrganizationId:    row.OrganizationID,
+				OrganizationName:  row.OrganizationName,
+				ShopwareVersion:   nilIfEmpty(row.ShopwareVersion),
+				PackageName:       row.PackageName,
+				InstalledVersion:  row.InstalledVersion,
+				AffectedVersions:  row.AffectedVersions,
+				Suppressed:        row.Suppressed,
+				MatchedAt:         row.MatchedAt.Time,
+			})
+		}
+		// One environment can match through several packages; the headline
+		// count is distinct environments, not match rows.
+		result.Total = len(envIDs)
+	} else {
+		result.Environments = []api.AdvisoryAffectedEnvironment{}
+	}
+
+	if includeGlobalTotal {
+		counts, err := s.queries.CountAffectedEnvironmentsForAdvisories(ctx, []string{advisoryID})
+		if err != nil {
+			return result, fmt.Errorf("count affected environments: %w", err)
+		}
+		total := 0
+		for _, c := range counts {
+			if c.AdvisoryID == advisoryID {
+				total = int(c.EnvironmentCount)
+			}
+		}
+		result.GlobalTotal = &total
+	}
+
+	return result, nil
+}
+
+// ScopedListParams filters the user-facing advisory list.
+type ScopedListParams struct {
+	Limit           int32
+	Offset          int32
+	OrganizationIDs []string
+	// OnlyAffected restricts results to advisories matching the caller's own
+	// environment inventory, excluding suppressed ones.
+	OnlyAffected bool
+	// OnlySuppressed restricts results to advisories the caller has
+	// acknowledged. Mutually exclusive with OnlyAffected.
+	OnlySuppressed bool
+	// Sort is one of reported (default), severity, affected, cvss.
+	Sort        string
+	PackageName *string
+	Severity    *string
+	Tag         *string
+	Search      *string
+}
+
+// ScopeCounts are the per-scope totals behind the list's scope tabs.
+type ScopeCounts struct {
+	All        int
+	Affected   int
+	Suppressed int
+}
+
+var allowedSorts = map[string]bool{
+	"reported": true,
+	"severity": true,
+	"affected": true,
+	"cvss":     true,
+}
+
+// ListScoped returns advisories with their affected-environment counts, and the
+// per-scope totals used for the scope tabs.
+//
+// A user with no organizations can have no affected advisories, so the affected
+// scope is empty for them; the counts still report the full catalog size so the
+// UI can steer them to the "all" tab.
+func (s *Service) ListScoped(ctx context.Context, params ScopedListParams) ([]AdvisoryView, ScopeCounts, error) {
+	if params.Limit <= 0 {
+		params.Limit = 25
+	}
+	if params.Limit > 100 {
+		params.Limit = 100
+	}
+	if params.Offset < 0 {
+		params.Offset = 0
+	}
+	if !allowedSorts[params.Sort] {
+		params.Sort = "reported"
+	}
+	// ANY($1::text[]) needs a non-nil array; an empty one matches nothing,
+	// which is the correct result for a user without organizations.
+	orgIDs := params.OrganizationIDs
+	if orgIDs == nil {
+		orgIDs = []string{}
+	}
+
+	rows, err := s.queries.ListComposerAdvisoriesScoped(ctx, queries.ListComposerAdvisoriesScopedParams{
+		OrganizationIds: orgIDs,
+		OnlyAffected:    params.OnlyAffected,
+		OnlySuppressed:  params.OnlySuppressed,
+		PackageName:     emptyToNil(params.PackageName),
+		Severity:        emptyToNil(params.Severity),
+		Tag:             emptyToNil(params.Tag),
+		Search:          emptyToNil(params.Search),
+		Sort:            params.Sort,
+		Limit:           params.Limit,
+		Offset:          params.Offset,
+	})
+	if err != nil {
+		return nil, ScopeCounts{}, fmt.Errorf("list scoped advisories: %w", err)
+	}
+
+	counts, err := s.queries.CountComposerAdvisoriesScoped(ctx, queries.CountComposerAdvisoriesScopedParams{
+		OrganizationIds: orgIDs,
+		PackageName:     emptyToNil(params.PackageName),
+		Severity:        emptyToNil(params.Severity),
+		Tag:             emptyToNil(params.Tag),
+		Search:          emptyToNil(params.Search),
+	})
+	if err != nil {
+		return nil, ScopeCounts{}, fmt.Errorf("count scoped advisories: %w", err)
+	}
+
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.AdvisoryID)
+	}
+	pkgsByID, err := s.packagesByAdvisoryIDs(ctx, ids)
+	if err != nil {
+		return nil, ScopeCounts{}, err
+	}
+
+	views := make([]AdvisoryView, 0, len(rows))
+	for _, row := range rows {
+		count := int(row.AffectedCount)
+		suppressed := int(row.SuppressedCount)
+		views = append(views, AdvisoryView{
+			Advisory:               scopedRowToAdvisory(row),
+			Packages:               pkgsByID[row.AdvisoryID],
+			AffectedEnvironments:   &count,
+			SuppressedEnvironments: &suppressed,
+		})
+	}
+
+	// One batched lookup for the whole page, keyed by GHSA.
+	if fixes, err := s.securityPluginFixesByGhsa(ctx, ghsaIDsOf(views)); err == nil {
+		for i := range views {
+			if ghsa := views[i].Advisory.GhsaID; ghsa != nil {
+				views[i].SecurityPluginFixes = fixes[*ghsa]
+			}
+		}
+	}
+
+	return views, ScopeCounts{
+		All:        int(counts.AllCount),
+		Affected:   int(counts.AffectedCount),
+		Suppressed: int(counts.SuppressedCount),
+	}, nil
+}
+
+// scopedRowToAdvisory drops the joined affected_count so the row can reuse the
+// shared advisory mapper.
+func scopedRowToAdvisory(row queries.ListComposerAdvisoriesScopedRow) queries.ComposerAdvisory {
+	return queries.ComposerAdvisory{
+		AdvisoryID:            row.AdvisoryID,
+		Title:                 row.Title,
+		Link:                  row.Link,
+		Cve:                   row.Cve,
+		GhsaID:                row.GhsaID,
+		Severity:              row.Severity,
+		Sources:               row.Sources,
+		ReportedAt:            row.ReportedAt,
+		ComposerRepository:    row.ComposerRepository,
+		SyncedAt:              row.SyncedAt,
+		CreatedAt:             row.CreatedAt,
+		UpdatedAt:             row.UpdatedAt,
+		Summary:               row.Summary,
+		Description:           row.Description,
+		CvssScore:             row.CvssScore,
+		CvssVector:            row.CvssVector,
+		Cwes:                  row.Cwes,
+		ExternalReferences:    row.ExternalReferences,
+		DetailsSource:         row.DetailsSource,
+		DetailsSyncedAt:       row.DetailsSyncedAt,
+		SeverityOverride:      row.SeverityOverride,
+		IsVisible:             row.IsVisible,
+		NotesPublic:           row.NotesPublic,
+		NotesInternal:         row.NotesInternal,
+		RemediationSummary:    row.RemediationSummary,
+		RemediationUrl:        row.RemediationUrl,
+		RecommendedUpgrade:    row.RecommendedUpgrade,
+		ShopwareImpactSummary: row.ShopwareImpactSummary,
+		AffectedComponents:    row.AffectedComponents,
+		Tags:                  row.Tags,
+		EnrichedAt:            row.EnrichedAt,
+		EnrichedBy:            row.EnrichedBy,
+		FirstPatchedVersions:  row.FirstPatchedVersions,
+	}
+}
+
+// AffectedCounts returns, per advisory id, how many of the caller's
+// environments are affected. Used to annotate advisory lists.
+func (s *Service) AffectedCounts(ctx context.Context, advisoryIDs, organizationIDs []string) (map[string]int, error) {
+	if len(advisoryIDs) == 0 || len(organizationIDs) == 0 {
+		return map[string]int{}, nil
+	}
+
+	rows, err := s.queries.CountAffectedEnvironmentsForAdvisoriesInOrgs(ctx, queries.CountAffectedEnvironmentsForAdvisoriesInOrgsParams{
+		Column1: advisoryIDs,
+		Column2: organizationIDs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("count affected environments in orgs: %w", err)
+	}
+
+	out := make(map[string]int, len(rows))
+	for _, row := range rows {
+		out[row.AdvisoryID] = int(row.EnvironmentCount)
+	}
+	return out, nil
+}

--- a/api/internal/readmodel/advisory/securityplugin.go
+++ b/api/internal/readmodel/advisory/securityplugin.go
@@ -1,0 +1,64 @@
+package advisory
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/friendsofshopware/shopmon/api/internal/api"
+)
+
+// securityPluginFixesByGhsa loads the backport map for a set of advisories in
+// one query, following the same batching shape as packagesByAdvisoryIDs so a
+// list page never issues one query per row.
+func (s *Service) securityPluginFixesByGhsa(ctx context.Context, ghsaIDs []string) (map[string][]api.AdvisorySecurityPluginFix, error) {
+	if len(ghsaIDs) == 0 {
+		return map[string][]api.AdvisorySecurityPluginFix{}, nil
+	}
+
+	rows, err := s.queries.ListSecurityPluginFixesForGhsas(ctx, ghsaIDs)
+	if err != nil {
+		return nil, fmt.Errorf("list security plugin fixes: %w", err)
+	}
+
+	out := make(map[string][]api.AdvisorySecurityPluginFix, len(rows))
+	for _, row := range rows {
+		out[row.GhsaID] = append(out[row.GhsaID], api.AdvisorySecurityPluginFix{
+			PluginBranch:   row.PluginBranch,
+			PluginVersion:  row.PluginVersion,
+			ShopwareBranch: row.ShopwareBranch,
+		})
+	}
+	return out, nil
+}
+
+// parseFirstPatchedVersions decodes the machine-derived {line: version} map.
+// A malformed value yields nil rather than an error: the remediation hint is
+// advisory, and losing it must never fail an advisory listing.
+func parseFirstPatchedVersions(raw json.RawMessage) *map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var parsed map[string]string
+	if err := json.Unmarshal(raw, &parsed); err != nil || len(parsed) == 0 {
+		return nil
+	}
+	return &parsed
+}
+
+// ghsaIDsOf collects the non-empty GHSA ids across advisory views.
+func ghsaIDsOf(views []AdvisoryView) []string {
+	out := make([]string, 0, len(views))
+	seen := make(map[string]bool, len(views))
+	for _, view := range views {
+		if view.Advisory.GhsaID == nil || *view.Advisory.GhsaID == "" {
+			continue
+		}
+		if seen[*view.Advisory.GhsaID] {
+			continue
+		}
+		seen[*view.Advisory.GhsaID] = true
+		out = append(out, *view.Advisory.GhsaID)
+	}
+	return out
+}

--- a/api/internal/readmodel/advisory/service.go
+++ b/api/internal/readmodel/advisory/service.go
@@ -1,0 +1,507 @@
+package advisory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/friendsofshopware/shopmon/api/internal/api"
+	"github.com/friendsofshopware/shopmon/api/internal/database"
+	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/jackc/pgx/v5"
+	"github.com/russross/blackfriday/v2"
+)
+
+var ErrNotFound = errors.New("advisory not found")
+
+// ErrInvalidInput marks a rejected enrichment value, so the handler can answer
+// 400 rather than 500.
+var ErrInvalidInput = errors.New("invalid advisory input")
+
+type Service struct {
+	queries *queries.Queries
+}
+
+func NewService(q *queries.Queries) *Service {
+	return &Service{queries: q}
+}
+
+type ListParams struct {
+	Limit       int32
+	Offset      int32
+	PackageName *string
+	Severity    *string
+	Tag         *string
+	Search      *string
+	// IsVisible filters by visibility when non-nil. User listing always passes true.
+	IsVisible *bool
+}
+
+type AdvisoryView struct {
+	Advisory queries.ComposerAdvisory
+	Packages []queries.ComposerAdvisoryPackage
+	// SecurityPluginFixes lists which SwagPlatformSecurity releases backport
+	// this advisory, per branch. Nil when not loaded.
+	SecurityPluginFixes []api.AdvisorySecurityPluginFix
+	// SuppressedEnvironments counts the caller's environments where this
+	// advisory has been acknowledged. Nil when not requested or unknown.
+	SuppressedEnvironments *int
+	// AffectedEnvironments counts the caller's environments whose Composer
+	// inventory matches this advisory. Nil when not requested or unknown.
+	AffectedEnvironments *int
+}
+
+func (s *Service) List(ctx context.Context, params ListParams) ([]AdvisoryView, int32, error) {
+	if params.Limit <= 0 {
+		params.Limit = 25
+	}
+	if params.Limit > 100 {
+		params.Limit = 100
+	}
+	if params.Offset < 0 {
+		params.Offset = 0
+	}
+
+	filter := queries.ListComposerAdvisoriesParams{
+		Limit:       params.Limit,
+		Offset:      params.Offset,
+		IsVisible:   params.IsVisible,
+		PackageName: emptyToNil(params.PackageName),
+		Severity:    emptyToNil(params.Severity),
+		Tag:         emptyToNil(params.Tag),
+		Search:      emptyToNil(params.Search),
+	}
+
+	rows, err := s.queries.ListComposerAdvisories(ctx, filter)
+	if err != nil {
+		return nil, 0, fmt.Errorf("list advisories: %w", err)
+	}
+
+	total, err := s.queries.CountComposerAdvisories(ctx, queries.CountComposerAdvisoriesParams{
+		IsVisible:   filter.IsVisible,
+		PackageName: filter.PackageName,
+		Severity:    filter.Severity,
+		Tag:         filter.Tag,
+		Search:      filter.Search,
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("count advisories: %w", err)
+	}
+
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.AdvisoryID)
+	}
+	pkgsByID, err := s.packagesByAdvisoryIDs(ctx, ids)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	out := make([]AdvisoryView, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, AdvisoryView{
+			Advisory: row,
+			Packages: pkgsByID[row.AdvisoryID],
+		})
+	}
+	return out, total, nil
+}
+
+func (s *Service) Get(ctx context.Context, advisoryID string, visibleOnly bool) (AdvisoryView, error) {
+	row, err := s.queries.GetComposerAdvisory(ctx, advisoryID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			// Allow old Packagist PKSA URLs to resolve to the canonical advisory.
+			row, err = s.queries.GetComposerAdvisoryByPackagistID(ctx, advisoryID)
+			if err != nil {
+				if errors.Is(err, pgx.ErrNoRows) {
+					return AdvisoryView{}, ErrNotFound
+				}
+				return AdvisoryView{}, fmt.Errorf("get advisory by packagist id: %w", err)
+			}
+		} else {
+			return AdvisoryView{}, fmt.Errorf("get advisory: %w", err)
+		}
+	}
+	if visibleOnly && !row.IsVisible {
+		return AdvisoryView{}, ErrNotFound
+	}
+	pkgs, err := s.queries.ListComposerAdvisoryPackagesForAdvisory(ctx, row.AdvisoryID)
+	if err != nil {
+		return AdvisoryView{}, fmt.Errorf("list advisory packages: %w", err)
+	}
+	packages := make([]queries.ComposerAdvisoryPackage, 0, len(pkgs))
+	for _, p := range pkgs {
+		packages = append(packages, queries.ComposerAdvisoryPackage{
+			AdvisoryID:          row.AdvisoryID,
+			PackageName:         p.PackageName,
+			PackagistAdvisoryID: p.PackagistAdvisoryID,
+			AffectedVersions:    p.AffectedVersions,
+			SyncedAt:            p.SyncedAt,
+		})
+	}
+	view := AdvisoryView{Advisory: row, Packages: packages}
+	if row.GhsaID != nil && *row.GhsaID != "" {
+		if fixes, err := s.securityPluginFixesByGhsa(ctx, []string{*row.GhsaID}); err == nil {
+			view.SecurityPluginFixes = fixes[*row.GhsaID]
+		}
+	}
+	return view, nil
+}
+
+func (s *Service) packagesByAdvisoryIDs(ctx context.Context, ids []string) (map[string][]queries.ComposerAdvisoryPackage, error) {
+	out := make(map[string][]queries.ComposerAdvisoryPackage, len(ids))
+	if len(ids) == 0 {
+		return out, nil
+	}
+	rows, err := s.queries.ListComposerAdvisoryPackagesForAdvisories(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("list packages for advisories: %w", err)
+	}
+	for _, row := range rows {
+		out[row.AdvisoryID] = append(out[row.AdvisoryID], row)
+	}
+	return out, nil
+}
+
+func (s *Service) ListPackages(ctx context.Context, visibleOnly bool) ([]string, error) {
+	var isVisible *bool
+	if visibleOnly {
+		t := true
+		isVisible = &t
+	}
+	names, err := s.queries.ListComposerAdvisoryPackages(ctx, isVisible)
+	if err != nil {
+		return nil, fmt.Errorf("list advisory packages: %w", err)
+	}
+	return names, nil
+}
+
+type EnrichmentUpdate struct {
+	SeverityOverride      *string
+	IsVisible             *bool
+	NotesPublic           *string
+	NotesInternal         *string
+	RemediationSummary    *string
+	RemediationUrl        *string
+	RecommendedUpgrade    *string
+	ShopwareImpactSummary *string
+	AffectedComponents    *[]string
+	Tags                  *[]string
+	EnrichedBy            string
+}
+
+// UpdateEnrichment applies admin enrichment as a partial update: a field the
+// caller omitted keeps its stored value, and an explicitly empty string clears
+// it. The endpoint is a PATCH with every field optional, so treating omission
+// as "clear" would let a request that only sets tags silently wipe an
+// advisory's notes — or, worse, republish one an admin had deliberately hidden.
+func (s *Service) UpdateEnrichment(ctx context.Context, advisoryID string, update EnrichmentUpdate) (AdvisoryView, error) {
+	view, err := s.Get(ctx, advisoryID, false)
+	if err != nil {
+		return AdvisoryView{}, err
+	}
+	current := view.Advisory
+	advisoryID = current.AdvisoryID
+
+	severityOverride := current.SeverityOverride
+	if update.SeverityOverride != nil {
+		trimmed := strings.ToLower(strings.TrimSpace(*update.SeverityOverride))
+		if trimmed == "" {
+			// An explicit empty value clears the override.
+			severityOverride = nil
+		} else {
+			// Reject unknown levels rather than storing a value that
+			// toSeverity would silently drop on read, leaving writes and
+			// reads disagreeing.
+			if !api.SeverityLevel(trimmed).Valid() {
+				return AdvisoryView{}, fmt.Errorf("%w: severity override %q", ErrInvalidInput, trimmed)
+			}
+			severityOverride = &trimmed
+		}
+	}
+
+	isVisible := current.IsVisible
+	if update.IsVisible != nil {
+		isVisible = *update.IsVisible
+	}
+
+	components := current.AffectedComponents
+	if update.AffectedComponents != nil {
+		components = *update.AffectedComponents
+	}
+	if components == nil {
+		components = []string{}
+	}
+	tags := current.Tags
+	if update.Tags != nil {
+		tags = *update.Tags
+	}
+	if tags == nil {
+		tags = []string{}
+	}
+
+	notesPublic := patchString(current.NotesPublic, update.NotesPublic)
+	notesInternal := patchString(current.NotesInternal, update.NotesInternal)
+	remediationSummary := patchString(current.RemediationSummary, update.RemediationSummary)
+	remediationURL := patchString(current.RemediationUrl, update.RemediationUrl)
+	recommendedUpgrade := patchString(current.RecommendedUpgrade, update.RecommendedUpgrade)
+	impact := patchString(current.ShopwareImpactSummary, update.ShopwareImpactSummary)
+
+	row, err := s.queries.UpdateComposerAdvisoryEnrichment(ctx, queries.UpdateComposerAdvisoryEnrichmentParams{
+		AdvisoryID:            advisoryID,
+		SeverityOverride:      severityOverride,
+		IsVisible:             isVisible,
+		NotesPublic:           notesPublic,
+		NotesInternal:         notesInternal,
+		RemediationSummary:    remediationSummary,
+		RemediationUrl:        remediationURL,
+		RecommendedUpgrade:    recommendedUpgrade,
+		ShopwareImpactSummary: impact,
+		AffectedComponents:    components,
+		Tags:                  tags,
+		EnrichedBy:            &update.EnrichedBy,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return AdvisoryView{}, ErrNotFound
+		}
+		return AdvisoryView{}, fmt.Errorf("update advisory enrichment: %w", err)
+	}
+	return AdvisoryView{Advisory: row, Packages: view.Packages}, nil
+}
+
+func ToUserAdvisory(view AdvisoryView) (api.Advisory, error) {
+	row := view.Advisory
+	sources, err := parseSources(row.Sources)
+	if err != nil {
+		return api.Advisory{}, err
+	}
+	cwes, err := parseCWEs(row.Cwes)
+	if err != nil {
+		return api.Advisory{}, err
+	}
+	refs, err := parseStringList(row.ExternalReferences)
+	if err != nil {
+		return api.Advisory{}, err
+	}
+
+	var descriptionHTML *string
+	if row.Description != nil && strings.TrimSpace(*row.Description) != "" {
+		html := renderMarkdown(*row.Description)
+		descriptionHTML = &html
+	}
+
+	packages := make([]api.AdvisoryAffectedPackage, 0, len(view.Packages))
+	for _, p := range view.Packages {
+		packages = append(packages, api.AdvisoryAffectedPackage{
+			PackageName:         p.PackageName,
+			AffectedVersions:    p.AffectedVersions,
+			PackagistAdvisoryId: p.PackagistAdvisoryID,
+		})
+	}
+
+	return api.Advisory{
+		AdvisoryId:                 row.AdvisoryID,
+		Packages:                   packages,
+		Title:                      row.Title,
+		Link:                       row.Link,
+		Cve:                        row.Cve,
+		GhsaId:                     row.GhsaID,
+		Severity:                   toSeverity(row.Severity),
+		SeverityOverride:           toSeverity(row.SeverityOverride),
+		EffectiveSeverity:          effectiveSeverity(row),
+		Sources:                    sources,
+		ReportedAt:                 database.TimePtr(row.ReportedAt),
+		ComposerRepository:         row.ComposerRepository,
+		Summary:                    row.Summary,
+		Description:                row.Description,
+		DescriptionHtml:            descriptionHTML,
+		CvssScore:                  row.CvssScore,
+		CvssVector:                 row.CvssVector,
+		Cwes:                       &cwes,
+		ExternalReferences:         &refs,
+		DetailsSource:              row.DetailsSource,
+		IsVisible:                  row.IsVisible,
+		NotesPublic:                row.NotesPublic,
+		RemediationSummary:         row.RemediationSummary,
+		RemediationUrl:             row.RemediationUrl,
+		RecommendedUpgrade:         row.RecommendedUpgrade,
+		ShopwareImpactSummary:      row.ShopwareImpactSummary,
+		AffectedComponents:         nonNilSlice(row.AffectedComponents),
+		Tags:                       nonNilSlice(row.Tags),
+		AffectedEnvironmentCount:   view.AffectedEnvironments,
+		SuppressedEnvironmentCount: view.SuppressedEnvironments,
+		SecurityPluginFixes:        &view.SecurityPluginFixes,
+		FirstPatchedVersions:       parseFirstPatchedVersions(row.FirstPatchedVersions),
+		SyncedAt:                   database.Time(row.SyncedAt),
+		CreatedAt:                  database.Time(row.CreatedAt),
+		UpdatedAt:                  database.Time(row.UpdatedAt),
+	}, nil
+}
+
+func ToAdminAdvisory(view AdvisoryView) (api.AdminAdvisory, error) {
+	base, err := ToUserAdvisory(view)
+	if err != nil {
+		return api.AdminAdvisory{}, err
+	}
+	return api.AdminAdvisory{
+		AdvisoryId:            base.AdvisoryId,
+		Packages:              base.Packages,
+		Title:                 base.Title,
+		Link:                  base.Link,
+		Cve:                   base.Cve,
+		GhsaId:                base.GhsaId,
+		Severity:              base.Severity,
+		SeverityOverride:      base.SeverityOverride,
+		EffectiveSeverity:     base.EffectiveSeverity,
+		Sources:               base.Sources,
+		ReportedAt:            base.ReportedAt,
+		ComposerRepository:    base.ComposerRepository,
+		Summary:               base.Summary,
+		Description:           base.Description,
+		DescriptionHtml:       base.DescriptionHtml,
+		CvssScore:             base.CvssScore,
+		CvssVector:            base.CvssVector,
+		Cwes:                  base.Cwes,
+		ExternalReferences:    base.ExternalReferences,
+		DetailsSource:         base.DetailsSource,
+		IsVisible:             base.IsVisible,
+		NotesPublic:           base.NotesPublic,
+		NotesInternal:         view.Advisory.NotesInternal,
+		RemediationSummary:    base.RemediationSummary,
+		RemediationUrl:        base.RemediationUrl,
+		RecommendedUpgrade:    base.RecommendedUpgrade,
+		ShopwareImpactSummary: base.ShopwareImpactSummary,
+		AffectedComponents:    base.AffectedComponents,
+		Tags:                  base.Tags,
+		SyncedAt:              base.SyncedAt,
+		CreatedAt:             base.CreatedAt,
+		UpdatedAt:             base.UpdatedAt,
+		EnrichedAt:            database.TimePtr(view.Advisory.EnrichedAt),
+		EnrichedBy:            view.Advisory.EnrichedBy,
+	}, nil
+}
+
+func parseSources(raw json.RawMessage) ([]api.AdvisorySource, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return []api.AdvisorySource{}, nil
+	}
+	var sources []struct {
+		Name     string `json:"name"`
+		RemoteID string `json:"remoteId"`
+	}
+	if err := json.Unmarshal(raw, &sources); err != nil {
+		return nil, fmt.Errorf("decode advisory sources: %w", err)
+	}
+	out := make([]api.AdvisorySource, 0, len(sources))
+	for _, s := range sources {
+		out = append(out, api.AdvisorySource{Name: s.Name, RemoteId: s.RemoteID})
+	}
+	return out, nil
+}
+
+func parseCWEs(raw json.RawMessage) ([]api.AdvisoryCWE, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return []api.AdvisoryCWE{}, nil
+	}
+	var items []struct {
+		ID   string `json:"cwe_id"`
+		Name string `json:"name"`
+	}
+	// Also accept API-shaped {id,name} after round-trips.
+	if err := json.Unmarshal(raw, &items); err != nil {
+		var alt []api.AdvisoryCWE
+		if err2 := json.Unmarshal(raw, &alt); err2 != nil {
+			return nil, fmt.Errorf("decode advisory cwes: %w", err)
+		}
+		return alt, nil
+	}
+	out := make([]api.AdvisoryCWE, 0, len(items))
+	for _, item := range items {
+		id := item.ID
+		if id == "" {
+			continue
+		}
+		out = append(out, api.AdvisoryCWE{Id: id, Name: item.Name})
+	}
+	return out, nil
+}
+
+func parseStringList(raw json.RawMessage) ([]string, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return []string{}, nil
+	}
+	var out []string
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, fmt.Errorf("decode string list: %w", err)
+	}
+	if out == nil {
+		return []string{}, nil
+	}
+	return out, nil
+}
+
+func renderMarkdown(md string) string {
+	// CommonExtensions covers fenced code, tables, autolinks, etc. that GHSA
+	// write-ups commonly use.
+	return string(blackfriday.Run(
+		[]byte(md),
+		blackfriday.WithExtensions(blackfriday.CommonExtensions),
+	))
+}
+
+func effectiveSeverity(row queries.ComposerAdvisory) *api.SeverityLevel {
+	if row.SeverityOverride != nil && *row.SeverityOverride != "" {
+		return toSeverity(row.SeverityOverride)
+	}
+	return toSeverity(row.Severity)
+}
+
+func toSeverity(s *string) *api.SeverityLevel {
+	if s == nil || *s == "" {
+		return nil
+	}
+	v := api.SeverityLevel(strings.ToLower(*s))
+	if !v.Valid() {
+		return nil
+	}
+	return &v
+}
+
+func nonNilSlice(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
+}
+
+func emptyToNil(s *string) *string {
+	if s == nil {
+		return nil
+	}
+	if strings.TrimSpace(*s) == "" {
+		return nil
+	}
+	v := strings.TrimSpace(*s)
+	return &v
+}
+
+// patchString resolves one optional PATCH field: omitted keeps the stored
+// value, present-but-blank clears it, anything else replaces it.
+func patchString(current, update *string) *string {
+	if update == nil {
+		return current
+	}
+	return nilIfEmpty(*update)
+}
+
+func nilIfEmpty(s string) *string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	v := s
+	return &v
+}

--- a/api/internal/suppression/postgres/repository.go
+++ b/api/internal/suppression/postgres/repository.go
@@ -1,0 +1,209 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/friendsofshopware/shopmon/api/internal/database"
+	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
+	"github.com/friendsofshopware/shopmon/api/internal/suppression"
+)
+
+// uniqueViolation is the PostgreSQL error code for a unique constraint breach.
+// The partial unique indexes on advisory_suppression turn a double-submit into
+// this rather than the lost-update clobber the legacy ignores PATCH suffers.
+const uniqueViolation = "23505"
+
+type Repository struct {
+	pool    *pgxpool.Pool
+	queries *queries.Queries
+}
+
+var _ suppression.Repository = (*Repository)(nil)
+
+func NewRepository(pool *pgxpool.Pool, q *queries.Queries) *Repository {
+	return &Repository{pool: pool, queries: q}
+}
+
+func (r *Repository) FindShopScope(ctx context.Context, shopID int32) (suppression.ShopScope, error) {
+	row, err := r.queries.GetShopByID(ctx, shopID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return suppression.ShopScope{}, suppression.ErrShopNotFound
+		}
+		return suppression.ShopScope{}, fmt.Errorf("get shop: %w", err)
+	}
+	return suppression.ShopScope{ShopID: row.ID, OrganizationID: row.OrganizationID}, nil
+}
+
+func (r *Repository) EnvironmentBelongsToShop(ctx context.Context, environmentID, shopID int32) (bool, error) {
+	row, err := r.queries.GetEnvironmentByID(ctx, environmentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get environment: %w", err)
+	}
+	return row.ShopID == shopID, nil
+}
+
+func (r *Repository) AdvisoryExists(ctx context.Context, advisoryID string) (bool, error) {
+	if _, err := r.queries.GetComposerAdvisory(ctx, advisoryID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, fmt.Errorf("get advisory: %w", err)
+	}
+	return true, nil
+}
+
+func (r *Repository) Create(ctx context.Context, record suppression.Suppression) (suppression.Suppression, error) {
+	row, err := r.insert(ctx, record)
+	if err == nil {
+		out := toDomain(row)
+		r.fillDisplayNames(ctx, &out)
+		return out, nil
+	}
+
+	var pgErr *pgconn.PgError
+	if !errors.As(err, &pgErr) || pgErr.Code != uniqueViolation {
+		return suppression.Suppression{}, fmt.Errorf("insert suppression: %w", err)
+	}
+
+	// The partial unique indexes cannot express expiry (NOW() is not usable in
+	// an index predicate), so the conflicting row may be an expired suppression
+	// that every read path already treats as inactive. Retire it — a soft
+	// revoke, preserving the audit trail — and retry once. If nothing expired
+	// was blocking, the scope really is actively suppressed.
+	retired, retireErr := r.queries.RevokeExpiredAdvisorySuppressions(ctx, queries.RevokeExpiredAdvisorySuppressionsParams{
+		ShopID:        record.ShopID,
+		AdvisoryID:    record.AdvisoryID,
+		EnvironmentID: record.EnvironmentID,
+		RevokedBy:     record.CreatedBy,
+	})
+	if retireErr != nil {
+		return suppression.Suppression{}, fmt.Errorf("retire expired suppression: %w", retireErr)
+	}
+	if retired == 0 {
+		return suppression.Suppression{}, suppression.ErrAlreadySuppressed
+	}
+
+	row, err = r.insert(ctx, record)
+	if err != nil {
+		if errors.As(err, &pgErr) && pgErr.Code == uniqueViolation {
+			return suppression.Suppression{}, suppression.ErrAlreadySuppressed
+		}
+		return suppression.Suppression{}, fmt.Errorf("insert suppression: %w", err)
+	}
+	out := toDomain(row)
+	r.fillDisplayNames(ctx, &out)
+	return out, nil
+}
+
+// fillDisplayNames resolves the shop (and environment) names the API contract
+// requires on a created suppression; the bare INSERT ... RETURNING cannot
+// provide them. Best-effort: a lookup failure leaves the field empty rather
+// than failing a write that already succeeded.
+func (r *Repository) fillDisplayNames(ctx context.Context, s *suppression.Suppression) {
+	if shop, err := r.queries.GetShopByID(ctx, s.ShopID); err == nil {
+		s.ShopName = shop.Name
+	}
+	if s.EnvironmentID != nil {
+		if env, err := r.queries.GetEnvironmentByID(ctx, *s.EnvironmentID); err == nil {
+			s.EnvironmentName = &env.Name
+		}
+	}
+}
+
+func (r *Repository) insert(ctx context.Context, record suppression.Suppression) (queries.AdvisorySuppression, error) {
+	return r.queries.CreateAdvisorySuppression(ctx, queries.CreateAdvisorySuppressionParams{
+		OrganizationID: record.OrganizationID,
+		ShopID:         record.ShopID,
+		EnvironmentID:  record.EnvironmentID,
+		AdvisoryID:     record.AdvisoryID,
+		Reason:         record.Reason,
+		ExpiresAt:      database.TimestampFromPtr(record.ExpiresAt),
+		CreatedBy:      record.CreatedBy,
+	})
+}
+
+func (r *Repository) Find(ctx context.Context, id int64, organizationIDs []string) (suppression.Suppression, error) {
+	row, err := r.queries.GetAdvisorySuppressionInOrgs(ctx, queries.GetAdvisorySuppressionInOrgsParams{
+		ID:              id,
+		OrganizationIds: organizationIDs,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return suppression.Suppression{}, suppression.ErrNotFound
+		}
+		return suppression.Suppression{}, fmt.Errorf("get suppression: %w", err)
+	}
+	return toDomain(row), nil
+}
+
+func (r *Repository) Revoke(ctx context.Context, id int64, userID string, organizationIDs []string) (suppression.Suppression, error) {
+	row, err := r.queries.RevokeAdvisorySuppression(ctx, queries.RevokeAdvisorySuppressionParams{
+		ID:              id,
+		RevokedBy:       &userID,
+		OrganizationIds: organizationIDs,
+	})
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return suppression.Suppression{}, suppression.ErrNotFound
+		}
+		return suppression.Suppression{}, fmt.Errorf("revoke suppression: %w", err)
+	}
+	return toDomain(row), nil
+}
+
+func (r *Repository) ListForOrganizations(ctx context.Context, organizationIDs []string, includeInactive bool) ([]suppression.Suppression, error) {
+	rows, err := r.queries.ListSuppressionsForOrganizations(ctx, queries.ListSuppressionsForOrganizationsParams{
+		OrganizationIds: organizationIDs,
+		IncludeInactive: includeInactive,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list suppressions: %w", err)
+	}
+
+	out := make([]suppression.Suppression, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, suppression.Suppression{
+			ID:              row.ID,
+			OrganizationID:  row.OrganizationID,
+			ShopID:          row.ShopID,
+			EnvironmentID:   row.EnvironmentID,
+			AdvisoryID:      row.AdvisoryID,
+			Reason:          row.Reason,
+			ExpiresAt:       database.TimePtr(row.ExpiresAt),
+			CreatedBy:       row.CreatedBy,
+			CreatedAt:       row.CreatedAt.Time,
+			RevokedAt:       database.TimePtr(row.RevokedAt),
+			RevokedBy:       row.RevokedBy,
+			ShopName:        row.ShopName,
+			EnvironmentName: row.EnvironmentName,
+			CreatedByName:   row.CreatedByName,
+		})
+	}
+	return out, nil
+}
+
+func toDomain(row queries.AdvisorySuppression) suppression.Suppression {
+	return suppression.Suppression{
+		ID:             row.ID,
+		OrganizationID: row.OrganizationID,
+		ShopID:         row.ShopID,
+		EnvironmentID:  row.EnvironmentID,
+		AdvisoryID:     row.AdvisoryID,
+		Reason:         row.Reason,
+		ExpiresAt:      database.TimePtr(row.ExpiresAt),
+		CreatedBy:      row.CreatedBy,
+		CreatedAt:      row.CreatedAt.Time,
+		RevokedAt:      database.TimePtr(row.RevokedAt),
+		RevokedBy:      row.RevokedBy,
+	}
+}

--- a/api/internal/suppression/service.go
+++ b/api/internal/suppression/service.go
@@ -1,0 +1,218 @@
+// Package suppression records a shop owner's decision that a known security
+// advisory is accepted or mitigated outside Shopmon — a WAF rule, an unused
+// component, or another compensating control.
+//
+// It is deliberately separate from environment.ignores: that column is a flat
+// array of check ids with no room for a reason, an actor, an expiry, or a
+// shop-wide scope, and it is rewritten wholesale by the generic environment
+// PATCH. Both mechanisms coexist and are unioned where checks are evaluated.
+package suppression
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/friendsofshopware/shopmon/api/internal/organization"
+)
+
+var (
+	ErrNotAuthorized     = errors.New("not authorized for organization")
+	ErrAdvisoryNotFound  = errors.New("advisory not found")
+	ErrShopNotFound      = errors.New("shop not found")
+	ErrEnvironmentScope  = errors.New("environment does not belong to shop")
+	ErrAlreadySuppressed = errors.New("advisory is already suppressed for this scope")
+	ErrNotFound          = errors.New("suppression not found")
+	ErrReasonRequired    = errors.New("a reason is required")
+	ErrExpiryInPast      = errors.New("expiry must be in the future")
+)
+
+// Suppression is one recorded risk acceptance.
+type Suppression struct {
+	ID             int64
+	OrganizationID string
+	ShopID         int32
+	// EnvironmentID nil means every environment of the shop.
+	EnvironmentID *int32
+	AdvisoryID    string
+	Reason        string
+	ExpiresAt     *time.Time
+	CreatedBy     *string
+	CreatedAt     time.Time
+	RevokedAt     *time.Time
+	RevokedBy     *string
+
+	// Display fields, populated by list queries that join the related rows.
+	// Empty on the records returned by Create/Revoke.
+	ShopName        string
+	EnvironmentName *string
+	CreatedByName   *string
+}
+
+// CreateCommand is the input for recording a suppression.
+type CreateCommand struct {
+	UserID        string
+	ShopID        int32
+	EnvironmentID *int32
+	AdvisoryID    string
+	Reason        string
+	ExpiresAt     *time.Time
+}
+
+// ShopScope is the ownership information the service needs to authorize and
+// validate a suppression without importing persistence types.
+type ShopScope struct {
+	ShopID         int32
+	OrganizationID string
+}
+
+// Repository is the persistence port.
+type Repository interface {
+	FindShopScope(ctx context.Context, shopID int32) (ShopScope, error)
+	EnvironmentBelongsToShop(ctx context.Context, environmentID, shopID int32) (bool, error)
+	AdvisoryExists(ctx context.Context, advisoryID string) (bool, error)
+	Create(ctx context.Context, record Suppression) (Suppression, error)
+	// Find loads a suppression restricted to the caller's organizations, so a
+	// revoke can be authorized against its actual scope before mutating it.
+	Find(ctx context.Context, id int64, organizationIDs []string) (Suppression, error)
+	Revoke(ctx context.Context, id int64, userID string, organizationIDs []string) (Suppression, error)
+	ListForOrganizations(ctx context.Context, organizationIDs []string, includeInactive bool) ([]Suppression, error)
+}
+
+// Authorizer reports a caller's role within an organization.
+type Authorizer interface {
+	RequireRole(ctx context.Context, userID, organizationID string, allowedRoles ...organization.Role) (organization.Role, error)
+}
+
+type Service struct {
+	repository Repository
+	authorizer Authorizer
+	now        func() time.Time
+}
+
+func NewService(repository Repository, authorizer Authorizer) *Service {
+	return &Service{repository: repository, authorizer: authorizer, now: time.Now}
+}
+
+// Create records a suppression after validating the scope and the caller's role.
+//
+// Suppressing is a risk-acceptance decision with blast radius across a whole
+// shop, so it requires owner or admin. Narrowing to a single environment is the
+// same decision at a smaller scale and is left to any member.
+func (s *Service) Create(ctx context.Context, cmd CreateCommand) (Suppression, error) {
+	reason := strings.TrimSpace(cmd.Reason)
+	if reason == "" {
+		return Suppression{}, ErrReasonRequired
+	}
+	if cmd.ExpiresAt != nil && !cmd.ExpiresAt.After(s.now().UTC()) {
+		return Suppression{}, ErrExpiryInPast
+	}
+
+	scope, err := s.repository.FindShopScope(ctx, cmd.ShopID)
+	if err != nil {
+		return Suppression{}, err
+	}
+
+	if err := s.authorizeScope(ctx, cmd.UserID, scope.OrganizationID, cmd.EnvironmentID); err != nil {
+		return Suppression{}, err
+	}
+
+	if cmd.EnvironmentID != nil {
+		belongs, err := s.repository.EnvironmentBelongsToShop(ctx, *cmd.EnvironmentID, cmd.ShopID)
+		if err != nil {
+			return Suppression{}, err
+		}
+		if !belongs {
+			return Suppression{}, ErrEnvironmentScope
+		}
+	}
+
+	exists, err := s.repository.AdvisoryExists(ctx, cmd.AdvisoryID)
+	if err != nil {
+		return Suppression{}, err
+	}
+	if !exists {
+		return Suppression{}, ErrAdvisoryNotFound
+	}
+
+	created, err := s.repository.Create(ctx, Suppression{
+		OrganizationID: scope.OrganizationID,
+		ShopID:         cmd.ShopID,
+		EnvironmentID:  cmd.EnvironmentID,
+		AdvisoryID:     cmd.AdvisoryID,
+		Reason:         reason,
+		ExpiresAt:      cmd.ExpiresAt,
+		CreatedBy:      &cmd.UserID,
+	})
+	if err != nil {
+		return Suppression{}, fmt.Errorf("create suppression: %w", err)
+	}
+	return created, nil
+}
+
+// Revoke soft-deletes a suppression, keeping the row as an audit record. The
+// organization scope is applied in the query so a caller cannot revoke another
+// tenant's suppression by guessing an id.
+//
+// Revoking carries the same role requirement as creating: withdrawing a
+// shop-wide risk acceptance is an owner/admin decision, and letting any member
+// undo one they could never have made would be a privilege asymmetry — the
+// audit trail would record an acceptance nobody with the authority to make it
+// chose to end.
+func (s *Service) Revoke(ctx context.Context, id int64, userID string, organizationIDs []string) (Suppression, error) {
+	if len(organizationIDs) == 0 {
+		return Suppression{}, ErrNotFound
+	}
+
+	existing, err := s.repository.Find(ctx, id, organizationIDs)
+	if err != nil {
+		return Suppression{}, err
+	}
+	if err := s.authorizeScope(ctx, userID, existing.OrganizationID, existing.EnvironmentID); err != nil {
+		return Suppression{}, err
+	}
+
+	revoked, err := s.repository.Revoke(ctx, id, userID, organizationIDs)
+	if err != nil {
+		return Suppression{}, err
+	}
+	return revoked, nil
+}
+
+// authorizeScope applies the role policy a suppression's blast radius demands:
+// shop-wide is owner/admin, environment-scoped additionally allows members.
+//
+// Only genuine membership/role denials become ErrNotAuthorized. A repository
+// or context failure is returned unchanged, so an outage surfaces as an error
+// rather than as a misleading 403.
+func (s *Service) authorizeScope(ctx context.Context, userID, organizationID string, environmentID *int32) error {
+	allowed := []organization.Role{organization.RoleOwner, organization.RoleAdmin}
+	if environmentID != nil {
+		allowed = append(allowed, organization.RoleMember)
+	}
+	if _, err := s.authorizer.RequireRole(ctx, userID, organizationID, allowed...); err != nil {
+		if errors.Is(err, organization.ErrMembershipNotFound) || errors.Is(err, organization.ErrRoleNotAllowed) {
+			return ErrNotAuthorized
+		}
+		return err
+	}
+	return nil
+}
+
+// List returns the suppressions visible to the caller's organizations.
+func (s *Service) List(ctx context.Context, organizationIDs []string, includeInactive bool) ([]Suppression, error) {
+	if len(organizationIDs) == 0 {
+		return nil, nil
+	}
+	return s.repository.ListForOrganizations(ctx, organizationIDs, includeInactive)
+}
+
+// Active reports whether a suppression is currently in force.
+func (s Suppression) Active(now time.Time) bool {
+	if s.RevokedAt != nil {
+		return false
+	}
+	return s.ExpiresAt == nil || s.ExpiresAt.After(now)
+}

--- a/api/internal/testutil/testutil.go
+++ b/api/internal/testutil/testutil.go
@@ -50,8 +50,11 @@ import (
 	packagespostgres "github.com/friendsofshopware/shopmon/api/internal/packagesmirror/postgres"
 	accountread "github.com/friendsofshopware/shopmon/api/internal/readmodel/account"
 	adminread "github.com/friendsofshopware/shopmon/api/internal/readmodel/admin"
+	advisoryread "github.com/friendsofshopware/shopmon/api/internal/readmodel/advisory"
 	environmentread "github.com/friendsofshopware/shopmon/api/internal/readmodel/environment"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/suppression"
+	suppressionpostgres "github.com/friendsofshopware/shopmon/api/internal/suppression/postgres"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/go-chi/chi/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -169,7 +172,10 @@ func Setup(t *testing.T, cfgFn ...func(*config.Config)) *TestEnv {
 	catalogService := catalog.NewService(catalogRepository, catalogGateway)
 	accountReadModel := accountread.NewService(q)
 	adminReadModel := adminread.NewService(q)
+	advisoryReadModel := advisoryread.NewService(q)
+	suppressionService := suppression.NewService(suppressionpostgres.NewRepository(pool, q), organizationAuthorizer)
 	environmentReadModel := environmentread.NewService(q, organizationAuthorizer, cfg)
+	jobDispatcher := jobs.NewDispatcher(bus)
 	ssoRepository := ssopostgres.NewRepository(q)
 	ssoGateway := ssooidc.NewGateway(15 * time.Second)
 	ssoService := organizationsso.NewService(ssoRepository, organizationAuthorizer, ssoGateway)
@@ -217,6 +223,9 @@ func Setup(t *testing.T, cfgFn ...func(*config.Config)) *TestEnv {
 		Account:       accountReadModel,
 		Admin:         adminReadModel,
 		Environments:  environmentReadModel,
+		Advisories:    advisoryReadModel,
+		Suppressions:  suppressionService,
+		AdvisorySync:  jobDispatcher,
 	})
 
 	// Build chi router matching production setup
@@ -330,6 +339,29 @@ func (e *TestEnv) SeedOrganization(t *testing.T, orgID, name, slug, userID strin
 	}
 
 	// Set as active organization on the user's session
+	_, err = e.Pool.Exec(ctx, `
+		UPDATE session SET active_organization_id = $1 WHERE user_id = $2 AND active_organization_id IS NULL
+	`, orgID, userID)
+	if err != nil {
+		t.Fatalf("failed to set active organization: %v", err)
+	}
+}
+
+// SeedMember adds a user to an existing organization with an explicit role.
+// SeedOrganization always creates an owner, so this is what makes role-gated
+// behaviour (member vs owner/admin) testable.
+func (e *TestEnv) SeedMember(t *testing.T, orgID, userID, role string) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, err := e.Pool.Exec(ctx, `
+		INSERT INTO member (id, organization_id, user_id, role, created_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, fmt.Sprintf("member-%s-%s", orgID, userID), orgID, userID, role, time.Now())
+	if err != nil {
+		t.Fatalf("failed to seed member: %v", err)
+	}
+
 	_, err = e.Pool.Exec(ctx, `
 		UPDATE session SET active_organization_id = $1 WHERE user_id = $2 AND active_organization_id IS NULL
 	`, orgID, userID)

--- a/api/oapi-codegen-api.yaml
+++ b/api/oapi-codegen-api.yaml
@@ -15,5 +15,6 @@ output-options:
     - Deployments
     - CLI
     - SSO
+    - Advisories
     - Admin
     - Info

--- a/api/openapi/spec.yaml
+++ b/api/openapi/spec.yaml
@@ -29,6 +29,8 @@ tags:
     description: CLI integration endpoints
   - name: SSO
     description: Single Sign-On provider management
+  - name: Advisories
+    description: Composer security advisories for Shopware packages
   - name: Admin
     description: Admin-only endpoints
   - name: Info
@@ -1389,6 +1391,265 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+
+  /admin/advisories:
+    get:
+      operationId: adminListAdvisories
+      tags: [Admin]
+      summary: List all Composer advisories including hidden ones (admin only)
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryLimit"
+        - $ref: "#/components/parameters/AdvisoryOffset"
+        - $ref: "#/components/parameters/AdvisoryPackage"
+        - $ref: "#/components/parameters/AdvisorySeverity"
+        - $ref: "#/components/parameters/AdvisoryTag"
+        - $ref: "#/components/parameters/AdvisorySearch"
+        - name: visible
+          in: query
+          schema:
+            type: boolean
+          description: When set, filter by visibility
+      responses:
+        "200":
+          description: Paginated advisories
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAdvisoryListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /admin/advisories/sync:
+    post:
+      operationId: adminSyncAdvisories
+      tags: [Admin]
+      summary: Enqueue a Packagist advisory sync job
+      responses:
+        "202":
+          description: Sync job enqueued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAdvisorySyncResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /admin/advisories/{advisoryId}:
+    get:
+      operationId: adminGetAdvisory
+      tags: [Admin]
+      summary: Get a single advisory with internal notes (admin only)
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryId"
+      responses:
+        "200":
+          description: Advisory detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAdvisory"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      operationId: adminUpdateAdvisory
+      tags: [Admin]
+      summary: Update Shopmon enrichment fields for an advisory
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAdvisoryEnrichmentRequest"
+      responses:
+        "200":
+          description: Updated advisory
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminAdvisory"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  # ──────────────────────────────────────────────
+  # Advisories (user-facing)
+  # ──────────────────────────────────────────────
+  /advisories:
+    get:
+      operationId: listAdvisories
+      tags: [Advisories]
+      summary: List visible Composer security advisories for Shopware packages
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryLimit"
+        - $ref: "#/components/parameters/AdvisoryOffset"
+        - $ref: "#/components/parameters/AdvisoryPackage"
+        - $ref: "#/components/parameters/AdvisorySeverity"
+        - $ref: "#/components/parameters/AdvisoryTag"
+        - $ref: "#/components/parameters/AdvisorySearch"
+        - $ref: "#/components/parameters/AdvisoryScope"
+        - $ref: "#/components/parameters/AdvisorySort"
+      responses:
+        "200":
+          description: Paginated visible advisories
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdvisoryListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /advisories/packages:
+    get:
+      operationId: listAdvisoryPackages
+      tags: [Advisories]
+      summary: List package names that have visible advisories
+      responses:
+        "200":
+          description: Package names
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /advisories/{advisoryId}:
+    get:
+      operationId: getAdvisory
+      tags: [Advisories]
+      summary: Get a visible advisory by Packagist advisory ID
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryId"
+      responses:
+        "200":
+          description: Advisory detail
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Advisory"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /advisories/{advisoryId}/suppressions:
+    post:
+      operationId: createAdvisorySuppression
+      tags: [Advisories]
+      summary: Record that an advisory is accepted or mitigated for a shop
+      description: >
+        Suppressing an advisory removes it from the "affecting my shops" list
+        and silences its alerts. Shop-wide suppression requires the owner or
+        admin role; narrowing to a single environment is open to any member.
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAdvisorySuppressionRequest"
+      responses:
+        "201":
+          description: Suppression recorded
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdvisorySuppression"
+        "400":
+          $ref: "#/components/responses/ValidationError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: An active suppression already covers this scope
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /suppressions:
+    get:
+      operationId: listSuppressions
+      tags: [Advisories]
+      summary: List advisory suppressions for the caller's organizations
+      parameters:
+        - name: includeInactive
+          in: query
+          schema:
+            type: boolean
+            default: false
+          description: Include revoked and expired suppressions
+      responses:
+        "200":
+          description: Suppressions
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdvisorySuppressionListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+
+  /suppressions/{suppressionId}:
+    delete:
+      operationId: revokeAdvisorySuppression
+      tags: [Advisories]
+      summary: Revoke a suppression so the advisory resurfaces
+      parameters:
+        - name: suppressionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "204":
+          description: Suppression revoked
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /advisories/{advisoryId}/affected:
+    get:
+      operationId: listAdvisoryAffectedEnvironments
+      tags: [Advisories]
+      summary: List the caller's environments affected by an advisory
+      description: >
+        Environments whose Composer package inventory (from the FroshTools SBOM)
+        matches this advisory. Restricted to organizations the caller belongs to;
+        admins additionally receive a fleet-wide affected count.
+      parameters:
+        - $ref: "#/components/parameters/AdvisoryId"
+      responses:
+        "200":
+          description: Affected environments
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdvisoryAffectedResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
 
   # ──────────────────────────────────────────────
   # Info
@@ -2830,6 +3091,88 @@ components:
       schema:
         type: integer
       description: Notification ID
+
+    AdvisoryId:
+      name: advisoryId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: >
+        Canonical advisory ID as returned in Advisory.advisoryId: the CVE when
+        known, else the GHSA, else the Packagist PKSA ID. Detail and suppression
+        endpoints also accept a package row's PKSA ID as a legacy alias, but
+        affected-environment lookups resolve the canonical ID only.
+
+    AdvisoryLimit:
+      name: limit
+      in: query
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 25
+
+    AdvisoryOffset:
+      name: offset
+      in: query
+      schema:
+        type: integer
+        minimum: 0
+        default: 0
+
+    AdvisoryPackage:
+      name: package
+      in: query
+      schema:
+        type: string
+      description: Filter by Composer package name (e.g. shopware/core)
+
+    AdvisorySeverity:
+      name: severity
+      in: query
+      schema:
+        type: string
+        enum: [none, low, medium, high, critical]
+      description: Filter by effective severity
+
+    AdvisoryTag:
+      name: tag
+      in: query
+      schema:
+        type: string
+      description: Filter by admin tag
+
+    AdvisorySearch:
+      name: q
+      in: query
+      schema:
+        type: string
+      description: Search title, CVE, GHSA, package, or advisory ID
+
+    AdvisoryScope:
+      name: scope
+      in: query
+      schema:
+        type: string
+        enum: [all, affected, suppressed]
+        default: affected
+      description: >
+        "affected" limits results to advisories matching the Composer inventory
+        of the caller's own environments, excluding suppressed ones;
+        "suppressed" returns only those the caller has acknowledged;
+        "all" returns the full catalog.
+
+    AdvisorySort:
+      name: sort
+      in: query
+      schema:
+        type: string
+        enum: [reported, severity, affected, cvss]
+        default: reported
+      description: >
+        Sort order: "reported" newest first, "severity" most severe first,
+        "affected" most affected environments first, "cvss" highest score first.
 
   # ──────────────────────────────────────────────
   # Responses
@@ -4914,3 +5257,474 @@ components:
           type: boolean
         packageMirrorEnabled:
           type: boolean
+
+    # ── Advisories ──────────────────────────────
+    SeverityLevel:
+      type: string
+      enum: [none, low, medium, high, critical]
+
+    AdvisorySource:
+      type: object
+      required:
+        - name
+        - remoteId
+      properties:
+        name:
+          type: string
+        remoteId:
+          type: string
+
+    AdvisoryAffectedPackage:
+      type: object
+      required:
+        - packageName
+        - affectedVersions
+        - packagistAdvisoryId
+      properties:
+        packageName:
+          type: string
+          description: Composer package name (e.g. shopware/core)
+        affectedVersions:
+          type: string
+          description: Composer constraint for this package
+        packagistAdvisoryId:
+          type: string
+          description: Original Packagist PKSA id for this package row
+
+    Advisory:
+      type: object
+      required:
+        - advisoryId
+        - packages
+        - title
+        - effectiveSeverity
+        - isVisible
+        - sources
+        - tags
+        - affectedComponents
+        - syncedAt
+        - createdAt
+        - updatedAt
+      properties:
+        advisoryId:
+          type: string
+          description: Canonical id (CVE, else GHSA, else Packagist PKSA)
+        packages:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisoryAffectedPackage"
+          description: Affected Composer packages (one CVE may span multiple packages)
+        title:
+          type: string
+        link:
+          type: string
+          nullable: true
+        cve:
+          type: string
+          nullable: true
+        ghsaId:
+          type: string
+          nullable: true
+        severity:
+          allOf:
+            - $ref: "#/components/schemas/SeverityLevel"
+          nullable: true
+        severityOverride:
+          allOf:
+            - $ref: "#/components/schemas/SeverityLevel"
+          nullable: true
+        effectiveSeverity:
+          allOf:
+            - $ref: "#/components/schemas/SeverityLevel"
+          nullable: true
+        sources:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisorySource"
+        reportedAt:
+          type: string
+          format: date-time
+          nullable: true
+        composerRepository:
+          type: string
+          nullable: true
+        summary:
+          type: string
+          nullable: true
+          description: Short summary from the disclosure source (e.g. GitHub Advisory)
+        description:
+          type: string
+          nullable: true
+          description: Full advisory write-up in Markdown (source form)
+        descriptionHtml:
+          type: string
+          nullable: true
+          description: description rendered as HTML for safe display after client sanitization
+        cvssScore:
+          type: number
+          format: double
+          nullable: true
+        cvssVector:
+          type: string
+          nullable: true
+        cwes:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisoryCWE"
+        externalReferences:
+          type: array
+          items:
+            type: string
+          description: External reference URLs (GHSA page, commits, etc.)
+        detailsSource:
+          type: string
+          nullable: true
+          description: Where disclosure details were loaded from (e.g. github)
+        isVisible:
+          type: boolean
+        notesPublic:
+          type: string
+          nullable: true
+        remediationSummary:
+          type: string
+          nullable: true
+        remediationUrl:
+          type: string
+          nullable: true
+        recommendedUpgrade:
+          type: string
+          nullable: true
+        shopwareImpactSummary:
+          type: string
+          nullable: true
+        affectedComponents:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        affectedEnvironmentCount:
+          type: integer
+          nullable: true
+          description: >
+            Number of the caller's environments whose Composer package inventory
+            matches this advisory and that are not suppressed. Null when no SBOM
+            data has been collected.
+        securityPluginFixes:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisorySecurityPluginFix"
+          description: >
+            Which SwagPlatformSecurity releases backport this advisory, per
+            branch. Empty when it is not backportable or not yet derived.
+        firstPatchedVersions:
+          type: object
+          additionalProperties:
+            type: string
+          description: >
+            First Shopware release per line that closes this advisory, e.g.
+            {"6.7": "6.7.10.1"}. Machine-derived from the GitHub advisory.
+        suppressedEnvironmentCount:
+          type: integer
+          nullable: true
+          description: >
+            Number of the caller's environments where this advisory has been
+            acknowledged via an active suppression.
+        syncedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    AdvisorySecurityPluginFix:
+      type: object
+      required: [pluginBranch, pluginVersion, shopwareBranch]
+      properties:
+        pluginBranch:
+          type: string
+          description: SwagPlatformSecurity major version, e.g. "4"
+        pluginVersion:
+          type: string
+          description: Lowest plugin version on this branch that backports the fix
+        shopwareBranch:
+          type: string
+          description: Shopware line this branch serves, e.g. "6.7"
+
+    AdvisorySuppression:
+      type: object
+      required:
+        - id
+        - advisoryId
+        - organizationId
+        - shopId
+        - shopName
+        - reason
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        advisoryId:
+          type: string
+        organizationId:
+          type: string
+        shopId:
+          type: integer
+        shopName:
+          type: string
+        environmentId:
+          type: integer
+          nullable: true
+          description: Null means every environment of the shop
+        environmentName:
+          type: string
+          nullable: true
+        reason:
+          type: string
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Null means the suppression does not expire
+        createdBy:
+          type: string
+          nullable: true
+        createdByName:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        revokedAt:
+          type: string
+          format: date-time
+          nullable: true
+
+    CreateAdvisorySuppressionRequest:
+      type: object
+      required:
+        - shopId
+        - reason
+      properties:
+        shopId:
+          type: integer
+        environmentId:
+          type: integer
+          nullable: true
+          description: Omit to suppress across every environment of the shop
+        reason:
+          type: string
+          minLength: 1
+          description: Why the advisory is accepted or how it is mitigated
+        expiresAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Omit for a suppression that does not expire
+
+    AdvisorySuppressionListResponse:
+      type: object
+      required:
+        - suppressions
+      properties:
+        suppressions:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisorySuppression"
+
+    AdvisoryAffectedEnvironment:
+      type: object
+      required:
+        - environmentId
+        - environmentName
+        - environmentStatus
+        - shopId
+        - shopName
+        - organizationId
+        - organizationName
+        - packageName
+        - installedVersion
+        - affectedVersions
+        - suppressed
+        - matchedAt
+      properties:
+        environmentId:
+          type: integer
+        environmentName:
+          type: string
+        environmentStatus:
+          type: string
+        shopId:
+          type: integer
+        shopName:
+          type: string
+        organizationId:
+          type: string
+        organizationName:
+          type: string
+        shopwareVersion:
+          type: string
+          nullable: true
+        packageName:
+          type: string
+          description: Installed Composer package that matched the advisory
+        installedVersion:
+          type: string
+        affectedVersions:
+          type: string
+          description: The advisory constraint the installed version falls into
+        suppressed:
+          type: boolean
+          description: Whether an active suppression covers this environment
+        matchedAt:
+          type: string
+          format: date-time
+
+    AdvisoryAffectedResponse:
+      type: object
+      required:
+        - environments
+        - total
+      properties:
+        environments:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdvisoryAffectedEnvironment"
+          description: Affected environments within the caller's organizations
+        total:
+          type: integer
+          description: Number of affected environments visible to the caller
+        globalTotal:
+          type: integer
+          nullable: true
+          description: Fleet-wide affected environment count; admins only
+
+    AdvisoryCWE:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          description: CWE identifier, e.g. CWE-918
+        name:
+          type: string
+
+    AdvisoryListResponse:
+      type: object
+      required:
+        - advisories
+        - total
+      properties:
+        advisories:
+          type: array
+          items:
+            $ref: "#/components/schemas/Advisory"
+        total:
+          type: integer
+          description: Advisories matching the current scope and filters
+        scopeCounts:
+          allOf:
+            - $ref: "#/components/schemas/AdvisoryScopeCounts"
+          nullable: true
+          description: Totals per scope, ignoring the scope filter, for tab badges
+
+    AdvisoryScopeCounts:
+      type: object
+      required:
+        - all
+        - affected
+        - suppressed
+      properties:
+        all:
+          type: integer
+          description: All visible advisories matching the non-scope filters
+        affected:
+          type: integer
+          description: >
+            Of those, how many affect the caller's environments and are not
+            suppressed
+        suppressed:
+          type: integer
+          description: Of those, how many the caller has acknowledged
+
+    AdminAdvisory:
+      allOf:
+        - $ref: "#/components/schemas/Advisory"
+        - type: object
+          properties:
+            notesInternal:
+              type: string
+              nullable: true
+            enrichedAt:
+              type: string
+              format: date-time
+              nullable: true
+            enrichedBy:
+              type: string
+              nullable: true
+
+    AdminAdvisoryListResponse:
+      type: object
+      required:
+        - advisories
+        - total
+      properties:
+        advisories:
+          type: array
+          items:
+            $ref: "#/components/schemas/AdminAdvisory"
+        total:
+          type: integer
+
+    UpdateAdvisoryEnrichmentRequest:
+      type: object
+      properties:
+        severityOverride:
+          allOf:
+            - $ref: "#/components/schemas/SeverityLevel"
+          nullable: true
+        isVisible:
+          type: boolean
+        notesPublic:
+          type: string
+          nullable: true
+        notesInternal:
+          type: string
+          nullable: true
+        remediationSummary:
+          type: string
+          nullable: true
+        remediationUrl:
+          type: string
+          nullable: true
+        recommendedUpgrade:
+          type: string
+          nullable: true
+        shopwareImpactSummary:
+          type: string
+          nullable: true
+        affectedComponents:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+
+    AdminAdvisorySyncResponse:
+      type: object
+      required:
+        - enqueued
+      properties:
+        enqueued:
+          type: boolean
+

--- a/api/server.go
+++ b/api/server.go
@@ -53,9 +53,12 @@ import (
 	packagespostgres "github.com/friendsofshopware/shopmon/api/internal/packagesmirror/postgres"
 	accountread "github.com/friendsofshopware/shopmon/api/internal/readmodel/account"
 	adminread "github.com/friendsofshopware/shopmon/api/internal/readmodel/admin"
+	advisoryread "github.com/friendsofshopware/shopmon/api/internal/readmodel/advisory"
 	environmentread "github.com/friendsofshopware/shopmon/api/internal/readmodel/environment"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	"github.com/friendsofshopware/shopmon/api/internal/storage"
+	"github.com/friendsofshopware/shopmon/api/internal/suppression"
+	suppressionpostgres "github.com/friendsofshopware/shopmon/api/internal/suppression/postgres"
 	"github.com/friendsofshopware/shopmon/api/internal/telemetry"
 	"github.com/friendsofshopware/shopmon/api/internal/webui"
 	"github.com/go-chi/chi/v5"
@@ -163,7 +166,10 @@ func runServer(cmd *cobra.Command, args []string) error {
 	catalogService := catalog.NewService(catalogRepository, catalogGateway)
 	accountReadModel := accountread.NewService(q)
 	adminReadModel := adminread.NewService(q)
+	advisoryReadModel := advisoryread.NewService(q)
+	suppressionService := suppression.NewService(suppressionpostgres.NewRepository(pool, q), organizationAuthorizer)
 	environmentReadModel := environmentread.NewService(q, organizationAuthorizer, cfg)
+	jobDispatcher := jobs.NewDispatcher(bus)
 	ssoRepository := ssopostgres.NewRepository(q)
 	ssoGateway := ssooidc.NewGateway(15 * time.Second)
 	ssoService := organizationsso.NewService(ssoRepository, organizationAuthorizer, ssoGateway)
@@ -217,6 +223,9 @@ func runServer(cmd *cobra.Command, args []string) error {
 		Account:       accountReadModel,
 		Admin:         adminReadModel,
 		Environments:  environmentReadModel,
+		Advisories:    advisoryReadModel,
+		Suppressions:  suppressionService,
+		AdvisorySync:  jobDispatcher,
 	})
 
 	// Router


### PR DESCRIPTION
Exposes the advisory data over HTTP:

- suppression: shop-owner acknowledgement that an advisory is accepted or
  mitigated outside Shopmon, scoped shop-wide or to one environment, revoked
  as a soft delete so the row stays an audit trail.
- readmodel/advisory: advisory detail, affected environments, and security
  plugin coverage, with private package names kept in-tenant.
- handler/advisory + openapi spec and generated server: user-facing advisory
  listing/detail and the admin enrichment endpoints.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>