### PR TITLE
fix(checker): ignore FroshTools Composer security advisories check

### DIFF
--- a/api/internal/shopware/checker/frosh_tools.go
+++ b/api/internal/shopware/checker/frosh_tools.go
@@ -25,6 +25,10 @@ var ignoredFroshChecks = map[string]bool{
 	"not-prod":             true,
 	"adminWorkerGood":      true,
 	"adminWorkerWarning":   true,
+	// Duplicated by the Security source, which matches the SBOM against the
+	// composer_advisory catalog with per-package detail and suppressions —
+	// the FroshTools counter adds a second red status without any of that.
+	"Composer security advisories": true,
 }
 
 func checkFroshTools(ctx context.Context, input Input, output *Output) {

--- a/api/internal/shopware/checker/frosh_tools_test.go
+++ b/api/internal/shopware/checker/frosh_tools_test.go
@@ -79,6 +79,14 @@ func TestMapFroshChecks(t *testing.T) {
 			wantKey:     "check.frosh.scheduledTaskWarning",
 		},
 		{
+			name:        "composer security advisories stays green despite duplicating the Security source",
+			check:       froshToolsCheck{Snippet: "Composer security advisories", State: "STATE_ERROR"},
+			wantEmitted: true,
+			wantID:      "frosh.Composer security advisories",
+			wantLevel:   StatusGreen,
+			wantKey:     "check.frosh.Composer security advisories",
+		},
+		{
 			name:        "unknown snippet still keyed, snippet param carries fallback",
 			check:       froshToolsCheck{Snippet: "somethingCustom", State: "STATE_OK"},
 			wantEmitted: true,


### PR DESCRIPTION
## Problem
The FroshTools health endpoint reports its own "Composer security advisories" check, which escalates the shop status to red whenever the shop has vulnerable Composer packages. shopmon's own `Security` source already covers this by matching the SBOM against the `composer_advisory` catalog — with per-package detail, CVE context, and suppression support. The FroshTools counter added a duplicate red status without any of that.

## Changes
- Add `Composer security advisories` to `ignoredFroshChecks` in `api/internal/shopware/checker/frosh_tools.go`, forcing it to green like the other ignored FroshTools checks (scheduled tasks, queues, admin worker, …).
- Test case in `frosh_tools_test.go` asserting the check stays green even in `STATE_ERROR`.

Existing red rows flip to green on the next environment scrape; checks are upserted per scrape, so no migration is needed.

## Verification
- [x] `mise run lint`
- [x] `mise run test`