### PR TITLE
fix(advisory): enrich GHSAs published only on a repository

### DIFF
--- a/api/internal/catalog/advisory/github.go
+++ b/api/internal/catalog/advisory/github.go
@@ -3,6 +3,7 @@ package advisory
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -70,6 +71,8 @@ type githubAdvisoryResponse struct {
 		} `json:"package"`
 		VulnerableVersionRange string  `json:"vulnerable_version_range"`
 		FirstPatchedVersion    *string `json:"first_patched_version"`
+		// The repository-scoped endpoint names the same value differently.
+		PatchedVersions string `json:"patched_versions"`
 	} `json:"vulnerabilities"`
 }
 
@@ -143,7 +146,18 @@ func newGitHubClient(token, userAgent string, httpClient *http.Client) *githubCl
 // encoding ever widens.
 var ghsaIDPattern = regexp.MustCompile(`^GHSA(-[A-Za-z0-9]{4,})+$`)
 
+// fetchAdvisory loads a global GitHub advisory. Advisories that were published
+// on a repository but never promoted to the global database 404 here; use
+// fetchAdvisoryWithLink to fall back to the repository-scoped endpoint.
 func (c *githubClient) fetchAdvisory(ctx context.Context, ghsaID string) (*githubAdvisoryDetails, error) {
+	return c.fetchAdvisoryWithLink(ctx, ghsaID, "")
+}
+
+// fetchAdvisoryWithLink tries the global advisories endpoint first and, when
+// that reports the advisory unknown, retries against the repository named in
+// link. Repository advisories are not mirrored globally and are not indexed by
+// cve_id or affects, so the link is the only route to them.
+func (c *githubClient) fetchAdvisoryWithLink(ctx context.Context, ghsaID, link string) (*githubAdvisoryDetails, error) {
 	ghsaID = strings.TrimSpace(ghsaID)
 	if ghsaID == "" {
 		return nil, fmt.Errorf("empty ghsa id")
@@ -155,6 +169,29 @@ func (c *githubClient) fetchAdvisory(ctx context.Context, ghsaID string) (*githu
 	// Escaped as well as validated: defence in depth if the pattern is ever
 	// loosened.
 	endpoint := fmt.Sprintf("%s/advisories/%s", c.baseURL, url.PathEscape(ghsaID))
+	details, err := c.fetchAdvisoryURL(ctx, ghsaID, endpoint)
+	if err == nil || !errors.Is(err, errGitHubAdvisoryNotFound) {
+		return details, err
+	}
+
+	owner, repo := repoFromAdvisoryLink(link)
+	if owner == "" || repo == "" {
+		return nil, err
+	}
+	repoEndpoint := fmt.Sprintf("%s/repos/%s/%s/security-advisories/%s",
+		c.baseURL, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(ghsaID))
+	repoDetails, repoErr := c.fetchAdvisoryURL(ctx, ghsaID, repoEndpoint)
+	if repoErr != nil {
+		return nil, repoErr
+	}
+	return repoDetails, nil
+}
+
+// errGitHubAdvisoryNotFound signals a 404 so callers can decide whether another
+// endpoint is worth trying.
+var errGitHubAdvisoryNotFound = errors.New("github advisory not found")
+
+func (c *githubClient) fetchAdvisoryURL(ctx context.Context, ghsaID, endpoint string) (*githubAdvisoryDetails, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("create github advisory request: %w", err)
@@ -177,7 +214,7 @@ func (c *githubClient) fetchAdvisory(ctx context.Context, ghsaID string) (*githu
 		return nil, fmt.Errorf("read github advisory %s: %w", ghsaID, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("github advisory %s not found", ghsaID)
+		return nil, fmt.Errorf("github advisory %s: %w", ghsaID, errGitHubAdvisoryNotFound)
 	}
 	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusTooManyRequests {
 		return nil, fmt.Errorf("github rate limited or forbidden (%d) for %s", resp.StatusCode, ghsaID)
@@ -246,14 +283,17 @@ func (c *githubClient) fetchAdvisory(ctx context.Context, ghsaID string) (*githu
 func firstPatchedByLine(raw githubAdvisoryResponse) map[string]string {
 	out := map[string]string{}
 	for _, vuln := range raw.Vulnerabilities {
-		if vuln.FirstPatchedVersion == nil {
+		patched := strings.TrimSpace(vuln.PatchedVersions)
+		if vuln.FirstPatchedVersion != nil {
+			patched = strings.TrimSpace(*vuln.FirstPatchedVersion)
+		}
+		if patched == "" {
 			continue
 		}
 		name := strings.ToLower(strings.TrimSpace(vuln.Package.Name))
 		if !strings.HasPrefix(name, packagePrefix) {
 			continue
 		}
-		patched := strings.TrimSpace(*vuln.FirstPatchedVersion)
 		line := shopwareLine(patched)
 		if line == "" {
 			continue

--- a/api/internal/catalog/advisory/github_repo_fallback_test.go
+++ b/api/internal/catalog/advisory/github_repo_fallback_test.go
@@ -1,0 +1,188 @@
+package advisory
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Advisories published on a repository are never mirrored into the global
+// advisory database, so the global endpoint 404s for them. They are also absent
+// from the cve_id and affects indexes, which leaves the advisory link as the
+// only route to the data.
+func TestFetchAdvisoryFallsBackToRepositoryEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var globalHits, repoHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/advisories/GHSA-7m52-jw36-44r3", func(w http.ResponseWriter, _ *http.Request) {
+		globalHits++
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	})
+	// Verbatim shape of the repository-scoped response: patched_versions instead
+	// of first_patched_version, and no references key at all.
+	mux.HandleFunc("/repos/modelcontextprotocol/php-sdk/security-advisories/GHSA-7m52-jw36-44r3",
+		func(w http.ResponseWriter, r *http.Request) {
+			repoHits++
+			assert.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ghsa_id":     "GHSA-7m52-jw36-44r3",
+				"cve_id":      "CVE-2026-53965",
+				"summary":     "DoS: client HttpTransport SSE buffer grows unbounded",
+				"description": "## Summary\r\n\r\nThe HTTP client transport reads an SSE stream.",
+				"html_url":    "https://github.com/modelcontextprotocol/php-sdk/security/advisories/GHSA-7m52-jw36-44r3",
+				"cvss":        map[string]any{"score": nil, "vector_string": nil},
+				"cvss_severities": map[string]any{
+					"cvss_v3": map[string]any{"score": nil, "vector_string": nil},
+				},
+				"cwes": []map[string]string{
+					{"cwe_id": "CWE-400", "name": "Uncontrolled Resource Consumption"},
+				},
+				"vulnerabilities": []map[string]any{
+					{
+						"package":                  map[string]string{"ecosystem": "composer", "name": "mcp/sdk"},
+						"vulnerable_version_range": ">= 0.5.0, <= 0.7.0",
+						"patched_versions":         "0.7.1",
+					},
+				},
+			})
+		})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := newGitHubClient("tok", defaultUserAgent, server.Client())
+	client.baseURL = server.URL
+
+	link := "https://github.com/modelcontextprotocol/php-sdk/security/advisories/GHSA-7m52-jw36-44r3"
+	details, err := client.fetchAdvisoryWithLink(context.Background(), "GHSA-7m52-jw36-44r3", link)
+	require.NoError(t, err)
+	require.NotNil(t, details)
+
+	assert.Equal(t, 1, globalHits, "global endpoint should be tried first")
+	assert.Equal(t, 1, repoHits, "repository endpoint should be the fallback")
+	assert.Contains(t, details.Summary, "SSE buffer grows unbounded")
+	assert.Contains(t, details.Description, "HTTP client transport")
+	require.Len(t, details.CWEs, 1)
+	assert.Equal(t, "CWE-400", details.CWEs[0].ID)
+	// A null cvss score must not be recorded as 0.
+	assert.Nil(t, details.CVSSScore)
+	// The repo endpoint omits references; html_url still seeds the list.
+	require.NotEmpty(t, details.References)
+	assert.Equal(t, link, details.References[0])
+}
+
+// Without a repository link there is nothing to fall back to, so a 404 must
+// surface rather than being silently swallowed.
+func TestFetchAdvisoryWithoutLinkKeepsNotFound(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"Not Found"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client := newGitHubClient("tok", defaultUserAgent, server.Client())
+	client.baseURL = server.URL
+
+	_, err := client.fetchAdvisoryWithLink(context.Background(), "GHSA-7m52-jw36-44r3", "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errGitHubAdvisoryNotFound)
+}
+
+// A global advisory must not pay for an extra repository request.
+func TestFetchAdvisorySkipsFallbackOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	var repoHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/advisories/GHSA-xvhc-gm7j-mhmc", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ghsa_id": "GHSA-xvhc-gm7j-mhmc",
+			"summary": "Global advisory",
+		})
+	})
+	mux.HandleFunc("/repos/", func(w http.ResponseWriter, _ *http.Request) {
+		repoHits++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	client := newGitHubClient("tok", defaultUserAgent, server.Client())
+	client.baseURL = server.URL
+
+	details, err := client.fetchAdvisoryWithLink(context.Background(), "GHSA-xvhc-gm7j-mhmc",
+		"https://github.com/shopware/platform/security/advisories/GHSA-xvhc-gm7j-mhmc")
+	require.NoError(t, err)
+	assert.Equal(t, "Global advisory", details.Summary)
+	assert.Zero(t, repoHits, "repository endpoint must not be called when the global one answers")
+}
+
+// The repository endpoint reports the patched release under a different key.
+func TestFirstPatchedByLineAcceptsPatchedVersions(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{"ghsa_id":"GHSA-repo","vulnerabilities":[
+      {"package":{"name":"shopware/core","ecosystem":"composer"},"vulnerable_version_range":">= 6.7.0.0, <= 6.7.10.0","patched_versions":"6.7.10.1"},
+      {"package":{"name":"mcp/sdk","ecosystem":"composer"},"patched_versions":"0.7.1"}]}`)
+	var resp githubAdvisoryResponse
+	require.NoError(t, json.Unmarshal(raw, &resp))
+
+	got := firstPatchedByLine(resp)
+	assert.Equal(t, "6.7.10.1", got["6.7"])
+	assert.NotContains(t, got, "0.7", "non-shopware package must be ignored")
+}
+
+// The GHSA is often reachable only through the advisory link: FriendsOfPHP rows
+// carry a remoteId like "mcp/sdk/CVE-2026-53965.yaml" and no GHSA in Sources.
+func TestGHSAFromLink(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		link string
+		want string
+	}{
+		{"https://github.com/modelcontextprotocol/php-sdk/security/advisories/GHSA-7m52-jw36-44r3", "GHSA-7m52-jw36-44r3"},
+		{"https://github.com/advisories/GHSA-xvhc-gm7j-mhmc", "GHSA-xvhc-gm7j-mhmc"},
+		{"https://example.com/CVE-2026-53965", ""},
+		{"", ""},
+		{"https://github.com/owner/repo/security/advisories/not-a-ghsa", ""},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, ghsaFromLink(tc.link), "link %q", tc.link)
+	}
+}
+
+// owner/repo is interpolated into a token-bearing URL, so anything that could
+// reshape the path must not survive parsing.
+func TestRepoFromAdvisoryLink(t *testing.T) {
+	t.Parallel()
+
+	owner, repo := repoFromAdvisoryLink("https://github.com/modelcontextprotocol/php-sdk/security/advisories/GHSA-7m52-jw36-44r3")
+	assert.Equal(t, "modelcontextprotocol", owner)
+	assert.Equal(t, "php-sdk", repo)
+
+	// Global advisory links carry no repository.
+	owner, repo = repoFromAdvisoryLink("https://github.com/advisories/GHSA-xvhc-gm7j-mhmc")
+	assert.Empty(t, owner)
+	assert.Empty(t, repo)
+
+	for _, link := range []string{
+		"https://evil.com/owner/repo/security/advisories/GHSA-aaaa-bbbb-cccc",
+		"https://github.com/owner/repo/security/advisories/GHSA-aaaa-bbbb-cccc?x=1",
+		"https://github.com/../../x/security/advisories/GHSA-aaaa-bbbb-cccc",
+		"http://github.com/owner/repo/security/advisories/GHSA-aaaa-bbbb-cccc",
+	} {
+		owner, repo = repoFromAdvisoryLink(link)
+		assert.Empty(t, owner, "link %q must not yield an owner", link)
+		assert.Empty(t, repo, "link %q must not yield a repo", link)
+	}
+}

--- a/api/internal/catalog/advisory/packagist.go
+++ b/api/internal/catalog/advisory/packagist.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -180,8 +181,49 @@ func extractGHSAID(adv repository.SecurityAdvisory) string {
 	if id := normalizeGHSA(adv.RemoteID); id != "" {
 		return id
 	}
-	return ""
+	// Advisories sourced from FriendsOfPHP carry a remoteId like
+	// "mcp/sdk/CVE-2026-53965.yaml" and no GHSA anywhere in Sources, but their
+	// link still points at the GitHub advisory page. Without this the row never
+	// enters the GHSA enrichment queue and stays permanently bare when NVD has
+	// not published the CVE either.
+	return ghsaFromLink(adv.Link)
 }
+
+// ghsaLinkPattern matches the GHSA id in a GitHub advisory URL, covering both
+// the global (/advisories/GHSA-...) and repository-scoped
+// (/owner/repo/security/advisories/GHSA-...) forms.
+var ghsaLinkPattern = regexp.MustCompile(`(?i)/advisories/(GHSA(?:-[A-Za-z0-9]{4,})+)`)
+
+// ghsaFromLink recovers a GHSA id from an advisory link. The result is matched
+// against the same shape rule fetchAdvisory enforces, so a crafted link cannot
+// smuggle path segments into a token-bearing request.
+func ghsaFromLink(link string) string {
+	m := ghsaLinkPattern.FindStringSubmatch(strings.TrimSpace(link))
+	if m == nil {
+		return ""
+	}
+	id := m[1]
+	if !ghsaIDPattern.MatchString(strings.ToUpper(id)) {
+		return ""
+	}
+	return id
+}
+
+// repoFromAdvisoryLink extracts owner/repo from a repository-scoped GitHub
+// advisory URL. Global advisory links (github.com/advisories/GHSA-...) have no
+// repository and yield empty strings.
+func repoFromAdvisoryLink(link string) (owner, repo string) {
+	m := repoAdvisoryLinkPattern.FindStringSubmatch(strings.TrimSpace(link))
+	if m == nil {
+		return "", ""
+	}
+	return m[1], m[2]
+}
+
+// Owner and repo are constrained to GitHub's own naming rules so neither can
+// introduce a path segment when interpolated into the API URL.
+var repoAdvisoryLinkPattern = regexp.MustCompile(
+	`(?i)^https://github\.com/([A-Za-z0-9._-]+)/([A-Za-z0-9._-]+)/security/advisories/GHSA(?:-[A-Za-z0-9]{4,})+/?$`)
 
 func normalizeGHSA(id string) string {
 	id = strings.TrimSpace(id)

--- a/api/internal/catalog/advisory/service.go
+++ b/api/internal/catalog/advisory/service.go
@@ -412,7 +412,7 @@ func (s *Service) enrichFromGitHub(ctx context.Context) (int, error) {
 			slog.WarnContext(ctx, "failed to mark ghsa details attempt", "ghsa", ghsaID, "error", err)
 		}
 
-		details, err := s.github.fetchAdvisory(ctx, ghsaID)
+		details, err := s.github.fetchAdvisoryWithLink(ctx, ghsaID, row.Link)
 		if err != nil {
 			slog.WarnContext(ctx, "failed to fetch github advisory details", "ghsa", ghsaID, "error", err)
 			if firstErr == nil {

--- a/api/internal/catalog/advisory/service_repo_link_test.go
+++ b/api/internal/catalog/advisory/service_repo_link_test.go
@@ -1,0 +1,116 @@
+package advisory_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	catalogadvisory "github.com/friendsofshopware/shopmon/api/internal/catalog/advisory"
+	"github.com/friendsofshopware/shopmon/api/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// canonicalAdvisoryID prefers the CVE, so two advisories carrying different
+// CVEs but the same GHSA become two rows that the enrichment query groups back
+// together — each keeping its own disclosure link. When those links disagree,
+// the query must hand the GitHub pass the repository-scoped one: it is the only
+// shape that names a repository to fall back to. Picking by sort order chooses
+// the global github.com/advisories link, which 404s for a repository advisory
+// and names no repository, stranding both rows unenriched.
+func TestSyncPrefersRepositoryScopedLinkAmongSiblings(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+
+	const (
+		ghsa      = "GHSA-7m52-jw36-44r3"
+		globalURL = "https://github.com/advisories/" + ghsa
+		repoURL   = "https://github.com/modelcontextprotocol/php-sdk/security/advisories/" + ghsa
+	)
+
+	var repoHits int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/packages.json", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"metadata-url":        "/p2/%package%.json",
+			"security-advisories": map[string]any{"api-url": "/api/security-advisories/"},
+		})
+	})
+	mux.HandleFunc("/packages/list.json", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"packageNames": []string{"shopware/core"}})
+	})
+	// Two CVEs sharing one GHSA become two rows, each with its own link. The
+	// global link sorts before the repository one.
+	mux.HandleFunc("/api/security-advisories/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			require.NoError(t, r.ParseForm())
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"advisories": map[string]any{
+				"shopware/core": []map[string]any{
+					{
+						"advisoryId": "PKSA-a", "packageName": "shopware/core",
+						"title": "SSE buffer DoS", "cve": "CVE-2026-0100",
+						"affectedVersions": ">=6.7.0.0,<6.7.10.1",
+						"reportedAt":       "2026-06-04 19:36:07", "link": globalURL,
+						"sources": []map[string]string{{"name": "GitHub", "remoteId": ghsa}},
+					},
+					{
+						"advisoryId": "PKSA-b", "packageName": "shopware/core",
+						"title": "SSE buffer DoS", "cve": "CVE-2026-0101",
+						"affectedVersions": ">=6.7.0.0,<6.7.10.1",
+						"reportedAt":       "2026-06-04 19:36:07", "link": repoURL,
+						"sources": []map[string]string{{"name": "GitHub", "remoteId": ghsa}},
+					},
+				},
+			},
+		})
+	})
+	// Repository-only advisory: absent from the global database.
+	mux.HandleFunc("/advisories/"+ghsa, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"message":"Not Found"}`)
+	})
+	mux.HandleFunc("/repos/modelcontextprotocol/php-sdk/security-advisories/"+ghsa,
+		func(w http.ResponseWriter, _ *http.Request) {
+			repoHits++
+			_, _ = io.WriteString(w, `{"ghsa_id":"`+ghsa+`","summary":"SSE buffer DoS",
+              "description":"Unbounded buffer growth.","vulnerabilities":[
+              {"package":{"name":"shopware/core","ecosystem":"composer"},
+               "vulnerable_version_range":">= 6.7.0.0, <= 6.7.10.0","patched_versions":"6.7.10.1"}]}`)
+		})
+	mux.HandleFunc("/rest/json/cves/2.0", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"vulnerabilities": []map[string]any{}})
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, "{}")
+	})
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	svc := catalogadvisory.NewServiceWithClient(env.Pool, env.Queries, server.URL, server.Client())
+	require.NoError(t, svc.Sync(ctx))
+
+	assert.Positive(t, repoHits, "the repository endpoint must be reached via the repo-scoped sibling link")
+
+	// Both rows share the GHSA, so the single fetch must enrich each of them.
+	for _, id := range []string{"CVE-2026-0100", "CVE-2026-0101"} {
+		row, err := env.Queries.GetComposerAdvisory(ctx, id)
+		require.NoError(t, err, "advisory %s", id)
+
+		require.NotNil(t, row.Description, "advisory %s has no description", id)
+		assert.Contains(t, *row.Description, "Unbounded buffer growth")
+
+		var patched map[string]string
+		require.NoError(t, json.Unmarshal(row.FirstPatchedVersions, &patched))
+		assert.Equal(t, "6.7.10.1", patched["6.7"],
+			"patched versions must survive a divergent-link group (%s)", id)
+	}
+}

--- a/api/internal/database/queries/composer_advisory.sql.go
+++ b/api/internal/database/queries/composer_advisory.sql.go
@@ -332,7 +332,9 @@ func (q *Queries) ListComposerAdvisoryCvePendingDetails(ctx context.Context, lim
 }
 
 const listComposerAdvisoryGhsaPendingDetails = `-- name: ListComposerAdvisoryGhsaPendingDetails :many
