### PR TITLE
chore: upgrade to Go 1.27 and apply go fix modernizations

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26"
+go = "1.27"
 node = "26"
 sqlc = "1.31"
 golangci-lint = "2"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN npm ci
 COPY frontend/ ./
 RUN npm run build && cp -R dist/. /out/
 
-FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS api-build
+FROM --platform=$BUILDPLATFORM golang:1.27-alpine AS api-build
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://shopmon.fos.gg
 - [mise](https://mise.jdx.dev) — manages Go, Node.js, and tool versions
 - [Docker](https://www.docker.com/) — for PostgreSQL, Redis, Mailpit, and demo shop
 
-All other tools (Go 1.26, Node 26, sqlc, golangci-lint, air) are installed automatically by mise.
+All other tools (Go 1.27, Node 26, sqlc, golangci-lint, air) are installed automatically by mise.
 
 ### Quick Start
 

--- a/api/fixtures.go
+++ b/api/fixtures.go
@@ -275,74 +275,74 @@ func (s *seeder) seedNotifications(org orgFixture, prodEnvID, stagingEnvID int32
 		// Owner: open production degradation with check reasons
 		{
 			userID: org.user1ID, dedupKey: fmt.Sprintf("environment.change-status.%d", prodEnvID),
-			level: notify.LevelWarning,
+			level:    notify.LevelWarning,
 			titleKey: "notification.statusDegraded.title", messageKey: "notification.statusDegraded.message",
 			params: map[string]any{"name": prodName, "from": "green", "to": "yellow", "reasons": prodDegradeReasons},
-			link: environmentLink(prodEnvID), read: false,
+			link:   environmentLink(prodEnvID), read: false,
 		},
 		// Owner: open staging auth failure
 		{
 			userID: org.user1ID, dedupKey: fmt.Sprintf("environment.update-auth-error.%d", stagingEnvID),
-			level: notify.LevelError,
+			level:    notify.LevelError,
 			titleKey: "notification.authError.title", messageKey: "notification.authError.message",
 			params: map[string]any{"name": stagingName, "error": "invalid_client: Client authentication failed"},
-			link: environmentLink(stagingEnvID), read: false,
+			link:   environmentLink(stagingEnvID), read: false,
 		},
 		// Owner: read recovery on production (earlier alert, already dismissed)
 		{
 			userID: org.user1ID, dedupKey: fmt.Sprintf("environment.recover-status.%d", prodEnvID),
-			level: notify.LevelInfo,
+			level:    notify.LevelInfo,
 			titleKey: "notification.statusRecovered.title", messageKey: "notification.statusRecovered.message",
 			params: map[string]any{"name": prodName, "from": "red", "to": "green", "reasons": prodRecoverReasons},
-			link: environmentLink(prodEnvID), read: true,
+			link:   environmentLink(prodEnvID), read: true,
 		},
 		// Admin: same production degradation (multi-subscriber)
 		{
 			userID: org.user2ID, dedupKey: fmt.Sprintf("environment.change-status.%d", prodEnvID),
-			level: notify.LevelWarning,
+			level:    notify.LevelWarning,
 			titleKey: "notification.statusDegraded.title", messageKey: "notification.statusDegraded.message",
 			params: map[string]any{"name": prodName, "from": "green", "to": "yellow", "reasons": prodDegradeReasons},
-			link: environmentLink(prodEnvID), read: false,
+			link:   environmentLink(prodEnvID), read: false,
 		},
 		// Admin: open staging data-fetch failure
 		{
 			userID: org.user2ID, dedupKey: fmt.Sprintf("environment.not.updated_%d", stagingEnvID),
-			level: notify.LevelError,
+			level:    notify.LevelError,
 			titleKey: "notification.dataFetchError.title", messageKey: "notification.dataFetchError.message",
 			params: map[string]any{"name": stagingName},
-			link: environmentLink(stagingEnvID), read: false,
+			link:   environmentLink(stagingEnvID), read: false,
 		},
 		// Admin: open staging degradation
 		{
 			userID: org.user2ID, dedupKey: fmt.Sprintf("environment.change-status.%d", stagingEnvID),
-			level: notify.LevelWarning,
+			level:    notify.LevelWarning,
 			titleKey: "notification.statusDegraded.title", messageKey: "notification.statusDegraded.message",
 			params: map[string]any{"name": stagingName, "from": "green", "to": "yellow", "reasons": stagingDegradeReasons},
-			link: environmentLink(stagingEnvID), read: false,
+			link:   environmentLink(stagingEnvID), read: false,
 		},
 		// Member: open staging data-fetch failure
 		{
 			userID: org.user3ID, dedupKey: fmt.Sprintf("environment.not.updated_%d", stagingEnvID),
-			level: notify.LevelError,
+			level:    notify.LevelError,
 			titleKey: "notification.dataFetchError.title", messageKey: "notification.dataFetchError.message",
 			params: map[string]any{"name": stagingName},
-			link: environmentLink(stagingEnvID), read: false,
+			link:   environmentLink(stagingEnvID), read: false,
 		},
 		// Member: read recovery on staging
 		{
 			userID: org.user3ID, dedupKey: fmt.Sprintf("environment.recover-status.%d", stagingEnvID),
-			level: notify.LevelInfo,
+			level:    notify.LevelInfo,
 			titleKey: "notification.statusRecovered.title", messageKey: "notification.statusRecovered.message",
 			params: map[string]any{"name": stagingName, "from": "yellow", "to": "green"},
-			link: environmentLink(stagingEnvID), read: true,
+			link:   environmentLink(stagingEnvID), read: true,
 		},
 		// Owner: read auth error on production (credentials fixed)
 		{
 			userID: org.user1ID, dedupKey: fmt.Sprintf("environment.update-auth-error.%d", prodEnvID),
-			level: notify.LevelError,
+			level:    notify.LevelError,
 			titleKey: "notification.authError.title", messageKey: "notification.authError.message",
 			params: map[string]any{"name": prodName, "error": "401 Unauthorized"},
-			link: environmentLink(prodEnvID), read: true,
+			link:   environmentLink(prodEnvID), read: true,
 		},
 	}
 
@@ -508,7 +508,7 @@ func (s *seeder) seedDeployments(environmentID int32) []deploymentRef {
 	}
 
 	var deployments []deploymentRef
-	for i := 0; i < 8; i++ {
+	for i := range 8 {
 		hoursAgo := (7 * 24 * i) / 8
 		startDate := s.now.Add(-time.Duration(hoursAgo) * time.Hour)
 		execTime := rand.Float32()*120 + 5
@@ -615,7 +615,7 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 		// ── Older history: the extension versions chain forward into the entries
 		// below, so PayPal walks 4.3.0 → 6.0.0 across the whole timeline.
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "installed", "newVersion": "4.3.0", "active": true},
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "installed", "newVersion": "3.0.0", "active": true},
 				{"name": "SwagLanguagePack", "label": "Language Pack", "state": "installed", "newVersion": "2.0.0", "active": true},
@@ -623,7 +623,7 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 			date: s.now.Add(-34 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "4.3.0", "newVersion": "4.4.0", "active": true},
 			}),
 			oldShopwareVersion: &v640,
@@ -631,46 +631,46 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 			date:               s.now.Add(-30 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagLanguagePack", "label": "Language Pack", "state": "deactivated", "active": false},
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "updated", "oldVersion": "3.0.0", "newVersion": "3.1.0", "active": true},
 			}),
 			date: s.now.Add(-27 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagLanguagePack", "label": "Language Pack", "state": "removed", "oldVersion": "2.0.0", "active": false},
 			}),
 			date: s.now.Add(-24 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "4.4.0", "newVersion": "4.5.0", "active": true},
 				{"name": "SwagB2bPlatform", "label": "B2B Platform", "state": "installed", "newVersion": "1.2.0", "active": true},
 			}),
 			date: s.now.Add(-21 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagB2bPlatform", "label": "B2B Platform", "state": "updated", "oldVersion": "1.2.0", "newVersion": "1.3.0", "active": true},
 			}),
 			date: s.now.Add(-18 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "updated", "oldVersion": "3.1.0", "newVersion": "4.0.0", "active": true},
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "4.5.0", "newVersion": "4.6.0", "active": true},
 			}),
 			date: s.now.Add(-15 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagB2bPlatform", "label": "B2B Platform", "state": "deactivated", "active": false},
 			}),
 			date: s.now.Add(-12 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "4.6.0", "newVersion": "5.0.0", "active": true},
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "deactivated", "active": false},
 			}),
@@ -679,14 +679,14 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 			date:               s.now.Add(-9 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagB2bPlatform", "label": "B2B Platform", "state": "activated", "active": true},
 			}),
 			date: s.now.Add(-8 * 24 * time.Hour),
 		},
 		// ── Recent history (the original fixtures).
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "5.0.0", "newVersion": "5.1.0", "active": true},
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "activated", "active": true},
 			}),
@@ -695,14 +695,14 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 			date:               s.now.Add(-6 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "5.1.0", "newVersion": "5.2.0", "active": true},
 				{"name": "FroshTools", "label": "FroshTools", "state": "installed", "newVersion": "1.0.0", "active": true},
 			}),
 			date: s.now.Add(-4 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "SwagCmsExtensions", "label": "CMS Extensions", "state": "deactivated", "active": false},
 			}),
 			oldShopwareVersion: &v651,
