### PR TITLE
fix: ack StoreExtensionSync when Store API rate-limits

### DIFF
--- a/api/internal/catalog/sync/service.go
+++ b/api/internal/catalog/sync/service.go
@@ -144,6 +144,9 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	// recordOutcome stays false for the "nothing to sync" early return so
 	// no-op freshness checks do not inflate shopmon.store_sync.outcome ok.
 	recordOutcome := true
+	// rateLimited is tracked separately from err: a 429 abort is a successful
+	// partial sync (job acked) but must still increment the rate_limited outcome.
+	rateLimited := false
 	defer func() {
 		if err != nil {
 			span.RecordError(err)
@@ -154,12 +157,11 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 			return
 		}
 		outcome := metrics.OutcomeOK
-		if err != nil {
-			if shopwareaccount.IsRateLimited(err) {
-				outcome = metrics.OutcomeRateLimited
-			} else {
-				outcome = metrics.OutcomeError
-			}
+		switch {
+		case rateLimited:
+			outcome = metrics.OutcomeRateLimited
+		case err != nil:
+			outcome = metrics.OutcomeError
 		}
 		metrics.RecordStoreSyncOutcome(ctx, outcome)
 	}()
@@ -199,8 +201,10 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	//
 	// Versions are probed sequentially (and locales within a version serially)
 	// so a rate-limit from the store is not amplified by fan-out. On 429 after
-	// client retries, remaining versions are aborted and the job returns an
-	// error for a later retry instead of burning through the rest of the list.
+	// client retries, remaining versions are aborted. Partial progress is
+	// persisted without advancing sync bookkeeping so the next scheduled scrape
+	// can finish the work. The job returns success so the queue does not
+	// nack/retry into a still-limited Store API.
 	//
 	// compat[swv][name] is the compatible latest version the store reports for
 	// that Shopware version; best[name] is the plugin data used to build the
@@ -217,7 +221,7 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 			if shopwareaccount.IsRateLimited(err) {
 				// Stop probing further versions; continuing would only deepen the
 				// 429 burst. Partial progress (if any) is persisted below without
-				// advancing sync bookkeeping so the queue / next scrape retries.
+				// advancing sync bookkeeping so the next scheduled scrape retries.
 				slog.Warn("store rate limited, aborting remaining version probes",
 					"shopwareVersion", swv, "error", err)
 				rateLimitErr = err
@@ -247,10 +251,12 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	}
 
 	if !anyProbeSucceeded {
-		// Bookkeeping is deliberately not updated so the queue retry (or the next
-		// scrape dispatch) tries again.
+		// Bookkeeping is deliberately not updated so the next scheduled scrape
+		// dispatch tries again. A rate-limit abort is not a job failure: nacking
+		// would immediately re-hit a still-limited Store API and burn retries.
 		if rateLimitErr != nil {
-			return fmt.Errorf("store rate limited; all probes failed for %d version(s): %w", len(swvs), rateLimitErr)
+			rateLimited = true
+			return nil
 		}
 		return fmt.Errorf("all store probes failed for %d version(s)", len(swvs))
 	}
@@ -270,11 +276,13 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 
 	if rateLimitErr != nil {
 		// Persist what we have but do not mark names fresh — missing compatibility
-		// rows and stale bookkeeping will re-dispatch, and the returned error lets
-		// the queue retry with its own backoff.
+		// rows and stale bookkeeping keep the name-set eligible for the next
+		// scheduled sync. Returning nil acks the job instead of burning the
+		// queue retry budget against a still-limited API.
 		slog.Warn("synced store extensions partially before rate limit",
 			"requested", len(names), "fetched", len(needed), "found", synced)
-		return fmt.Errorf("store rate limited after probing %d/%d version(s): %w", len(compat), len(swvs), rateLimitErr)
+		rateLimited = true
+		return nil
 	}
 
 	if err := h.queries.UpsertStoreExtensionSyncStates(ctx, needed); err != nil {

--- a/api/internal/catalog/sync/service_test.go
+++ b/api/internal/catalog/sync/service_test.go
@@ -13,11 +13,15 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/maintenance"
+	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // mockExtension describes what the mock store returns for one technical name.
@@ -43,6 +47,9 @@ type mockStoreServer struct {
 	// rateLimitedVersions, when set, causes pluginsByName for those Shopware
 	// versions to respond with HTTP 429.
 	rateLimitedVersions map[string]bool
+	// serverErrorVersions, when set, causes pluginsByName for those Shopware
+	// versions to respond with HTTP 500 (non-retryable, not a rate limit).
+	serverErrorVersions map[string]bool
 	// seen records locale@shopwareVersion hits in order.
 	seen []string
 	// inFlight tracks concurrent handlers; maxInFlight is the high-water mark.
@@ -63,6 +70,7 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 			},
 		},
 		rateLimitedVersions: map[string]bool{},
+		serverErrorVersions: map[string]bool{},
 	}
 
 	mux := http.NewServeMux()