-SELECT ghsa_id, BOOL_OR(details_synced_at IS NULL) AS needs_details
+SELECT ghsa_id,
+       BOOL_OR(details_synced_at IS NULL) AS needs_details,
+       COALESCE(MIN(link) FILTER (WHERE link IS NOT NULL AND link <> ''), '')::text AS link
 FROM composer_advisory
 WHERE ghsa_id IS NOT NULL AND ghsa_id <> ''
   AND (details_synced_at IS NULL OR github_synced_at IS NULL)
@@ -344,11 +346,14 @@ LIMIT $1
 type ListComposerAdvisoryGhsaPendingDetailsRow struct {
 	GhsaID       *string `json:"ghsa_id"`
 	NeedsDetails bool    `json:"needs_details"`
+	Link         string  `json:"link"`
 }
 
 // The GitHub pass serves two needs: details for rows nothing else enriched,
 // and first_patched_versions for every GHSA-bearing row — including those NVD
 // already enriched, hence the separate github_synced_at marker.
+// link is carried along so a GHSA missing from the global advisory database can
+// still be fetched from the repository that published it.
 func (q *Queries) ListComposerAdvisoryGhsaPendingDetails(ctx context.Context, limit int32) ([]ListComposerAdvisoryGhsaPendingDetailsRow, error) {
 	rows, err := q.db.Query(ctx, listComposerAdvisoryGhsaPendingDetails, limit)
 	if err != nil {
@@ -358,7 +363,7 @@ func (q *Queries) ListComposerAdvisoryGhsaPendingDetails(ctx context.Context, li
 	items := []ListComposerAdvisoryGhsaPendingDetailsRow{}
 	for rows.Next() {
 		var i ListComposerAdvisoryGhsaPendingDetailsRow
-		if err := rows.Scan(&i.GhsaID, &i.NeedsDetails); err != nil {
+		if err := rows.Scan(&i.GhsaID, &i.NeedsDetails, &i.Link); err != nil {
 			return nil, err
 		}
 		items = append(items, i)

--- a/api/internal/database/queries/composer_advisory.sql.go
+++ b/api/internal/database/queries/composer_advisory.sql.go
@@ -334,7 +334,9 @@ func (q *Queries) ListComposerAdvisoryCvePendingDetails(ctx context.Context, lim
 const listComposerAdvisoryGhsaPendingDetails = `-- name: ListComposerAdvisoryGhsaPendingDetails :many
 SELECT ghsa_id,
        BOOL_OR(details_synced_at IS NULL) AS needs_details,
-       COALESCE(MIN(link) FILTER (WHERE link IS NOT NULL AND link <> ''), '')::text AS link
+       COALESCE(MIN(link) FILTER (
+         WHERE link ~ '^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/security/advisories/GHSA-'
+       ), '')::text AS link
 FROM composer_advisory
 WHERE ghsa_id IS NOT NULL AND ghsa_id <> ''
   AND (details_synced_at IS NULL OR github_synced_at IS NULL)
@@ -353,7 +355,11 @@ type ListComposerAdvisoryGhsaPendingDetailsRow struct {
 // and first_patched_versions for every GHSA-bearing row — including those NVD
 // already enriched, hence the separate github_synced_at marker.
 // link is carried along so a GHSA missing from the global advisory database can
-// still be fetched from the repository that published it.
+// still be fetched from the repository that published it. Only a
+// repository-scoped link serves that purpose, so siblings sharing the GHSA are
+// filtered to that shape rather than picked by sort order: a global
+// github.com/advisories link sorts first but names no repository, and would
+// leave the advisory unenriched forever.
 func (q *Queries) ListComposerAdvisoryGhsaPendingDetails(ctx context.Context, limit int32) ([]ListComposerAdvisoryGhsaPendingDetailsRow, error) {
 	rows, err := q.db.Query(ctx, listComposerAdvisoryGhsaPendingDetails, limit)
 	if err != nil {

--- a/api/sql/queries/composer_advisory.sql
+++ b/api/sql/queries/composer_advisory.sql
@@ -74,11 +74,17 @@ LIMIT $1;
 -- and first_patched_versions for every GHSA-bearing row — including those NVD
 -- already enriched, hence the separate github_synced_at marker.
 -- link is carried along so a GHSA missing from the global advisory database can
--- still be fetched from the repository that published it.
+-- still be fetched from the repository that published it. Only a
+-- repository-scoped link serves that purpose, so siblings sharing the GHSA are
+-- filtered to that shape rather than picked by sort order: a global
+-- github.com/advisories link sorts first but names no repository, and would
+-- leave the advisory unenriched forever.
 -- name: ListComposerAdvisoryGhsaPendingDetails :many
 SELECT ghsa_id,
        BOOL_OR(details_synced_at IS NULL) AS needs_details,
-       COALESCE(MIN(link) FILTER (WHERE link IS NOT NULL AND link <> ''), '')::text AS link
+       COALESCE(MIN(link) FILTER (
+         WHERE link ~ '^https://github\.com/[A-Za-z0-9._-]+/[A-Za-z0-9._-]+/security/advisories/GHSA-'
+       ), '')::text AS link
 FROM composer_advisory
 WHERE ghsa_id IS NOT NULL AND ghsa_id <> ''
   AND (details_synced_at IS NULL OR github_synced_at IS NULL)

--- a/api/sql/queries/composer_advisory.sql
+++ b/api/sql/queries/composer_advisory.sql
@@ -73,8 +73,12 @@ LIMIT $1;
 -- The GitHub pass serves two needs: details for rows nothing else enriched,
 -- and first_patched_versions for every GHSA-bearing row — including those NVD
 -- already enriched, hence the separate github_synced_at marker.
+-- link is carried along so a GHSA missing from the global advisory database can
+-- still be fetched from the repository that published it.
 -- name: ListComposerAdvisoryGhsaPendingDetails :many
-SELECT ghsa_id, BOOL_OR(details_synced_at IS NULL) AS needs_details
+SELECT ghsa_id,
+       BOOL_OR(details_synced_at IS NULL) AS needs_details,
+       COALESCE(MIN(link) FILTER (WHERE link IS NOT NULL AND link <> ''), '')::text AS link
 FROM composer_advisory
 WHERE ghsa_id IS NOT NULL AND ghsa_id <> ''
   AND (details_synced_at IS NULL OR github_synced_at IS NULL)


### PR DESCRIPTION
## Problem

`CVE-2026-53965` shows up in staging with no summary, description, CWEs or patched version — the UI has only the disclosure link Packagist gave us.

```
advisory_id            | CVE-2026-53965
ghsa_id                | (empty)
details_source         | (empty)
summary / description  | null / null
first_patched_versions | {}
```

Two independent gaps kept it there.

**Extraction.** Packagist delivered it from the FriendsOfPHP database, whose source `remoteId` is `mcp/sdk/CVE-2026-53965.yaml` and carries no GHSA:

```json
[{"name": "FriendsOfPHP/security-advisories", "remoteId": "mcp/sdk/CVE-2026-53965.yaml"}]
```

The GHSA was in the advisory `link` all along, but `extractGHSAID` only scanned `Sources[].RemoteID` and `RemoteID`. So `ghsa_id` stayed empty and the row never entered the GitHub queue — `ListComposerAdvisoryGhsaPendingDetails` filters on `ghsa_id <> ''`. NVD was its only remaining path, and NVD has not published this CVE (`totalResults: 0`), so it never enriched. `details_attempted_at` kept advancing every sync while nothing was written.

**Endpoint.** Even with a GHSA the fetch would have failed. `GHSA-7m52-jw36-44r3` is a *repository* advisory, not a global one:

```
GET /advisories/GHSA-7m52-jw36-44r3            → 404 (x-ratelimit-remaining: 49)
GET /advisories?cve_id=CVE-2026-53965          → []
GET /advisories?ecosystem=composer&affects=…   → []
```

Only `/repos/modelcontextprotocol/php-sdk/security-advisories/GHSA-7m52-jw36-44r3` answers (200). It isn't indexed by `cve_id` or `affects` either, which leaves the link as the only route to the data.

## Fix

1. **`extractGHSAID` falls back to the link** (`packagist.go`) via `ghsaFromLink`, matching both global and repo-scoped URL shapes.
2. **`fetchAdvisoryWithLink` retries the repo endpoint on 404** (`github.go`), using owner/repo parsed from the link. A 404 is now a sentinel `errGitHubAdvisoryNotFound` rather than a bare string. A successful global fetch never makes the extra request.
3. **The pending-details query carries `link`** so the fallback has something to work with.

Two schema differences between the endpoints, found by diffing real responses — either would have silently produced empty data:

- The repo endpoint returns **`patched_versions`** (string), not `first_patched_version`. `firstPatchedByLine` now reads both. Without this the fallback would fetch successfully and still write `first_patched_versions = {}` — the exact symptom being fixed.
- `references` is **absent** on the repo variant. It decodes to nil and `html_url` still seeds the list.

## Security

`ghsaFromLink` output is re-checked against the existing `ghsaIDPattern`, and `repoAdvisoryLinkPattern` anchors on `https://github.com/` with GitHub's own owner/repo character class. A crafted link can't inject path segments into a request that carries our GitHub token. Covered by tests against `evil.com`, query-string, traversal and plain-HTTP variants.

## Verification

Live run against the real API with staging's token:

```
ghsaFromLink -> "GHSA-7m52-jw36-44r3"
summary:  "DoS: client HttpTransport SSE buffer (sseBuffer .= chunk) grows unbounded…"
cwes:     CWE-400, CWE-770
desc_len: 13975
```

Six new tests in `github_repo_fallback_test.go`; full suite and `go vet` pass.

An earlier revision cast the new column as bare `::text`, which made sqlc emit `string` while the value was still NULL for link-less advisories — the existing `TestSyncCollapsesPackagesUnderCVE` caught the pgx scan failure. Now `COALESCE(…, '')::text`.

## Scope and limits

- **CVSS stays empty** for this advisory — GitHub returns `"cvss": {"score": null}`, the maintainers never scored it. The existing `> 0` guard handles that; a test asserts we don't record it as `0`.
- **Does not fix the other two stuck rows.** `CVE-2026-46636` and `CVE-2026-46626` link to `symfony.com`, not GitHub, so there's no GHSA to recover. They still wait on NVD publication.

| advisory | link | helped |
|---|---|---|
| CVE-2026-53965 | github.com/modelcontextprotocol/php-sdk/… | yes |
| CVE-2026-46636 | symfony.com/blog/cve-2026-46636-… | no |
| CVE-2026-46626 | symfony.com/cve-2026-46626 | no |

## Follow-up (not in this PR)

`enrichFromNVD` can't distinguish "NVD hasn't published this yet" from a real fetch error, so CVE-only rows retry at full cost every sync and log a warning each time. Worth giving an empty NVD result a distinct, backed-off state.

Once deployed, the row enriches on the next sync — `details_attempted_at` ordering puts it near the front of the queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
