### PR TITLE
fix(ui): style advisory code blocks and clean up Sources list

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -206,6 +206,36 @@
     @apply font-semibold text-foreground;
   }
   .richtext code {
-    @apply rounded bg-muted px-1.5 py-0.5 text-sm;
+    @apply rounded bg-muted px-1.5 py-0.5 font-mono text-[13px];
+  }
+  /* Fenced code blocks from advisory write-ups (PoC, vulnerable code) must
+     scroll instead of stretching the card, and must not double up on the
+     inline-code background. */
+  .richtext pre {
+    @apply mb-3 overflow-x-auto rounded-lg bg-muted p-3;
+  }
+  .richtext pre code {
+    @apply bg-transparent p-0 font-mono text-[13px] leading-relaxed;
+  }
+  .richtext blockquote {
+    @apply mb-3 border-l-2 border-border pl-3 text-muted-foreground;
+  }
+  .richtext table {
+    @apply mb-3 w-full text-left text-[13px];
+  }
+  .richtext th,
+  .richtext td {
+    @apply border-b border-border px-2 py-1.5;
+  }
+  .richtext th {
+    @apply font-semibold;
+  }
+  .richtext hr {
+    @apply my-4 border-border;
+  }
+  /* Long autolinks and unbroken tokens inside prose must wrap, not overflow
+     the card. */
+  .richtext a {
+    @apply break-all;
   }
 }

--- a/frontend/src/views/advisories/DetailAdvisory.vue
+++ b/frontend/src/views/advisories/DetailAdvisory.vue
@@ -477,15 +477,22 @@
                 <div class="text-xs font-medium text-muted-foreground">
                   {{ $t("advisories.sources") }}
                 </div>
-                <div class="mt-1 flex flex-wrap gap-1">
-                  <Badge
+                <!-- The remote id is the useful identifier (CVE/GHSA); the
+                     source name only says where it was synced from, so it is
+                     the secondary label rather than cramming both into one
+                     overflowing badge. -->
+                <ul class="mt-1.5 space-y-1.5">
+                  <li
                     v-for="(src, i) in advisory.sources"
                     :key="i"
-                    variant="outline"
-                    class="font-mono text-[10px]"
-                    >{{ src.name }}: {{ src.remoteId }}</Badge
+                    class="flex items-center justify-between gap-2"
                   >
-                </div>
+                    <span class="truncate text-xs text-muted-foreground">{{ src.name }}</span>
+                    <Badge variant="outline" class="shrink-0 font-mono text-[10px]">
+                      {{ src.remoteId }}
+                    </Badge>
+                  </li>
+                </ul>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Problem
On the advisory detail page the description's fenced code blocks (vulnerable code, proof of concept) rendered as plain unstyled text, because the global `.richtext` styles only covered paragraphs, lists, headings, and inline code. Long unbroken tokens and autolinks also overflowed the card.

In the sidebar, each advisory source was rendered as a single `name: remoteId` badge (e.g. `FriendsOfPHP/security-advisories: CVE-2026-53985`), which overflowed the 360px sidebar.

## Changes
- `frontend/src/app.css`: add `.richtext` rules for `pre` (scrollable, muted background), `pre code` (no double background), `blockquote`, `table`, `hr`, and `break-all` on links. Applies to all views using `.richtext`, including the admin advisory detail.
- `frontend/src/views/advisories/DetailAdvisory.vue`: render Sources as one row per source — muted sync-source name on the left, compact mono badge with the remote id (CVE/GHSA) on the right.

## Verification
- [x] `mise run lint` (golangci-lint, oxlint, vue-tsc, oxfmt, Vitest unit tests)
- [x] `mise run test` (API integration tests)