@@ -710,7 +710,7 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 			date:               s.now.Add(-2 * 24 * time.Hour),
 		},
 		{
-			extensions: mustJSON([]map[string]interface{}{
+			extensions: mustJSON([]map[string]any{
 				{"name": "FroshTools", "label": "FroshTools", "state": "updated", "oldVersion": "1.0.0", "newVersion": "1.1.0", "active": true},
 				{"name": "SwagPayPal", "label": "PayPal", "state": "updated", "oldVersion": "5.2.0", "newVersion": "6.0.0", "active": true},
 			}),
@@ -735,7 +735,7 @@ func (s *seeder) seedChangelogs(environmentID int32) {
 	slog.Info("created changelog entries", "environmentId", environmentID, "count", count)
 }
 
-func mustJSON(v interface{}) json.RawMessage {
+func mustJSON(v any) json.RawMessage {
 	b, err := json.Marshal(v)
 	if err != nil {
 		panic(err)

--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/friendsofshopware/shopmon/api
 
-go 1.26.1
+go 1.27.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.43.5

--- a/api/internal/api/models.go
+++ b/api/internal/api/models.go
@@ -1056,7 +1056,7 @@ type EnvironmentCheck struct {
 	MessageKey *string `json:"messageKey,omitempty"`
 
 	// Params Structured params for interpolating messageKey.
-	Params *map[string]interface{} `json:"params,omitempty"`
+	Params *map[string]any `json:"params,omitempty"`
 }
 
 // EnvironmentDetail defines model for EnvironmentDetail.
@@ -1193,9 +1193,9 @@ type Notification struct {
 	MessageKey *string `json:"messageKey,omitempty"`
 
 	// Params Structured params for interpolating titleKey/messageKey.
-	Params *map[string]interface{} `json:"params,omitempty"`
-	Read   bool                    `json:"read"`
-	Title  string                  `json:"title"`
+	Params *map[string]any `json:"params,omitempty"`
+	Read   bool            `json:"read"`
+	Title  string          `json:"title"`
 
 	// TitleKey Translation key for the title; render with params client-side. Falls back to title.
 	TitleKey *string `json:"titleKey,omitempty"`
@@ -1354,10 +1354,10 @@ type StatusEvent struct {
 
 // StatusReason defines model for StatusReason.
 type StatusReason struct {
-	Level      string                  `json:"level"`
-	MessageKey string                  `json:"messageKey"`
-	Params     *map[string]interface{} `json:"params,omitempty"`
-	Source     *string                 `json:"source,omitempty"`
+	Level      string          `json:"level"`
+	MessageKey string          `json:"messageKey"`
+	Params     *map[string]any `json:"params,omitempty"`
+	Source     *string         `json:"source,omitempty"`
 }
 
 // SubscribedEnvironment defines model for SubscribedEnvironment.

--- a/api/internal/auth/admin_test.go
+++ b/api/internal/auth/admin_test.go
@@ -135,7 +135,7 @@ func TestAdminGetUserDetail(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var detail map[string]interface{}
+	var detail map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&detail))
 	assert.Equal(t, "regular@example.com", detail["email"])
 	// Sub-resources must be present (and never contain secrets).
@@ -299,14 +299,14 @@ func TestAdminImpersonate(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 
 	impersonationToken, ok := result["token"].(string)
 	require.True(t, ok)
 	assert.NotEmpty(t, impersonationToken)
 
-	session, ok := result["session"].(map[string]interface{})
+	session, ok := result["session"].(map[string]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, session["token"])
 	assert.NotEmpty(t, session["impersonatedBy"])
@@ -320,13 +320,13 @@ func TestAdminImpersonate(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 
-	var sessionResp map[string]interface{}
+	var sessionResp map[string]any
 	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&sessionResp))
-	user := sessionResp["user"].(map[string]interface{})
+	user := sessionResp["user"].(map[string]any)
 	assert.Equal(t, "user@example.com", user["email"])
 
 	// Banner visibility depends on session.impersonatedBy being present
-	sessionInfo, ok := sessionResp["session"].(map[string]interface{})
+	sessionInfo, ok := sessionResp["session"].(map[string]any)
 	require.True(t, ok)
 	assert.NotEmpty(t, sessionInfo["impersonatedBy"])
 }

--- a/api/internal/auth/credentials_test.go
+++ b/api/internal/auth/credentials_test.go
@@ -26,10 +26,10 @@ func TestSignUpEmail(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 
-	user := result["user"].(map[string]interface{})
+	user := result["user"].(map[string]any)
 	assert.Equal(t, "New User", user["name"])
 	assert.Equal(t, "new@example.com", user["email"])
 	assert.NotEmpty(t, user["id"])
@@ -104,9 +104,9 @@ func TestSignInEmail(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-	user := result["user"].(map[string]interface{})
+	user := result["user"].(map[string]any)
 	assert.Equal(t, "Login User", user["name"])
 	assert.Equal(t, "login@example.com", user["email"])
 
@@ -210,7 +210,7 @@ func TestGetSession(t *testing.T) {
 	resp, err := testutil.Post(t, env.Server.URL+"/api/auth/sign-up/email", "application/json", bytes.NewReader(body))
 	require.NoError(t, err)
 
-	var signUpResult map[string]interface{}
+	var signUpResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&signUpResult))
 	_ = resp.Body.Close()
 	token := signUpResult["token"].(string)
@@ -226,9 +226,9 @@ func TestGetSession(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
-	user := result["user"].(map[string]interface{})
+	user := result["user"].(map[string]any)
 	assert.Equal(t, "Session User", user["name"])
 	assert.Equal(t, "session@example.com", user["email"])
 	assert.NotNil(t, result["session"])
@@ -252,7 +252,7 @@ func TestGetSession_ExpiredBan(t *testing.T) {
 	resp, err := testutil.Post(t, env.Server.URL+"/api/auth/sign-up/email", "application/json", bytes.NewReader(body))
 	require.NoError(t, err)
 
-	var signUpResult map[string]interface{}
+	var signUpResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&signUpResult))
 	_ = resp.Body.Close()
 	token := signUpResult["token"].(string)
@@ -284,7 +284,7 @@ func TestSignOut(t *testing.T) {
 	resp, err := testutil.Post(t, env.Server.URL+"/api/auth/sign-up/email", "application/json", bytes.NewReader(body))
 	require.NoError(t, err)
 
-	var signUpResult map[string]interface{}
+	var signUpResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&signUpResult))
 	_ = resp.Body.Close()
 	token := signUpResult["token"].(string)

--- a/api/internal/auth/github_test.go
+++ b/api/internal/auth/github_test.go
@@ -142,10 +142,10 @@ type mockGithub struct {
 	// response omits access_token (simulating an exchange failure).
 	accessToken string
 	// user is the JSON object returned by GET /user.
-	user map[string]interface{}
+	user map[string]any
 	// emails is the JSON array returned by GET /user/emails (the fallback used
 	// when the user has no public email).
-	emails []map[string]interface{}
+	emails []map[string]any
 }
 
 func newMockGithub(t *testing.T) *mockGithub {
@@ -228,7 +228,7 @@ func githubCallback(t *testing.T, serverURL, code, state string) *http.Response 
 func TestGithubCallback_HappyPath(t *testing.T) {
 	mock := newMockGithub(t)
 	defer mock.server.Close()
-	mock.user = map[string]interface{}{
+	mock.user = map[string]any{
 		"id":         12345,
 		"login":      "octocat",
 		"name":       "The Octocat",
@@ -275,14 +275,14 @@ func TestGithubCallback_HappyPath(t *testing.T) {
 func TestGithubCallback_EmailFallback(t *testing.T) {
 	mock := newMockGithub(t)
 	defer mock.server.Close()
-	mock.user = map[string]interface{}{
+	mock.user = map[string]any{
 		"id":         67890,
 		"login":      "hubot",
 		"name":       "Hubot",
 		"email":      "", // no public email
 		"avatar_url": "",
 	}
-	mock.emails = []map[string]interface{}{
+	mock.emails = []map[string]any{
 		{"email": "noreply@github.com", "primary": false, "verified": true},
 		{"email": "hubot@github.com", "primary": true, "verified": true},
 	}
@@ -329,7 +329,7 @@ func TestGithubCallback_NoAccessToken(t *testing.T) {
 func TestGithubCallback_LinksExistingUser(t *testing.T) {
 	mock := newMockGithub(t)
 	defer mock.server.Close()
-	mock.user = map[string]interface{}{
+	mock.user = map[string]any{
 		"id":         24680,
 		"login":      "existing",
 		"name":       "Existing User",

--- a/api/internal/auth/handler.go
+++ b/api/internal/auth/handler.go
@@ -35,8 +35,8 @@ type AuthHandler struct {
 }
 
 type StateStore interface {
-	Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error
-	Get(ctx context.Context, key string, destination interface{}) error
+	Set(ctx context.Context, key string, value any, ttl time.Duration) error
+	Get(ctx context.Context, key string, destination any) error
 }
 
 type HandlerConfig struct {

--- a/api/internal/auth/jwks.go
+++ b/api/internal/auth/jwks.go
@@ -11,11 +11,11 @@ import (
 // ssoClaims holds the OIDC ID token claims we read beyond the standard ones
 // (sub/iss/aud/exp/iat) that go-oidc validates and exposes on *oidc.IDToken.
 type ssoClaims struct {
-	Email         string      `json:"email"`
-	EmailVerified interface{} `json:"email_verified"`
-	Name          string      `json:"name"`
-	Picture       string      `json:"picture"`
-	Nonce         string      `json:"nonce"`
+	Email         string `json:"email"`
+	EmailVerified any    `json:"email_verified"`
+	Name          string `json:"name"`
+	Picture       string `json:"picture"`
+	Nonce         string `json:"nonce"`
 }
 
 // verifyIDToken verifies an OIDC ID token's RS256 signature against the

--- a/api/internal/auth/organization_test.go
+++ b/api/internal/auth/organization_test.go
@@ -23,7 +23,7 @@ func signUp(t *testing.T, serverURL, email, password, name string) string {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 	token, ok := result["token"].(string)
 	require.True(t, ok, "response must contain a token string")
@@ -32,7 +32,7 @@ func signUp(t *testing.T, serverURL, email, password, name string) string {
 }
 
 // authRequest performs an authenticated HTTP request with a JSON body.
-func authRequest(t *testing.T, method, url string, token string, body interface{}) *http.Response {
+func authRequest(t *testing.T, method, url string, token string, body any) *http.Response {
 	t.Helper()
 	var reqBody *bytes.Reader
 	if body != nil {
@@ -50,7 +50,7 @@ func authRequest(t *testing.T, method, url string, token string, body interface{
 }
 
 // authPost performs an authenticated POST request with a JSON body.
-func authPost(t *testing.T, serverURL, path string, token string, body interface{}) *http.Response {
+func authPost(t *testing.T, serverURL, path string, token string, body any) *http.Response {
 	t.Helper()
 	return authRequest(t, "POST", serverURL+path, token, body)
 }
@@ -62,7 +62,7 @@ func authGet(t *testing.T, serverURL, path string, token string) *http.Response 
 }
 
 // authPatch performs an authenticated PATCH request with a JSON body.
-func authPatch(t *testing.T, serverURL, path string, token string, body interface{}) *http.Response {
+func authPatch(t *testing.T, serverURL, path string, token string, body any) *http.Response {
 	t.Helper()
 	return authRequest(t, "PATCH", serverURL+path, token, body)
 }
@@ -74,15 +74,15 @@ func authDelete(t *testing.T, serverURL, path string, token string) *http.Respon
 }
 
 // decodeJSON decodes the response body into a generic map.
-func decodeJSON(t *testing.T, resp *http.Response) map[string]interface{} {
+func decodeJSON(t *testing.T, resp *http.Response) map[string]any {
 	t.Helper()
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 	return result
 }
 
 // createOrg is a helper that creates an organization and returns the parsed response.
-func createOrg(t *testing.T, serverURL string, cookie string, name string) map[string]interface{} {
+func createOrg(t *testing.T, serverURL string, cookie string, name string) map[string]any {
 	t.Helper()
 	resp := authPost(t, serverURL, "/api/auth/organizations", cookie, map[string]string{"name": name})
 	defer func() { _ = resp.Body.Close() }()
@@ -142,7 +142,7 @@ func TestOrgUpdate(t *testing.T) {
 	orgID := org["id"].(string)
 
 	newName := "Updated Name"
-	resp := authPatch(t, env.Server.URL, fmt.Sprintf("/api/auth/organizations/%s", orgID), cookie, map[string]interface{}{
+	resp := authPatch(t, env.Server.URL, fmt.Sprintf("/api/auth/organizations/%s", orgID), cookie, map[string]any{
 		"name": newName,
 	})
 	defer func() { _ = resp.Body.Close() }()
@@ -199,7 +199,7 @@ func TestOrgInviteAndAccept(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&members))
 	assert.Len(t, members, 2)
 }
@@ -232,7 +232,7 @@ func TestOrgInviteAndReject(t *testing.T) {
 	defer func() { _ = resp3.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp3.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&members))
 	assert.Len(t, members, 1) // only the owner
 }
@@ -252,7 +252,7 @@ func TestOrgRemoveMember(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&members))
 	require.Len(t, members, 2)
 
@@ -276,7 +276,7 @@ func TestOrgRemoveMember(t *testing.T) {
 	defer func() { _ = resp3.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp3.StatusCode)
 
-	var remaining []map[string]interface{}
+	var remaining []map[string]any
 	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&remaining))
 	assert.Len(t, remaining, 1)
 }
@@ -301,7 +301,7 @@ func TestOrgLeave(t *testing.T) {
 	defer func() { _ = resp2.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp2.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp2.Body).Decode(&members))
 	assert.Len(t, members, 1)
 	assert.Equal(t, "owner", members[0]["role"])
@@ -335,7 +335,7 @@ func TestOrgSetRole(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&members))
 
 	var memberUserID string
@@ -359,7 +359,7 @@ func TestOrgSetRole(t *testing.T) {
 	defer func() { _ = resp3.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp3.StatusCode)
 
-	var updated []map[string]interface{}
+	var updated []map[string]any
 	require.NoError(t, json.NewDecoder(resp3.Body).Decode(&updated))
 
 	for _, m := range updated {
@@ -381,7 +381,7 @@ func TestOrgListMembers(t *testing.T) {
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var members []map[string]interface{}
+	var members []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&members))
 	require.Len(t, members, 1)
 	assert.Equal(t, "owner", members[0]["role"])

--- a/api/internal/auth/passkey_test.go
+++ b/api/internal/auth/passkey_test.go
@@ -98,7 +98,7 @@ func TestPasskeyFullRegistrationAndLogin(t *testing.T) {
 	attResponse := virtualwebauthn.CreateAttestationResponse(rp, authenticator, credential, *attOpts)
 
 	// Merge challengeKey and name into the attestation response
-	var attJSON map[string]interface{}
+	var attJSON map[string]any
 	require.NoError(t, json.Unmarshal([]byte(attResponse), &attJSON))
 	attJSON["challengeKey"] = regOptions.ChallengeKey
 	attJSON["name"] = "My Test Passkey"
@@ -118,7 +118,7 @@ func TestPasskeyFullRegistrationAndLogin(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "register failed: body=%s", string(body))
 	}
 
-	var regResult map[string]interface{}
+	var regResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&regResult))
 	assert.NotEmpty(t, regResult["id"])
 	assert.Equal(t, "My Test Passkey", regResult["name"])
@@ -153,7 +153,7 @@ func TestPasskeyFullRegistrationAndLogin(t *testing.T) {
 	assResponse := virtualwebauthn.CreateAssertionResponse(rp, authenticator, credential, *assOpts)
 
 	// Merge challengeKey into assertion
-	var assJSON map[string]interface{}
+	var assJSON map[string]any
 	require.NoError(t, json.Unmarshal([]byte(assResponse), &assJSON))
 	assJSON["challengeKey"] = loginOptions.ChallengeKey
 	loginBody, _ := json.Marshal(assJSON)
@@ -168,9 +168,9 @@ func TestPasskeyFullRegistrationAndLogin(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "login failed: body=%s", string(body))
 	}
 
-	var loginResult map[string]interface{}
+	var loginResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&loginResult))
-	user, ok := loginResult["user"].(map[string]interface{})
+	user, ok := loginResult["user"].(map[string]any)
 	require.True(t, ok, "response must contain user object, got: %v", loginResult)
 	assert.Equal(t, "passkey@example.com", user["email"])
 	assert.Equal(t, "Passkey User", user["name"])
@@ -259,7 +259,7 @@ func TestPasskeyLoginLegacyBetterAuth(t *testing.T) {
 			require.NoError(t, err)
 			attResponse := virtualwebauthn.CreateAttestationResponse(rp, authenticator, credential, *attOpts)
 
-			var attJSON map[string]interface{}
+			var attJSON map[string]any
 			require.NoError(t, json.Unmarshal([]byte(attResponse), &attJSON))
 			attJSON["challengeKey"] = regOptions.ChallengeKey
 			attJSON["name"] = "Legacy Passkey"
@@ -324,7 +324,7 @@ func TestPasskeyLoginLegacyBetterAuth(t *testing.T) {
 			require.NoError(t, err)
 			assResponse := virtualwebauthn.CreateAssertionResponse(rp, authenticator, credential, *assOpts)
 
-			var assJSON map[string]interface{}
+			var assJSON map[string]any
 			require.NoError(t, json.Unmarshal([]byte(assResponse), &assJSON))
 			assJSON["challengeKey"] = loginOptions.ChallengeKey
 			loginBody, _ := json.Marshal(assJSON)
@@ -338,9 +338,9 @@ func TestPasskeyLoginLegacyBetterAuth(t *testing.T) {
 				require.Equal(t, http.StatusOK, resp.StatusCode, "legacy login failed: body=%s", string(body))
 			}
 
-			var loginResult map[string]interface{}
+			var loginResult map[string]any
 			require.NoError(t, json.NewDecoder(resp.Body).Decode(&loginResult))
-			user, ok := loginResult["user"].(map[string]interface{})
+			user, ok := loginResult["user"].(map[string]any)
 			require.True(t, ok, "response must contain user object, got: %v", loginResult)
 			assert.Equal(t, "legacy@example.com", user["email"])
 		})
@@ -413,7 +413,7 @@ func TestPasskeyRegisterMultiple(t *testing.T) {
 		attOpts, _ := virtualwebauthn.ParseAttestationOptions(string(opts.Options))
 		attResp := virtualwebauthn.CreateAttestationResponse(rp, authenticator, cred, *attOpts)
 
-		var attJSON map[string]interface{}
+		var attJSON map[string]any
 		require.NoError(t, json.Unmarshal([]byte(attResp), &attJSON))
 		attJSON["challengeKey"] = opts.ChallengeKey
 		attJSON["name"] = name

--- a/api/internal/auth/sso.go
+++ b/api/internal/auth/sso.go
@@ -18,7 +18,7 @@ import (
 
 // isTrue interprets an OIDC claim value (which may be a bool or a string) as a
 // boolean. OIDC providers sometimes encode email_verified as the string "true".
-func isTrue(v interface{}) bool {
+func isTrue(v any) bool {
 	switch val := v.(type) {
 	case bool:
 		return val
@@ -290,11 +290,11 @@ func (h *AuthHandler) SsoCallback(ctx context.Context, input *ssoCallbackInput) 
 }
 
 type userInfoResponse struct {
-	Sub           string      `json:"sub"`
-	Email         string      `json:"email"`
-	EmailVerified interface{} `json:"email_verified"`
-	Name          string      `json:"name"`
-	Picture       string      `json:"picture"`
+	Sub           string `json:"sub"`
+	Email         string `json:"email"`
+	EmailVerified any    `json:"email_verified"`
+	Name          string `json:"name"`
+	Picture       string `json:"picture"`
 }
 
 func (h *AuthHandler) fetchUserInfo(ctx context.Context, accessToken, issuer string) (*userInfoResponse, error) {

--- a/api/internal/auth/sso_test.go
+++ b/api/internal/auth/sso_test.go
@@ -41,9 +41,9 @@ type mockOIDC struct {
 }
 
 // jwkFromPublicKey encodes an RSA public key as a JWK for the JWKS endpoint.
-func jwkFromPublicKey(pub *rsa.PublicKey, kid string) map[string]interface{} {
+func jwkFromPublicKey(pub *rsa.PublicKey, kid string) map[string]any {
 	eBytes := big.NewInt(int64(pub.E)).Bytes()
-	return map[string]interface{}{
+	return map[string]any{
 		"kty": "RSA",
 		"use": "sig",
 		"alg": "RS256",
@@ -65,7 +65,7 @@ func mockOIDCProvider(t *testing.T) *mockOIDC {
 		switch r.URL.Path {
 		case "/.well-known/openid-configuration":
 			baseURL := "http://" + r.Host
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"issuer":                 baseURL,
 				"authorization_endpoint": baseURL + "/authorize",
 				"token_endpoint":         baseURL + "/token",
@@ -75,8 +75,8 @@ func mockOIDCProvider(t *testing.T) *mockOIDC {
 			})
 
 		case "/jwks":
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"keys": []interface{}{jwkFromPublicKey(&privateKey.PublicKey, "test-key")},
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"keys": []any{jwkFromPublicKey(&privateKey.PublicKey, "test-key")},
 			})
 
 		case "/token":
@@ -121,7 +121,7 @@ func mockOIDCProvider(t *testing.T) *mockOIDC {
 			if uiSub == "" {
 				uiSub = "sso-user-123"
 			}
-			ui := map[string]interface{}{
+			ui := map[string]any{
 				"sub":   uiSub,
 				"email": "ssouser@testcorp.com",
 				"name":  "SSO User",
@@ -183,7 +183,7 @@ func createOrgWithSSO(t *testing.T, env *testutil.TestEnv, idpURL string) (orgID
 	resp := authPost(t, env.Server.URL, "/api/auth/organizations", ownerCookie, map[string]string{
 		"name": "Test Corp",
 	})
-	var orgResult map[string]interface{}
+	var orgResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&orgResult))
 	_ = resp.Body.Close()
 	orgID = orgResult["id"].(string)
@@ -289,9 +289,9 @@ func TestSSOCallback(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var sessionResult map[string]interface{}
+	var sessionResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&sessionResult))
-	user := sessionResult["user"].(map[string]interface{})
+	user := sessionResult["user"].(map[string]any)
 	assert.Equal(t, "ssouser@testcorp.com", user["email"])
 	assert.Equal(t, "SSO User", user["name"])
 }
@@ -379,10 +379,10 @@ func TestSSOCallback_ExistingUserLinksAccount(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+ssoToken)
 	resp, _ = http.DefaultClient.Do(req)
 
-	var sessionResult map[string]interface{}
+	var sessionResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&sessionResult))
 	_ = resp.Body.Close()
-	user := sessionResult["user"].(map[string]interface{})
+	user := sessionResult["user"].(map[string]any)
 	assert.Equal(t, "ssouser@testcorp.com", user["email"])
 
 	var userCount int
@@ -624,7 +624,7 @@ func TestSSOCallback_RejectsInsecureStoredEndpoint(t *testing.T) {
 	resp := authPost(t, env.Server.URL, "/api/auth/organizations", ownerCookie, map[string]string{
 		"name": "Test Corp",
 	})
-	var orgResult map[string]interface{}
+	var orgResult map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&orgResult))
 	_ = resp.Body.Close()
 	orgID := orgResult["id"].(string)

--- a/api/internal/catalog/advisory/github.go
+++ b/api/internal/catalog/advisory/github.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -257,13 +258,7 @@ func (c *githubClient) fetchAdvisoryURL(ctx context.Context, ghsaID, endpoint st
 	details.References = append(details.References, raw.References...)
 	if details.HTMLURL != "" {
 		// Prefer GHSA page as a stable first reference.
-		found := false
-		for _, r := range details.References {
-			if r == details.HTMLURL {
-				found = true
-				break
-			}
-		}
+		found := slices.Contains(details.References, details.HTMLURL)
 		if !found {
 			details.References = append([]string{details.HTMLURL}, details.References...)
 		}

--- a/api/internal/catalog/advisory/packagist.go
+++ b/api/internal/catalog/advisory/packagist.go
@@ -127,10 +127,7 @@ func (c *packagistClient) advisoriesForPackages(ctx context.Context, packages []
 
 	result := repository.Advisories{}
 	for i := 0; i < len(packages); i += packageBatchSize {
-		end := i + packageBatchSize
-		if end > len(packages) {
-			end = len(packages)
-		}
+		end := min(i+packageBatchSize, len(packages))
 		batch := packages[i:end]
 
 		part, err := c.repo.GetSecurityAdvisories(ctx, batch)

--- a/api/internal/catalog/advisory/service.go
+++ b/api/internal/catalog/advisory/service.go
@@ -113,7 +113,7 @@ func (s *Service) Sync(ctx context.Context) error {
 			LastUpdatedSince:      state.LastUpdatedSince,
 			LastFullSyncAt:        state.LastFullSyncAt,
 			LastIncrementalSyncAt: state.LastIncrementalSyncAt,
-			LastError:             ptrString(err.Error()),
+			LastError:             new(err.Error()),
 		})
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -252,15 +252,15 @@ func (s *Service) upsertOne(ctx context.Context, adv repository.SecurityAdvisory
 	}
 	var link *string
 	if strings.TrimSpace(adv.Link) != "" {
-		link = ptrString(strings.TrimSpace(adv.Link))
+		link = new(strings.TrimSpace(adv.Link))
 	}
 	var severity *string
 	if strings.TrimSpace(adv.Severity) != "" {
-		severity = ptrString(strings.ToLower(strings.TrimSpace(adv.Severity)))
+		severity = new(strings.ToLower(strings.TrimSpace(adv.Severity)))
 	}
 	var repo *string
 	if strings.TrimSpace(adv.ComposerRepository) != "" {
-		repo = ptrString(strings.TrimSpace(adv.ComposerRepository))
+		repo = new(strings.TrimSpace(adv.ComposerRepository))
 	}
 
 	affected := adv.AffectedVersions
@@ -448,7 +448,7 @@ func (s *Service) applyDetailsByCVE(ctx context.Context, cveID string, details *
 		CvssVector:         details.CVSSVector,
 		Cwes:               cwesJSON,
 		ExternalReferences: refsJSON,
-		DetailsSource:      ptrString(source),
+		DetailsSource:      new(source),
 	}); err != nil {
 		return fmt.Errorf("update details for %s: %w", cveID, err)
 	}
@@ -470,7 +470,7 @@ func (s *Service) applyDetailsByGHSA(ctx context.Context, ghsaID string, details
 			CvssVector:         details.CVSSVector,
 			Cwes:               cwesJSON,
 			ExternalReferences: refsJSON,
-			DetailsSource:      ptrString(source),
+			DetailsSource:      new(source),
 		}); err != nil {
 			return fmt.Errorf("update details for %s: %w", ghsaID, err)
 		}
@@ -557,8 +557,4 @@ func mergePackageNames(base, extra []string) []string {
 	add(base)
 	add(extra)
 	return out
-}
-
-func ptrString(s string) *string {
-	return &s
 }

--- a/api/internal/catalog/advisory/service_test.go
+++ b/api/internal/catalog/advisory/service_test.go
@@ -137,7 +137,7 @@ func TestSyncCollapsesPackagesUnderCVE(t *testing.T) {
 		NotesPublic:        &notes,
 		AffectedComponents: []string{},
 		Tags:               []string{"ssrf"},
-		EnrichedBy:         ptr("admin"),
+		EnrichedBy:         new("admin"),
 	})
 	require.NoError(t, err)
 	require.NoError(t, svc.Sync(ctx))
@@ -148,8 +148,6 @@ func TestSyncCollapsesPackagesUnderCVE(t *testing.T) {
 	assert.Equal(t, notes, *row.NotesPublic)
 	assert.Equal(t, []string{"ssrf"}, row.Tags)
 }
-
-func ptr(s string) *string { return &s }
 
 // A Packagist outage must not hold back alerts for matches that scrapes have
 // already stored. The scrape path records match rows but never notifies —

--- a/api/internal/catalog/sync/service.go
+++ b/api/internal/catalog/sync/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/friendsofshopware/shopmon/api/internal/catalog/storemodel"
@@ -320,13 +321,7 @@ func (h *Service) shopwareVersionsToProbe(ctx context.Context, shopwareVersion s
 	if err != nil {
 		return nil, fmt.Errorf("get distinct shopware versions: %w", err)
 	}
-	found := false
-	for _, v := range swvs {
-		if v == shopwareVersion {
-			found = true
-			break
-		}
-	}
+	found := slices.Contains(swvs, shopwareVersion)
 	if !found && shopwareVersion != "" {
 		swvs = append(swvs, shopwareVersion)
 	}

--- a/api/internal/database/span_name.go
+++ b/api/internal/database/span_name.go
@@ -13,7 +13,7 @@ const sqlOperationUnknown = "UNKNOWN"
 // collapses Datadog resources to `query --`. Prefer the sqlc query name when
 // present; otherwise fall back to the first SQL keyword.
 func SQLSpanName(stmt string) string {
-	for _, line := range strings.Split(stmt, "\n") {
+	for line := range strings.SplitSeq(stmt, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -51,7 +51,7 @@ func sqlcQueryName(line string) (string, bool) {
 }
 
 func firstSQLKeyword(line string) string {
-	for _, field := range strings.Fields(line) {
+	for field := range strings.FieldsSeq(line) {
 		return strings.ToUpper(field)
 	}
 	return sqlOperationUnknown

--- a/api/internal/deployment/s3output/store.go
+++ b/api/internal/deployment/s3output/store.go
@@ -40,16 +40,13 @@ func isNotFound(err error) bool {
 	if err == nil {
 		return false
 	}
-	var noSuchKey *types.NoSuchKey
-	if errors.As(err, &noSuchKey) {
+	if _, ok := errors.AsType[*types.NoSuchKey](err); ok {
 		return true
 	}
-	var notFound *types.NotFound
-	if errors.As(err, &notFound) {
+	if _, ok := errors.AsType[*types.NotFound](err); ok {
 		return true
 	}
-	var apiError smithy.APIError
-	if errors.As(err, &apiError) {
+	if apiError, ok := errors.AsType[smithy.APIError](err); ok {
 		switch apiError.ErrorCode() {
 		case "NoSuchKey", "NotFound", "404":
 			return true

--- a/api/internal/deployment/service.go
+++ b/api/internal/deployment/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -379,12 +380,7 @@ func (s *Service) authorizeShop(ctx context.Context, cmd ShopCommand) error {
 }
 
 func containsScope(scopes []string, expected string) bool {
-	for _, scope := range scopes {
-		if scope == expected {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(scopes, expected)
 }
 
 // HashAPIKeyToken returns the SHA-256 hex digest stored for a plaintext API key.

--- a/api/internal/handler/advisory_test.go
+++ b/api/internal/handler/advisory_test.go
@@ -22,10 +22,10 @@ func seedAdvisory(t *testing.T, q *queries.Queries, id string, packages []string
 	require.NoError(t, q.UpsertComposerAdvisory(ctx, queries.UpsertComposerAdvisoryParams{
 		AdvisoryID: id,
 		Title:      "Seeded advisory " + id,
-		Link:       ptrStr("https://example.com/" + id),
-		Cve:        ptrStr(id),
-		GhsaID:     ptrStr("GHSA-" + id),
-		Severity:   ptrStr("medium"),
+		Link:       new("https://example.com/" + id),
+		Cve:        new(id),
+		GhsaID:     new("GHSA-" + id),
+		Severity:   new("medium"),
 		Sources:    []byte(`[{"name":"GitHub","remoteId":"GHSA-` + id + `"}]`),
 		ReportedAt: pgtype.Timestamp{Time: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC), Valid: true},
 	}))
@@ -44,18 +44,16 @@ func seedAdvisory(t *testing.T, q *queries.Queries, id string, packages []string
 			NotesInternal:      notesInternal,
 			AffectedComponents: []string{},
 			Tags:               []string{"seed"},
-			EnrichedBy:         ptrStr("test"),
+			EnrichedBy:         new("test"),
 		})
 		require.NoError(t, err)
 	}
 }
 
-func ptrStr(s string) *string { return &s }
-
 func TestListAdvisoriesHidesInvisibleAndInternalNotes(t *testing.T) {
 	env := testutil.Setup(t)
-	seedAdvisory(t, env.Queries, "CVE-VISIBLE", []string{"shopware/core", "shopware/platform"}, true, ptrStr("secret-internal"))
-	seedAdvisory(t, env.Queries, "CVE-HIDDEN", []string{"shopware/core"}, false, ptrStr("hidden-internal"))
+	seedAdvisory(t, env.Queries, "CVE-VISIBLE", []string{"shopware/core", "shopware/platform"}, true, new("secret-internal"))
+	seedAdvisory(t, env.Queries, "CVE-HIDDEN", []string{"shopware/core"}, false, new("hidden-internal"))
 
 	token := env.SeedUser(t, "user-1", "Regular User", "user@example.com", "user")
 

--- a/api/internal/handler/api_key.go
+++ b/api/internal/handler/api_key.go
@@ -97,13 +97,11 @@ func (h *Handler) CreateApiKey(ctx context.Context, input *createApiKeyInput) (*
 		return nil, err
 	}
 	key, err := h.deployments.CreateAPIKey(ctx, deployment.CreateAPIKeyCommand{
-		ShopCommand: deployment.ShopCommand{
-			UserID:         user.ID,
-			OrganizationID: input.OrgID,
-			ShopID:         int32(input.ShopID),
-		},
-		Name:   input.Body.Name,
-		Scopes: input.Body.Scopes,
+		UserID:         user.ID,
+		OrganizationID: input.OrgID,
+		ShopID:         int32(input.ShopID),
+		Name:           input.Body.Name,
+		Scopes:         input.Body.Scopes,
 	})
 	if err != nil {
 		return nil, h.writeDeploymentError(ctx, "create api key", err)

--- a/api/internal/handler/environment_test.go
+++ b/api/internal/handler/environment_test.go
@@ -106,7 +106,7 @@ func TestGetEnvironment_NotMember(t *testing.T) {
 // first, so that the newest entry is the last one inserted.
 func seedChangelogs(t *testing.T, env *testutil.TestEnv, environmentID, count int) {
 	t.Helper()
-	for i := 0; i < count; i++ {
+	for i := range count {
 		extensions := fmt.Sprintf(
 			`[{"name":"SwagPayPal","label":"PayPal","state":"updated","oldVersion":"1.%d.0","newVersion":"1.%d.0","active":true}]`,
 			i, i+1,
@@ -191,7 +191,7 @@ func TestGetEnvironmentChangelogs_IdenticalDatesPaginateWithoutOverlap(t *testin
 	shopID := env.SeedShop(t, "org-1", "Test Shop")
 	environmentID := env.SeedEnvironment(t, "org-1", shopID, "My Environment", "https://env.example.com")
 
-	for i := 0; i < 15; i++ {
+	for range 15 {
 		_, err := env.Pool.Exec(t.Context(),
 			`INSERT INTO environment_changelog (environment_id, extensions, date)
 			 VALUES ($1, '[]'::jsonb, '2026-01-01 12:00:00')`, environmentID)

--- a/api/internal/handler/notification.go
+++ b/api/internal/handler/notification.go
@@ -49,7 +49,7 @@ func (h *Handler) GetNotifications(ctx context.Context, _ *struct{}) (*getNotifi
 		}
 
 		if len(row.Params) > 0 {
-			params := map[string]interface{}(row.Params)
+			params := map[string]any(row.Params)
 			if len(params) > 0 {
 				n.Params = &params
 			}

--- a/api/internal/handler/packages_token.go
+++ b/api/internal/handler/packages_token.go
@@ -127,12 +127,10 @@ func (h *Handler) CreatePackagesToken(ctx context.Context, input *createPackages
 	}
 
 	if err := h.packages.Create(ctx, packagesmirror.CreateCommand{
-		ShopCommand: packagesmirror.ShopCommand{
-			UserID:         user.ID,
-			OrganizationID: input.OrgID,
-			ShopID:         int32(input.ShopID),
-		},
-		Token: input.Body.Token,
+		UserID:         user.ID,
+		OrganizationID: input.OrgID,
+		ShopID:         int32(input.ShopID),
+		Token:          input.Body.Token,
 	}); err != nil {
 		return nil, h.writePackagesError(ctx, "create packages token", err)
 	}
@@ -148,12 +146,10 @@ func (h *Handler) DeletePackagesToken(ctx context.Context, input *deletePackages
 	}
 
 	if err := h.packages.Delete(ctx, packagesmirror.TokenCommand{
-		ShopCommand: packagesmirror.ShopCommand{
-			UserID:         user.ID,
-			OrganizationID: input.OrgID,
-			ShopID:         int32(input.ShopID),
-		},
-		TokenID: int(input.TokenID),
+		UserID:         user.ID,
+		OrganizationID: input.OrgID,
+		ShopID:         int32(input.ShopID),
+		TokenID:        int(input.TokenID),
 	}); err != nil {
 		return nil, h.writePackagesError(ctx, "delete packages token", err)
 	}
@@ -169,12 +165,10 @@ func (h *Handler) SyncPackagesToken(ctx context.Context, input *syncPackagesToke
 	}
 
 	if err := h.packages.Sync(ctx, packagesmirror.TokenCommand{
-		ShopCommand: packagesmirror.ShopCommand{
-			UserID:         user.ID,
-			OrganizationID: input.OrgID,
-			ShopID:         int32(input.ShopID),
-		},
-		TokenID: int(input.TokenID),
+		UserID:         user.ID,
+		OrganizationID: input.OrgID,
+		ShopID:         int32(input.ShopID),
+		TokenID:        int(input.TokenID),
 	}); err != nil {
 		return nil, h.writePackagesError(ctx, "sync packages token", err)
 	}
@@ -197,8 +191,7 @@ func (h *Handler) writePackagesError(ctx context.Context, operation string, err 
 	case errors.Is(err, packagesmirror.ErrTokenRequired):
 		return huma.Error400BadRequest("token is required")
 	default:
-		var remoteError *packagesmirror.RemoteError
-		if errors.As(err, &remoteError) {
+		if remoteError, ok := errors.AsType[*packagesmirror.RemoteError](err); ok {
 			return newPackagesRemoteError(remoteError)
 		}
 		slog.ErrorContext(ctx, "packages operation failed", "operation", operation, "error", err)

--- a/api/internal/handler/packages_token_test.go
+++ b/api/internal/handler/packages_token_test.go
@@ -83,7 +83,7 @@ func TestGetPackagesTokens_WithMockAPI(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("shopmon-project-%d", shopID), r.URL.Query().Get("source"))
 
 		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode([]map[string]interface{}{
+		_ = json.NewEncoder(w).Encode([]map[string]any{
 			{"id": 1, "source": "shopware", "lastSyncedAt": 1700000000},
 			{"id": 2, "source": "custom", "lastSyncedAt": nil},
 		})
@@ -108,7 +108,7 @@ func TestGetPackagesTokens_WithMockAPI(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 
-	var tokens []map[string]interface{}
+	var tokens []map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&tokens))
 	assert.Len(t, tokens, 2)
 }
@@ -127,7 +127,7 @@ func TestCreatePackagesToken_WithMockAPI(t *testing.T) {
 
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"id":           3,
 			"source":       "shopware",
 			"lastSyncedAt": nil,
@@ -162,7 +162,7 @@ func TestDeletePackagesToken_WithMockAPI(t *testing.T) {
 		if r.Method == "GET" {
 			assert.Equal(t, "/api/tokens", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{"id": 42, "source": r.URL.Query().Get("source")}})
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 42, "source": r.URL.Query().Get("source")}})
 			return
 		}
 		assert.Equal(t, "DELETE", r.Method)
@@ -195,7 +195,7 @@ func TestDeletePackagesToken_CrossShopForbidden(t *testing.T) {
 		// Ownership check returns no tokens for this shop; the DELETE must never fire.
 		if r.Method == "GET" {
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{})
+			_ = json.NewEncoder(w).Encode([]map[string]any{})
 			return
 		}
 		assert.Fail(t, "must not proxy a mutation for a token not owned by the shop")
@@ -227,7 +227,7 @@ func TestSyncPackagesToken_WithMockAPI(t *testing.T) {
 		if r.Method == "GET" {
 			assert.Equal(t, "/api/tokens", r.URL.Path)
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode([]map[string]interface{}{{"id": 42, "source": r.URL.Query().Get("source")}})
+			_ = json.NewEncoder(w).Encode([]map[string]any{{"id": 42, "source": r.URL.Query().Get("source")}})
 			return
 		}
 		assert.Equal(t, "POST", r.Method)

--- a/api/internal/handler/shop_test.go
+++ b/api/internal/handler/shop_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
-
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil"
 	"github.com/stretchr/testify/assert"
@@ -64,7 +62,7 @@ func TestCreateShop(t *testing.T) {
 
 	body, _ := json.Marshal(api.CreateShopRequest{
 		Name:            "New Shop",
-		Description:     ptr.Of("A test shop"),
+		Description:     new("A test shop"),
 		EnvironmentName: "Production",
 		EnvironmentUrl:  mockShopware.URL,
 		ClientId:        "test-client-id",
@@ -81,7 +79,7 @@ func TestCreateShop(t *testing.T) {
 
 	assert.Equal(t, http.StatusCreated, resp.StatusCode)
 
-	var result map[string]interface{}
+	var result map[string]any
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
 	assert.NotNil(t, result["id"])
 }

--- a/api/internal/handler/sso_test.go
+++ b/api/internal/handler/sso_test.go
@@ -148,7 +148,7 @@ func TestGetSsoProviders_NotMember(t *testing.T) {
 func TestDiscoverSso(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/.well-known/openid-configuration" {
-			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			_ = json.NewEncoder(w).Encode(map[string]any{
 				"issuer":                 "https://idp.example.com",
 				"authorization_endpoint": "https://idp.example.com/authorize",
 				"token_endpoint":         "https://idp.example.com/token",

--- a/api/internal/httputil/httputil.go
+++ b/api/internal/httputil/httputil.go
@@ -48,7 +48,7 @@ func WriteForbidden(w http.ResponseWriter) {
 }
 
 // WriteJSON writes a JSON response with the given status code.
-func WriteJSON(w http.ResponseWriter, status int, v interface{}) {
+func WriteJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
@@ -104,7 +104,7 @@ func WriteErrorAuto(w http.ResponseWriter, err error) {
 }
 
 // DecodeBody decodes a JSON request body into the given value.
-func DecodeBody(r *http.Request, v interface{}) error {
+func DecodeBody(r *http.Request, v any) error {
 	defer func() { _ = r.Body.Close() }()
 	return json.NewDecoder(r.Body).Decode(v)
 }
@@ -112,8 +112,8 @@ func DecodeBody(r *http.Request, v interface{}) error {
 // ExtractToken extracts the session token from the Authorization: Bearer header.
 func ExtractToken(r *http.Request) string {
 	authHeader := r.Header.Get("Authorization")
-	if strings.HasPrefix(authHeader, "Bearer ") {
-		return strings.TrimPrefix(authHeader, "Bearer ")
+	if after, ok := strings.CutPrefix(authHeader, "Bearer "); ok {
+		return after
 	}
 	return ""
 }

--- a/api/internal/httputil/huma_error.go
+++ b/api/internal/httputil/huma_error.go
@@ -45,8 +45,7 @@ func init() {
 // WriteStatusError writes err using the standard {"message":"..."} JSON shape.
 // Huma status errors keep their status and message; anything else becomes a 500.
 func WriteStatusError(w http.ResponseWriter, err error) {
-	var se huma.StatusError
-	if errors.As(err, &se) {
+	if se, ok := errors.AsType[huma.StatusError](err); ok {
 		WriteError(w, se.GetStatus(), se.Error())
 		return
 	}

--- a/api/internal/identity/passkey/service.go
+++ b/api/internal/identity/passkey/service.go
@@ -56,8 +56,8 @@ type Repository interface {
 }
 
 type ChallengeStore interface {
-	Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error
-	Get(ctx context.Context, key string, destination interface{}) error
+	Set(ctx context.Context, key string, value any, ttl time.Duration) error
+	Get(ctx context.Context, key string, destination any) error
 }
 
 type SessionIssuer interface {
@@ -296,7 +296,7 @@ func storedToCredential(stored StoredPasskey) (webauthn.Credential, error) {
 	}
 	var transports []protocol.AuthenticatorTransport
 	if stored.Transports != nil && *stored.Transports != "" {
-		for _, transport := range strings.Split(*stored.Transports, ",") {
+		for transport := range strings.SplitSeq(*stored.Transports, ",") {
 			transports = append(transports, protocol.AuthenticatorTransport(strings.TrimSpace(transport)))
 		}
 	}

--- a/api/internal/identity/postgres/admin_repository.go
+++ b/api/internal/identity/postgres/admin_repository.go
@@ -59,11 +59,9 @@ func (r *AdminRepository) FindUser(ctx context.Context, userID string) (identity
 		return identity.AdminUserDetail{}, fmt.Errorf("query admin user detail: %w", err)
 	}
 	detail := identity.AdminUserDetail{
-		AdminUser: identity.AdminUser{
-			ID: row.ID, Name: row.Name, Email: row.Email, EmailVerified: row.EmailVerified,
-			Image: row.Image, Role: row.Role, Banned: row.Banned, BanReason: row.BanReason,
-			CreatedAt: row.CreatedAt.Time,
-		},
+		ID: row.ID, Name: row.Name, Email: row.Email, EmailVerified: row.EmailVerified,
+		Image: row.Image, Role: row.Role, Banned: row.Banned, BanReason: row.BanReason,
+		CreatedAt: row.CreatedAt.Time,
 		UpdatedAt: row.UpdatedAt.Time,
 	}
 	if row.BanExpires.Valid {

--- a/api/internal/identity/redisstate/store.go
+++ b/api/internal/identity/redisstate/store.go
@@ -24,7 +24,7 @@ func New(redisURL, prefix string) (*Store, error) {
 	return &Store{client: redis.NewClient(options), prefix: prefix}, nil
 }
 
-func (s *Store) Set(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+func (s *Store) Set(ctx context.Context, key string, value any, ttl time.Duration) error {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return fmt.Errorf("marshal identity state: %w", err)
@@ -35,7 +35,7 @@ func (s *Store) Set(ctx context.Context, key string, value interface{}, ttl time
 	return nil
 }
 
-func (s *Store) Get(ctx context.Context, key string, destination interface{}) error {
+func (s *Store) Get(ctx context.Context, key string, destination any) error {
 	data, err := s.client.GetDel(ctx, s.prefix+key).Bytes()
 	if err != nil {
 		return fmt.Errorf("consume identity state: %w", err)

--- a/api/internal/monitoring/scrape/persist_test.go
+++ b/api/internal/monitoring/scrape/persist_test.go
@@ -9,7 +9,6 @@ import (
 	catalogsync "github.com/friendsofshopware/shopmon/api/internal/catalog/sync"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -104,17 +103,17 @@ func baseScrapeResult() scrapeResult {
 		extensions: []extensionEntry{
 			{
 				Name: "FroshTools", Label: "Frosh Tools", Active: true, Version: "1.0.0",
-				LatestVersion: ptr.Of("1.2.0"), Installed: true, InstalledAt: ptr.Of("2024-01-01T00:00:00Z"),
+				LatestVersion: new("1.2.0"), Installed: true, InstalledAt: new("2024-01-01T00:00:00Z"),
 				isStore: true,
 			},
 			{
 				Name: "CustomPlugin", Label: "Custom Plugin", Active: true, Version: "2.0.0",
-				Installed: true, InstalledAt: ptr.Of("2024-02-01T00:00:00Z"),
+				Installed: true, InstalledAt: new("2024-02-01T00:00:00Z"),
 			},
 		},
 		scheduledTasks: []shopwareScheduledTask{
 			{ID: "task-1", Name: "log_entry.cleanup", Status: "scheduled", RunInterval: 86400,
-				LastExecutionTime: ptr.Of("2024-01-01T00:00:00Z"), NextExecutionTime: ptr.Of("2999-01-01T00:00:00Z")},
+				LastExecutionTime: new("2024-01-01T00:00:00Z"), NextExecutionTime: new("2999-01-01T00:00:00Z")},
 		},
 		queueEntries: []shopwareQueueEntry{
 			{Name: "async", Size: json.Number("42")},
@@ -124,7 +123,7 @@ func baseScrapeResult() scrapeResult {
 			{ID: "check.a", Level: checker.StatusGreen, MessageKey: "check.a", Source: "env"},
 			{ID: "check.b", Level: checker.StatusYellow, MessageKey: "check.b", Source: "worker", Link: "https://docs.example.com"},
 		},
-		favicon: ptr.Of("https://shop.example.com/favicon.ico"),
+		favicon: new("https://shop.example.com/favicon.ico"),
 	}
 }
 
@@ -341,13 +340,13 @@ func TestResolveExtensionsFromCatalog(t *testing.T) {
 	require.NoError(t, err, "seed extra catalog rows")
 
 	extensions := []extensionEntry{
-		{Name: "FroshTools", Version: "1.0.0", LatestVersion: ptr.Of("1.1.0")}, // compat row 1.2.0 must win
-		{Name: "AcmeNull", Version: "2.0.0", LatestVersion: ptr.Of("2.5.0")},   // NULL compat row keeps shop value
-		{Name: "AcmePending", Version: "3.0.0"},                                // no compat row: prior link value
-		{Name: "CustomPlugin", Version: "2.0.0"},                               // not in catalog
+		{Name: "FroshTools", Version: "1.0.0", LatestVersion: new("1.1.0")}, // compat row 1.2.0 must win
+		{Name: "AcmeNull", Version: "2.0.0", LatestVersion: new("2.5.0")},   // NULL compat row keeps shop value
+		{Name: "AcmePending", Version: "3.0.0"},                             // no compat row: prior link value
+		{Name: "CustomPlugin", Version: "2.0.0"},                            // not in catalog
 	}
 	oldExtensions := []existingExtension{
-		{Name: "AcmePending", Version: "3.0.0", IsStore: true, LatestVersion: ptr.Of("3.9.0")},
+		{Name: "AcmePending", Version: "3.0.0", IsStore: true, LatestVersion: new("3.9.0")},
 	}
 
 	catalog, err := h.resolveExtensionsFromCatalog(ctx, extensions, oldExtensions, "6.5.0.0")
@@ -367,8 +366,8 @@ func TestResolveExtensionsFromCatalog(t *testing.T) {
 		assert.Equalf(t, wantStore, ext.isStore, "%s: isStore", ext.Name)
 		assert.Equalf(t, wantLatest, ext.LatestVersion, "%s: latest version", ext.Name)
 	}
-	assertExt(0, true, ptr.Of("1.2.0"))
-	assertExt(1, true, ptr.Of("2.5.0"))
-	assertExt(2, true, ptr.Of("3.9.0"))
+	assertExt(0, true, new("1.2.0"))
+	assertExt(1, true, new("2.5.0"))
+	assertExt(2, true, new("3.9.0"))
 	assertExt(3, false, nil)
 }

--- a/api/internal/monitoring/scrape/sbom.go
+++ b/api/internal/monitoring/scrape/sbom.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/sbom"
 )
@@ -52,8 +51,7 @@ func (h *Service) fetchSbom(ctx context.Context, env queries.GetAllEnvironmentsR
 
 	doc, err := sbom.Fetch(ctx, client)
 	if err != nil {
-		var unsupported *sbom.ErrUnsupported
-		if errors.As(err, &unsupported) {
+		if unsupported, ok := errors.AsType[*sbom.ErrUnsupported](err); ok {
 			// Expected for FroshTools releases without the SBOM route, or when
 			// the integration lacks the frosh_tools:read ACL.
 			slog.DebugContext(ctx, "sbom endpoint unavailable",
@@ -194,7 +192,7 @@ func persistSbom(ctx context.Context, q *queries.Queries, environmentID int32, r
 		return q.UpsertEnvironmentSbomStateStatus(ctx, queries.UpsertEnvironmentSbomStateStatusParams{
 			EnvironmentID: environmentID,
 			Supported:     true,
-			LastError:     ptr.Of(sbom.SanitizeError(errText)),
+			LastError:     new(sbom.SanitizeError(errText)),
 		})
 	}
 

--- a/api/internal/monitoring/scrape/service.go
+++ b/api/internal/monitoring/scrape/service.go
@@ -15,7 +15,6 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/mail"
 	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/notify"
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware/checker"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel"
@@ -134,7 +133,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 			log.Warn("authentication failed", "error", err)
 			h.notifyAuthError(ctx, env, err)
 			if err := h.queries.UpdateEnvironmentScrapeError(ctx, queries.UpdateEnvironmentScrapeErrorParams{
-				LastScrapedError: ptr.Of(fmt.Sprintf("Authentication failed: %v", err)),
+				LastScrapedError: new(fmt.Sprintf("Authentication failed: %v", err)),
 				ID:               env.ID,
 			}); err != nil {
 				slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
@@ -171,15 +170,15 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 	}()
 	go func() {
 		defer wg.Done()
-		fr.pluginData, fr.pluginErr = client.Post(ctx, "/search/plugin", map[string]interface{}{"limit": 500})
+		fr.pluginData, fr.pluginErr = client.Post(ctx, "/search/plugin", map[string]any{"limit": 500})
 	}()
 	go func() {
 		defer wg.Done()
-		fr.appData, fr.appErr = client.Post(ctx, "/search/app", map[string]interface{}{"limit": 500})
+		fr.appData, fr.appErr = client.Post(ctx, "/search/app", map[string]any{"limit": 500})
 	}()
 	go func() {
 		defer wg.Done()
-		fr.taskData, fr.taskErr = client.Post(ctx, "/search/scheduled-task", map[string]interface{}{"limit": 500})
+		fr.taskData, fr.taskErr = client.Post(ctx, "/search/scheduled-task", map[string]any{"limit": 500})
 	}()
 	go func() {
 		defer wg.Done()
@@ -197,7 +196,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 		errMsg := fmt.Sprintf("failed to fetch environment config: %v", fr.configErr)
 		h.notifyDataFetchError(ctx, env, errMsg)
 		if err := h.queries.UpdateEnvironmentScrapeError(ctx, queries.UpdateEnvironmentScrapeErrorParams{
-			LastScrapedError: ptr.Of(errMsg),
+			LastScrapedError: new(errMsg),
 			ID:               env.ID,
 		}); err != nil {
 			slog.Error("failed to update environment scrape error", "environmentId", env.ID, "error", err)
@@ -258,7 +257,7 @@ func (h *Service) scrapeEnvironment(ctx context.Context, env queries.GetAllEnvir
 					Active:      a.Active,
 					Version:     a.Version,
 					Installed:   true,
-					InstalledAt: ptr.Of(a.CreatedAt),
+					InstalledAt: new(a.CreatedAt),
 				})
 			}
 		}
@@ -807,7 +806,7 @@ func (h *Service) persistScrapeResult(ctx context.Context, env queries.GetAllEnv
 
 	var lastChangelogJSON []byte
 	if hasShopwareUpdate {
-		lastChangelogJSON, err = json.Marshal(map[string]interface{}{
+		lastChangelogJSON, err = json.Marshal(map[string]any{
 			"date": time.Now().Format(time.RFC3339),
 			"from": env.ShopwareVersion,
 			"to":   res.shopwareVersion,

--- a/api/internal/monitoring/scrape/util.go
+++ b/api/internal/monitoring/scrape/util.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/httputil"
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 )
 
 // existingExtension is the unified prior state of an extension (store-known or
@@ -91,7 +90,7 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 				Name:       old.Name,
 				Label:      old.Label,
 				State:      "removed",
-				OldVersion: ptr.Of(old.Version),
+				OldVersion: new(old.Version),
 				Active:     old.Active,
 			})
 			continue
@@ -113,8 +112,8 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 			Name:       newExt.Name,
 			Label:      newExt.Label,
 			State:      state,
-			OldVersion: ptr.Of(old.Version),
-			NewVersion: ptr.Of(newExt.Version),
+			OldVersion: new(old.Version),
+			NewVersion: new(newExt.Version),
 			Active:     newExt.Active,
 		})
 	}
@@ -128,7 +127,7 @@ func calculateExtensionDiff(oldExtensions []existingExtension, newExtensions []e
 			Name:       ne.Name,
 			Label:      ne.Label,
 			State:      "installed",
-			NewVersion: ptr.Of(ne.Version),
+			NewVersion: new(ne.Version),
 			Active:     ne.Active,
 		})
 	}

--- a/api/internal/monitoring/shopware/gateway.go
+++ b/api/internal/monitoring/shopware/gateway.go
@@ -60,7 +60,7 @@ func (g *Gateway) RescheduleTask(ctx context.Context, credentials monitoring.Sto
 	if err != nil {
 		return err
 	}
-	body := map[string]interface{}{
+	body := map[string]any{
 		"status":            "scheduled",
 		"nextExecutionTime": nextExecution.Format("2006-01-02T15:04:05+00:00"),
 	}

--- a/api/internal/monitoring/sitespeed/service.go
+++ b/api/internal/monitoring/sitespeed/service.go
@@ -80,7 +80,7 @@ func (s *Service) scrapeEnvironment(ctx context.Context, env queries.GetEnvironm
 	log.Info("calling sitespeed service", "urls", len(urls), "recordId", recordID)
 	endpoint := fmt.Sprintf("%s/api/result/%s", s.cfg.SitespeedEndpoint, recordID)
 
-	reqBody, err := json.Marshal(map[string]interface{}{
+	reqBody, err := json.Marshal(map[string]any{
 		"urls": urls,
 		"headers": map[string]string{
 			"shopmon-shop-token": env.EnvironmentToken,

--- a/api/internal/notify/channel_email.go
+++ b/api/internal/notify/channel_email.go
@@ -35,18 +35,19 @@ func (c *emailChannel) Send(ctx context.Context, r Recipient, ev Event, msg Rend
 
 	intro := c.tr.T(r.Locale, "email.alertIntro", ev.Params)
 
-	message := msg.Body
+	var message strings.Builder
+	message.WriteString(msg.Body)
 	if len(ev.Reasons) > 0 {
-		message += "\n\n"
+		message.WriteString("\n\n")
 		for i, reason := range ev.Reasons {
 			if i > 0 {
-				message += "\n"
+				message.WriteString("\n")
 			}
-			message += "- " + c.tr.RenderCheck(r.Locale, reason.Key, reason.Params)
+			message.WriteString("- " + c.tr.RenderCheck(r.Locale, reason.Key, reason.Params))
 		}
 	}
 
-	email := c.mail.BuildAlertEmail(r.Name, subject, intro, message, c.alertAction(r.Locale, ev))
+	email := c.mail.BuildAlertEmail(r.Name, subject, intro, message.String(), c.alertAction(r.Locale, ev))
 
 	if err := c.mail.Send(ctx, r.Email, email); err != nil {
 		return fmt.Errorf("send email: %w", err)

--- a/api/internal/notify/channel_inapp.go
+++ b/api/internal/notify/channel_inapp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 )
@@ -23,9 +24,7 @@ func (c *inAppChannel) Send(ctx context.Context, r Recipient, ev Event, msg Rend
 	stored := ev.Params
 	if len(ev.Reasons) > 0 {
 		stored = make(map[string]any, len(ev.Params)+1)
-		for k, v := range ev.Params {
-			stored[k] = v
-		}
+		maps.Copy(stored, ev.Params)
 		stored["reasons"] = ev.Reasons
 	}
 

--- a/api/internal/organization/authorization.go
+++ b/api/internal/organization/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 )
 
 var (
@@ -118,10 +119,8 @@ func (a *Authorizer) RequireRole(ctx context.Context, userID, organizationID str
 	if err != nil {
 		return "", err
 	}
-	for _, allowedRole := range allowedRoles {
-		if role == allowedRole {
-			return role, nil
-		}
+	if slices.Contains(allowedRoles, role) {
+		return role, nil
 	}
 	return "", fmt.Errorf("%w: %s", ErrRoleNotAllowed, role)
 }

--- a/api/internal/packagesmirror/packagesapi/client.go
+++ b/api/internal/packagesmirror/packagesapi/client.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 
 	"github.com/friendsofshopware/shopmon/api/internal/packagesmirror"
@@ -84,10 +85,8 @@ func (c *Client) request(ctx context.Context, method, endpoint string, body io.R
 	if len(responseBody) > maxResponseSize {
 		return nil, fmt.Errorf("%w: response exceeds %d bytes", packagesmirror.ErrRemote, maxResponseSize)
 	}
-	for _, successCode := range successCodes {
-		if resp.StatusCode == successCode {
-			return responseBody, nil
-		}
+	if slices.Contains(successCodes, resp.StatusCode) {
+		return responseBody, nil
 	}
 	return nil, &packagesmirror.RemoteError{StatusCode: resp.StatusCode, Body: responseBody}
 }

--- a/api/internal/ptr/ptr.go
+++ b/api/internal/ptr/ptr.go
@@ -4,8 +4,10 @@ package ptr
 import "time"
 
 // Of returns a pointer to v.
+//
+//go:fix inline
 func Of[T any](v T) *T {
-	return &v
+	return new(v)
 }
 
 // Deref returns the value pointed to by p, or the zero value of T when p is nil.

--- a/api/internal/ptr/ptr_test.go
+++ b/api/internal/ptr/ptr_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestOf(t *testing.T) {
-	p := ptr.Of("hello")
+	p := new("hello")
 	if p == nil || *p != "hello" {
 		t.Fatalf("Of() = %v, want pointer to hello", p)
 	}
@@ -18,7 +18,7 @@ func TestDeref(t *testing.T) {
 	if got := ptr.Deref((*string)(nil)); got != "" {
 		t.Fatalf("Deref(nil) = %q, want empty", got)
 	}
-	if got := ptr.Deref(ptr.Of(42)); got != 42 {
+	if got := ptr.Deref(new(42)); got != 42 {
 		t.Fatalf("Deref(42) = %d, want 42", got)
 	}
 }
@@ -27,7 +27,7 @@ func TestDerefOr(t *testing.T) {
 	if got := ptr.DerefOr((*string)(nil), "fallback"); got != "fallback" {
 		t.Fatalf("DerefOr(nil) = %q, want fallback", got)
 	}
-	if got := ptr.DerefOr(ptr.Of("value"), "fallback"); got != "value" {
+	if got := ptr.DerefOr(new("value"), "fallback"); got != "value" {
 		t.Fatalf("DerefOr(value) = %q, want value", got)
 	}
 }
@@ -36,7 +36,7 @@ func TestMap(t *testing.T) {
 	if got := ptr.Map((*int32)(nil), func(v int32) int { return int(v) }); got != nil {
 		t.Fatalf("Map(nil) = %v, want nil", got)
 	}
-	got := ptr.Map(ptr.Of(int32(7)), func(v int32) int { return int(v) })
+	got := ptr.Map(new(int32(7)), func(v int32) int { return int(v) })
 	if got == nil || *got != 7 {
 		t.Fatalf("Map(7) = %v, want pointer to 7", got)
 	}
@@ -46,7 +46,7 @@ func TestInt(t *testing.T) {
 	if got := ptr.Int((*int32)(nil)); got != nil {
 		t.Fatalf("Int(nil) = %v, want nil", got)
 	}
-	got := ptr.Int(ptr.Of(int32(9)))
+	got := ptr.Int(new(int32(9)))
 	if got == nil || *got != 9 {
 		t.Fatalf("Int(9) = %v, want pointer to 9", got)
 	}
@@ -56,10 +56,10 @@ func TestParseTime(t *testing.T) {
 	if got := ptr.ParseTime(nil, time.RFC3339); got != nil {
 		t.Fatalf("ParseTime(nil) = %v, want nil", got)
 	}
-	if got := ptr.ParseTime(ptr.Of("not-a-time"), time.RFC3339); got != nil {
+	if got := ptr.ParseTime(new("not-a-time"), time.RFC3339); got != nil {
 		t.Fatalf("ParseTime(invalid) = %v, want nil", got)
 	}
-	got := ptr.ParseTime(ptr.Of("2024-01-02T03:04:05Z"), time.RFC3339)
+	got := ptr.ParseTime(new("2024-01-02T03:04:05Z"), time.RFC3339)
 	if got == nil || !got.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)) {
 		t.Fatalf("ParseTime(valid) = %v, want 2024-01-02T03:04:05Z", got)
 	}

--- a/api/internal/readmodel/environment/projection.go
+++ b/api/internal/readmodel/environment/projection.go
@@ -218,7 +218,7 @@ func mapEnvironmentChecks(rows []queries.EnvironmentCheck) []api.EnvironmentChec
 		}
 
 		if len(row.Params) > 0 {
-			var params map[string]interface{}
+			var params map[string]any
 			if err := json.Unmarshal(row.Params, &params); err == nil && len(params) > 0 {
 				check.Params = &params
 			}

--- a/api/internal/shopware/checker/frosh_tools_test.go
+++ b/api/internal/shopware/checker/frosh_tools_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,7 +95,7 @@ func TestMapFroshChecks(t *testing.T) {
 		},
 		{
 			name:            "current and recommended carried as params",
-			check:           froshToolsCheck{Snippet: "phpOutdated", State: "STATE_WARNING", Current: ptr.Of("7.4"), Recommended: ptr.Of("8.2")},
+			check:           froshToolsCheck{Snippet: "phpOutdated", State: "STATE_WARNING", Current: new("7.4"), Recommended: new("8.2")},
 			wantEmitted:     true,
 			wantID:          "frosh.phpOutdated",
 			wantLevel:       StatusYellow,

--- a/api/internal/shopware/client.go
+++ b/api/internal/shopware/client.go
@@ -93,7 +93,7 @@ func (c *Client) getToken(ctx context.Context) (string, error) {
 	// Collapse concurrent fetches: only one goroutine performs the network
 	// round-trip; the rest wait and share its result. The HTTP call runs
 	// outside c.mu so a slow token endpoint never blocks cache reads.
-	token, err, _ := c.tokenGroup.Do("token", func() (interface{}, error) {
+	token, err, _ := c.tokenGroup.Do("token", func() (any, error) {
 		// Another goroutine may have populated the cache while we waited.
 		if token := c.cachedAccessToken(); token != "" {
 			return token, nil
@@ -168,7 +168,7 @@ func (c *Client) Authenticate(ctx context.Context) error {
 // request performs an authenticated Admin API call. HTTP client tracing comes
 // from httputil's otelhttp transport (span name METHOD host/path); we do not
 // create a second Internal span that would duplicate that client span in Datadog.
-func (c *Client) request(ctx context.Context, method, path string, body interface{}, retry bool) ([]byte, error) {
+func (c *Client) request(ctx context.Context, method, path string, body any, retry bool) ([]byte, error) {
 	token, err := c.getToken(ctx)
 	if err != nil {
 		return nil, err
@@ -227,18 +227,18 @@ func (c *Client) Get(ctx context.Context, path string) ([]byte, error) {
 	return c.request(ctx, "GET", path, nil, true)
 }
 
-func (c *Client) Post(ctx context.Context, path string, body interface{}) ([]byte, error) {
+func (c *Client) Post(ctx context.Context, path string, body any) ([]byte, error) {
 	return c.request(ctx, "POST", path, body, true)
 }
 
-func (c *Client) Put(ctx context.Context, path string, body interface{}) ([]byte, error) {
+func (c *Client) Put(ctx context.Context, path string, body any) ([]byte, error) {
 	return c.request(ctx, "PUT", path, body, true)
 }
 
-func (c *Client) Patch(ctx context.Context, path string, body interface{}) ([]byte, error) {
+func (c *Client) Patch(ctx context.Context, path string, body any) ([]byte, error) {
 	return c.request(ctx, "PATCH", path, body, true)
 }
 
-func (c *Client) Delete(ctx context.Context, path string, body interface{}) ([]byte, error) {
+func (c *Client) Delete(ctx context.Context, path string, body any) ([]byte, error) {
 	return c.request(ctx, "DELETE", path, body, true)
 }

--- a/api/internal/shopware/client_test.go
+++ b/api/internal/shopware/client_test.go
@@ -84,7 +84,7 @@ func TestGetTokenCaches(t *testing.T) {
 	defer ts.Close()
 	c := newTestClient(ts.URL)
 
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		_, err := c.Get(context.Background(), "/_info/config")
 		require.NoError(t, err)
 	}
@@ -144,7 +144,7 @@ func TestGetTokenSingleflight(t *testing.T) {
 	var wg sync.WaitGroup
 	errs := make([]error, n)
 	wg.Add(n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		go func(i int) {
 			defer wg.Done()
 			_, errs[i] = c.Get(context.Background(), "/_info/config")

--- a/api/internal/shopware/sbom/sbom.go
+++ b/api/internal/shopware/sbom/sbom.go
@@ -273,8 +273,7 @@ func SanitizeError(s string) string {
 // classifying it as an absent capability would hide it behind a Debug log while
 // package-level advisory coverage stays silently disabled.
 func isMissingRoute(err error) bool {
-	var apiErr *shopware.ApiError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := errors.AsType[*shopware.ApiError](err); ok {
 		return apiErr.StatusCode == http.StatusNotFound
 	}
 	return false

--- a/api/internal/shopware/sbom/sbom_test.go
+++ b/api/internal/shopware/sbom/sbom_test.go
@@ -169,8 +169,7 @@ func TestParseRejectsNonCycloneDXAsError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error for a non-CycloneDX document")
 	}
-	var unsupported *ErrUnsupported
-	if errors.As(err, &unsupported) {
+	if _, ok := errors.AsType[*ErrUnsupported](err); ok {
 		t.Fatalf("err = %v, want a plain parse error, not ErrUnsupported", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Bump Go from 1.26 to 1.27 in `.mise.toml` (drives CI via mise-action), `api/go.mod`, `Dockerfile` (`golang:1.27-alpine`), and the README tooling note
- Run `go fix ./...` with Go 1.27 as autofixer, which modernized 51 files:
  - `interface{}` → `any`
  - `for i := 0; i < n; i++` → `for i := range n` (and `for range n` for unused counters)
  - `for _, x := range strings.Split(...)` → `strings.SplitSeq`
  - Prefix-strip checks → `strings.CutPrefix`, contains-loops → `slices.Contains`, concatenation → `strings.Builder`
  - Call sites of small pointer helpers rewritten to the new `new(expr)` form; `ptr.Of` now carries a `//go:fix inline` directive
- Drop three pointer helpers (`ptrString`, `ptr`, `ptrStr`) that `go fix` orphaned after inlining their call sites

## Verification

- `mise run lint` — golangci-lint + frontend oxlint/vue-tsc/oxfmt + 263 Vitest unit tests pass
- `mise run test` — API integration tests (testcontainers) pass
- `go mod tidy` produced no dependency churn beyond the `go` directive bump