@@ -78,6 +86,7 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 			m.maxInFlight = m.inFlight
 		}
 		rateLimited := m.rateLimitedVersions[swv]
+		serverError := m.serverErrorVersions[swv]
 		delay := m.handlerDelay
 		m.mu.Unlock()
 
@@ -94,6 +103,10 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 		if rateLimited {
 			w.Header().Set("Retry-After", "1")
 			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		if serverError {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -228,6 +241,41 @@ func snapshotRowVersions(t *testing.T, pool *pgxpool.Pool) map[string]string {
 		require.NoError(t, rows.Err(), "iterate %s", table)
 	}
 	return result
+}
+
+func withStoreSyncMetrics(t *testing.T) func() map[string]int64 {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	prev := otel.GetMeterProvider()
+	otel.SetMeterProvider(mp)
+	metrics.Register()
+	t.Cleanup(func() {
+		otel.SetMeterProvider(prev)
+		_ = mp.Shutdown(context.Background())
+	})
+	return func() map[string]int64 {
+		t.Helper()
+		var rm metricdata.ResourceMetrics
+		require.NoError(t, reader.Collect(context.Background(), &rm))
+		out := make(map[string]int64)
+		for _, sm := range rm.ScopeMetrics {
+			for _, m := range sm.Metrics {
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				if !ok {
+					continue
+				}
+				for _, dp := range sum.DataPoints {
+					key := m.Name
+					for _, attr := range dp.Attributes.ToSlice() {
+						key += "|" + string(attr.Key) + "=" + attr.Value.AsString()
+					}
+					out[key] = dp.Value
+				}
+			}
+		}
+		return out
+	}
 }
 
 func countRows(t *testing.T, pool *pgxpool.Pool, table string) int {
@@ -450,10 +498,12 @@ func TestStoreExtensionSyncSerializesLocaleProbes(t *testing.T) {
 // TestStoreExtensionSyncAbortsRemainingVersionsOn429: once the store rate-limits
 // a version probe, SyncNames must stop probing further versions instead of
 // stomping through the rest of the list, leave sync bookkeeping untouched so a
-// retry can continue, and still persist any versions already probed.
+// later scheduled sync can continue, persist any versions already probed, and
+// return nil so the queue acks instead of nacking into a still-limited API.
 func TestStoreExtensionSyncAbortsRemainingVersionsOn429(t *testing.T) {
 	h, pool, store := setupSyncTest(t)
 	ctx := context.Background()
+	collect := withStoreSyncMetrics(t)
 
 	// Newest version (6.6.0.0) succeeds; older 6.5.0.0 is rate-limited. Probes
 	// run newest-first, so we get partial progress then abort.
@@ -461,8 +511,8 @@ func TestStoreExtensionSyncAbortsRemainingVersionsOn429(t *testing.T) {
 	h.account = fastStoreClient(store.URL)
 
 	err := h.SyncNames(ctx, []string{"FroshTools"}, "6.6.0.0", false)
-	require.Error(t, err)
-	assert.True(t, shopwareaccount.IsRateLimited(err), "expected rate-limit error, got %v", err)
+	require.NoError(t, err, "rate-limit abort must not fail the job")
+	assert.Equal(t, int64(1), collect()["shopmon.store_sync.outcome|outcome=rate_limited"], "abort must record rate_limited")
 
 	// 6.6 en+de succeeded; 6.5 en hit 429 and aborted before de (and before any
 	// further versions, of which there are none).
@@ -483,23 +533,85 @@ func TestStoreExtensionSyncAbortsRemainingVersionsOn429(t *testing.T) {
 	// not be advanced (otherwise the hourly freshness gate would starve retries).
 	assert.Equal(t, 1, countRows(t, pool, "store_extension_compatibility"))
 	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"), "bookkeeping not marked fresh after rate limit")
+
+	// Incomplete work stays eligible for the next scheduled pass — both the
+	// aborted Shopware version (compat gap) and a fresh re-sync of the same
+	// names (bookkeeping never written).
+	needing, err := h.namesNeedingSync(ctx, []string{"FroshTools"}, "6.5.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"FroshTools"}, needing, "aborted version must remain eligible")
+	needing, err = h.namesNeedingSync(ctx, []string{"FroshTools"}, "6.6.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"FroshTools"}, needing, "partial sync must not mark the name-set fresh")
 }
 
 // TestStoreExtensionSyncAllProbesRateLimited: when the first version is already
-// rate-limited, nothing is persisted and the error surfaces for job retry.
+// rate-limited, nothing is persisted, bookkeeping stays stale, and the job
+// still succeeds so the queue does not immediately retry.
 func TestStoreExtensionSyncAllProbesRateLimited(t *testing.T) {
 	h, pool, store := setupSyncTest(t)
+	ctx := context.Background()
+	collect := withStoreSyncMetrics(t)
 	store.rateLimitedVersions["6.6.0.0"] = true
 	store.rateLimitedVersions["6.5.0.0"] = true
 	h.account = fastStoreClient(store.URL)
 
-	err := h.SyncNames(context.Background(), []string{"FroshTools"}, "6.6.0.0", false)
-	require.Error(t, err)
-	assert.True(t, shopwareaccount.IsRateLimited(err), "expected rate-limit error, got %v", err)
+	err := h.SyncNames(ctx, []string{"FroshTools"}, "6.6.0.0", false)
+	require.NoError(t, err, "rate-limit abort must not fail the job")
+	assert.Equal(t, int64(1), collect()["shopmon.store_sync.outcome|outcome=rate_limited"], "abort must record rate_limited")
 
 	assert.Equal(t, []string{"en_GB@6.6.0.0"}, store.seenLocales(), "must not continue after first 429")
 	assert.Equal(t, 0, countRows(t, pool, "store_extension"))
 	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"))
+
+	needing, err := h.namesNeedingSync(ctx, []string{"FroshTools"}, "6.6.0.0")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"FroshTools"}, needing, "unsynced names must remain eligible")
+}
+
+// TestStoreExtensionSyncNon429StillErrors: a non-429 probe failure on every
+// version is a real job error, not a graceful backoff.
+func TestStoreExtensionSyncNon429StillErrors(t *testing.T) {
+	h, pool, store := setupSyncTest(t)
+	collect := withStoreSyncMetrics(t)
+	store.serverErrorVersions["6.6.0.0"] = true
+	store.serverErrorVersions["6.5.0.0"] = true
+	h.account = fastStoreClient(store.URL)
+
+	err := h.SyncNames(context.Background(), []string{"FroshTools"}, "6.6.0.0", false)
+	require.Error(t, err)
+	assert.False(t, shopwareaccount.IsRateLimited(err), "500 must not be classified as rate-limited")
+	assert.Contains(t, err.Error(), "all store probes failed")
+	assert.Equal(t, int64(1), collect()["shopmon.store_sync.outcome|outcome=error"], "non-429 must record error")
+
+	assert.Equal(t, 0, countRows(t, pool, "store_extension"))
+	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"))
+}
+
+// TestStoreExtensionSyncRateLimitThenScheduledPass: after a 429 abort, a later
+// SyncNames (the next scheduled scrape dispatch) finishes the remaining
+// versions and only then marks bookkeeping fresh.
+func TestStoreExtensionSyncRateLimitThenScheduledPass(t *testing.T) {
+	h, pool, store := setupSyncTest(t)
+	ctx := context.Background()
+	store.rateLimitedVersions["6.5.0.0"] = true
+	h.account = fastStoreClient(store.URL)
+
+	require.NoError(t, h.SyncNames(ctx, []string{"FroshTools"}, "6.6.0.0", false), "partial abort")
+	assert.Equal(t, 0, countRows(t, pool, "store_extension_sync"))
+
+	store.mu.Lock()
+	store.rateLimitedVersions["6.5.0.0"] = false
+	store.seen = nil
+	store.mu.Unlock()
+
+	require.NoError(t, h.SyncNames(ctx, []string{"FroshTools"}, "6.6.0.0", false), "scheduled follow-up")
+	assert.Equal(t, 1, countRows(t, pool, "store_extension_sync"), "bookkeeping marked fresh only after a complete sync")
+	assert.Equal(t, 2, countRows(t, pool, "store_extension_compatibility"), "both versions probed")
+
+	needing, err := h.namesNeedingSync(ctx, []string{"FroshTools"}, "6.6.0.0")
+	require.NoError(t, err)
+	assert.Empty(t, needing, "complete sync must satisfy freshness")
 }
 
 // TestOldDataCleanupRetainsCatalog verifies the catalog itself — including its

--- a/api/internal/jobs/handlers.go
+++ b/api/internal/jobs/handlers.go
@@ -3,7 +3,9 @@ package jobs
 import (
 	"context"
 	"errors"
+	"log/slog"
 
+	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
 	goqueue "github.com/shyim/go-queue"
 )
 
@@ -84,7 +86,7 @@ func RegisterHandlers(bus *goqueue.Bus, handlers Handlers) error {
 	})
 	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, message StoreExtensionSync) error {
 		// Names are high-cardinality; keep them off the Consumer entry span.
-		return handlers.StoreExtensionSynchronizer.Sync(ctx, message.Names, message.ShopwareVersion)
+		return handleStoreExtensionSync(ctx, handlers.StoreExtensionSynchronizer, message)
 	})
 	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, message SitespeedScrape) error {
 		return runEnvironmentJob(ctx, message.EnvironmentID, func(ctx context.Context) error {
@@ -111,4 +113,16 @@ func RegisterHandlers(bus *goqueue.Bus, handlers Handlers) error {
 		return handlers.SecurityPluginSynchronizer.Sync(ctx)
 	})
 	return nil
+}
+
+// handleStoreExtensionSync runs catalog sync and acks Store API rate-limit
+// aborts so the worker does not nack/retry into a still-limited API. Incomplete
+// names stay eligible for the next scheduled scrape dispatch.
+func handleStoreExtensionSync(ctx context.Context, syncer StoreExtensionSynchronizer, message StoreExtensionSync) error {
+	err := syncer.Sync(ctx, message.Names, message.ShopwareVersion)
+	if shopwareaccount.IsRateLimited(err) {
+		slog.Warn("store extension sync rate limited, acknowledging job for later scheduled sync", "error", err)
+		return nil
+	}
+	return err
 }

--- a/api/internal/jobs/handlers_test.go
+++ b/api/internal/jobs/handlers_test.go
@@ -1,0 +1,47 @@
+package jobs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type syncResultStub struct {
+	err error
+}
+
+func (s syncResultStub) Sync(context.Context, []string, string) error {
+	return s.err
+}
+
+func TestHandleStoreExtensionSyncAcksRateLimit(t *testing.T) {
+	err := handleStoreExtensionSync(context.Background(), syncResultStub{
+		err: &shopwareaccount.APIError{StatusCode: http.StatusTooManyRequests},
+	}, StoreExtensionSync{Names: []string{"FroshTools"}, ShopwareVersion: "6.6.0.0"})
+	require.NoError(t, err, "rate-limit abort must be acked")
+}
+
+func TestHandleStoreExtensionSyncAcksWrappedRateLimit(t *testing.T) {
+	err := handleStoreExtensionSync(context.Background(), syncResultStub{
+		err: fmt.Errorf("store rate limited after probing 1/2 version(s): %w", &shopwareaccount.APIError{StatusCode: http.StatusTooManyRequests}),
+	}, StoreExtensionSync{})
+	require.NoError(t, err, "wrapped rate-limit must be acked")
+}
+
+func TestHandleStoreExtensionSyncPropagatesOtherErrors(t *testing.T) {
+	want := errors.New("all store probes failed for 2 version(s)")
+	err := handleStoreExtensionSync(context.Background(), syncResultStub{err: want}, StoreExtensionSync{})
+	assert.Equal(t, want, err)
+}
+
+func TestHandleStoreExtensionSyncPropagatesNon429APIError(t *testing.T) {
+	want := &shopwareaccount.APIError{StatusCode: http.StatusInternalServerError}
+	err := handleStoreExtensionSync(context.Background(), syncResultStub{err: want}, StoreExtensionSync{})
+	assert.Equal(t, want, err)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

#789 stopped the APM 429 storm (`store api returned status 429` no longer floods error spans) by adding client-side Retry-After/backoff, serializing locale probes, and aborting remaining version probes.

The abort was still treated as a **job failure**. `SyncNames` returned a wrapped rate-limit error; the `StoreExtensionSync` consumer nacked it. Immediate retries (3 attempts, 5s/10s backoff) re-hit `api.shopware.com/pluginStore/pluginsByName` while still rate-limited, then dropped the message (`max retries exceeded, rejecting message`).

Production (env:production, ~2026-08-17): logs show `store rate limited, aborting remaining version probes`, ~193 `StoreExtensionSync` failures/hour, and 12 rejected messages after 3 attempts. Partial catalog writes happened; remaining versions were skipped; scrapes then re-dispatched because bookkeeping was (correctly) not marked fresh.

## Change

Treat a Store API 429 abort as a **successful partial sync**:

1. **Ack the job.** `SyncNames` returns `nil` after a rate-limit abort (partial or all-probes-failed). The consumer also swallows `shopwareaccount.IsRateLimited` as defense in depth, so a leftover wrapped 429 cannot nack.
2. **Do not immediately retry.** Unfinished work is picked up by the next scheduled scrape dispatch, not by queue nack/retry against a still-limited API.
3. **Keep bookkeeping honest.** Sync states are still not upserted on abort, so unsynced versions stay eligible on the next scheduled pass (freshness + compatibility-gap filter).
4. **Real errors still fail.** Non-429 probe failures (e.g. all versions 500) still return an error and nack.
5. **`shopmon.store_sync.outcome=rate_limited`** is still incremented on abort (tracked separately from the now-nil return).

#789's retry/serialize/abort-remaining-probes work is unchanged.

## Tests

- Rate-limit abort (partial and all-probes) → no `SyncNames` error; bookkeeping not marked fresh; names remain eligible; `rate_limited` outcome recorded
- Non-429 all-probe failure → job error + `error` outcome
- Follow-up `SyncNames` after the API recovers finishes remaining versions and only then marks bookkeeping fresh
- Job handler acks 429 / wrapped 429 and still propagates other errors

## Verification

- `mise run lint` — passed (API golangci-lint + frontend oxlint/tsc/oxfmt/vitest)
- `mise run test` — passed (`go test ./internal/...`)
- Also: `go test ./internal/jobs/ ./internal/catalog/sync/`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92188a40-22c3-4127-a2e6-280af7f7d1e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92188a40-22c3-4127-a2e6-280af7f7d1e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

