### PR TITLE
fix: stop StoreExtensionSync backlog from starving shop scrapes

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -169,14 +169,16 @@ Background jobs run on PostgreSQL by default — no extra infrastructure needed.
 
 | Variable | Default | Description |
 |---|---|---|
-| `QUEUE_TRANSPORT` | `postgres` | Job backend: `postgres` (jobs stored in the `queue_messages` table) or `amqp` |
+| `QUEUE_TRANSPORT` | `postgres` | Job backend: `postgres` (jobs stored in `queue_messages` + `queue_messages_scrape`) or `amqp` |
 | `QUEUE_AMQP_DSN` | `amqp://guest:guest@localhost:5672/` | Broker connection string |
 | `QUEUE_AMQP_EXCHANGE` | `shopmon` | Exchange to publish jobs to (declared on startup) |
-| `QUEUE_AMQP_QUEUE` | `shopmon` | Queue workers consume from; also used as the routing key |
-| `QUEUE_AMQP_PREFETCH` | `10` | Unacknowledged deliveries per consumer. Keep it at or above the worker concurrency (10) |
+| `QUEUE_AMQP_QUEUE` | `shopmon` | Catalog-sync queue (and routing key). Shop-facing jobs use `<QUEUE_AMQP_QUEUE>-scrape` (default `shopmon-scrape`) |
+| `QUEUE_AMQP_PREFETCH` | `10` | Unacknowledged deliveries per consumer per queue. Keep it at or above the worker concurrency (10) |
 | `QUEUE_AMQP_DELAYED_EXCHANGE` | `true` | Declare the exchange as `x-delayed-message` so delayed jobs are held by the broker. Accepts `true`/`false`, `1`/`0`, `TRUE`/`FALSE`; an unparseable value keeps delayed delivery on |
 
 Set the same values on the `api` and `worker` services — the API publishes jobs and the worker consumes them.
+
+Shop-refresh jobs (`EnvironmentScrape`, sitespeed, changelog, cleanup, advisory sync) use a dedicated queue so a `StoreExtensionSync` backlog cannot starve shop updates. On PostgreSQL the worker creates `queue_messages_scrape` automatically. On AMQP it declares `<QUEUE_AMQP_QUEUE>-scrape`. After deploy, confirm the worker logs `enqueued environment scrapes` at `:00` and `scraping environment` shortly after. Leftover `EnvironmentScrape` rows in `queue_messages` (or messages still on the catalog AMQP queue) can be left to drain or deleted; the hourly cron republishes to the scrape queue.
 
 Shopmon delays some jobs (post-deployment scrapes, sitespeed reruns), which needs broker-side delayed delivery: **LavinMQ supports it natively**, RabbitMQ needs the [rabbitmq_delayed_message_exchange](https://github.com/rabbitmq/rabbitmq-delayed-message-exchange) plugin. Only set `QUEUE_AMQP_DELAYED_EXCHANGE=false` if your broker has neither — delayed jobs are then delivered immediately, so a post-deployment scrape runs before the shop has settled.
 

--- a/api/.env.example
+++ b/api/.env.example
@@ -33,6 +33,7 @@ QUEUE_TRANSPORT=postgres
 QUEUE_AMQP_DSN=amqp://guest:guest@localhost:5672/
 QUEUE_AMQP_EXCHANGE=shopmon
 QUEUE_AMQP_QUEUE=shopmon
+# Shop-facing jobs use `${QUEUE_AMQP_QUEUE}-scrape` (shopmon-scrape).
 QUEUE_AMQP_PREFETCH=10
 # Delayed jobs need a broker that supports x-delayed-message: LavinMQ natively,
 # RabbitMQ via the delayed-message plugin. Set to false only if yours does not

--- a/api/internal/jobs/bus.go
+++ b/api/internal/jobs/bus.go
@@ -44,11 +44,14 @@ type AMQPConfig struct {
 // dispatch messages, while the worker adds executable handlers through
 // RegisterHandlers.
 //
+// Two transports are registered: the legacy async/catalog queue and the
+// shop-facing scrape queue. See ScrapeTransportName for why they are split.
+//
 // The returned close function releases resources the bus owns itself (the AMQP
-// connection). It never touches the caller-owned pgx pool, so callers keep
+// connections). It never touches the caller-owned pgx pool, so callers keep
 // closing that themselves.
 func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue.Bus, func() error, error) {
-	transport, closeTransport, err := newTransport(pool, config)
+	transports, closeTransport, err := newTransports(pool, config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -59,7 +62,9 @@ func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue
 			queueotel.WithSpanNameNormalizer(queueotel.DefaultSpanNameNormalizer),
 		))
 	}
-	bus.AddTransport(TransportName, transport)
+	for name, transport := range transports {
+		bus.AddTransport(name, transport)
+	}
 
 	if err := bus.Setup(ctx); err != nil {
 		_ = closeTransport()
@@ -69,6 +74,14 @@ func NewBus(ctx context.Context, pool *pgxpool.Pool, config BusConfig) (*goqueue
 }
 
 func newTransport(pool *pgxpool.Pool, config BusConfig) (goqueue.Transport, func() error, error) {
+	transports, closeTransport, err := newTransports(pool, config)
+	if err != nil {
+		return nil, nil, err
+	}
+	return transports[TransportName], closeTransport, nil
+}
+
+func newTransports(pool *pgxpool.Pool, config BusConfig) (map[string]goqueue.Transport, func() error, error) {
 	noopClose := func() error { return nil }
 
 	switch config.Driver {
@@ -76,34 +89,67 @@ func newTransport(pool *pgxpool.Pool, config BusConfig) (goqueue.Transport, func
 		if pool == nil {
 			return nil, nil, fmt.Errorf("job bus: postgres driver requires a database pool")
 		}
-		// The pool is shared with the rest of the process, so the transport must
+		// The pool is shared with the rest of the process, so the transports must
 		// not be closed with the bus — postgres.Transport.Close() closes the pool.
-		return postgres.NewTransportFromPool(pool, postgres.Config{
-			Table: "queue_messages",
-		}), noopClose, nil
+		return map[string]goqueue.Transport{
+			TransportName: postgres.NewTransportFromPool(pool, postgres.Config{
+				Table:   "queue_messages",
+				Channel: "queue_notify",
+			}),
+			ScrapeTransportName: postgres.NewTransportFromPool(pool, postgres.Config{
+				Table:   "queue_messages_scrape",
+				Channel: "queue_notify_scrape",
+			}),
+		}, noopClose, nil
 	case DriverAMQP:
 		if config.AMQP.DSN == "" {
 			return nil, nil, fmt.Errorf("job bus: amqp driver requires a broker DSN")
 		}
-		transport := amqp.NewTransport(amqp.Config{
-			DSN:           config.AMQP.DSN,
-			Exchange:      config.AMQP.Exchange,
-			Queue:         config.AMQP.Queue,
-			RoutingKey:    config.AMQP.Queue,
-			PrefetchCount: config.AMQP.PrefetchCount,
-			Durable:       true,
-			// Re-declare exchange, queue, and binding after a broker restart.
-			AutoSetup:         true,
-			PublisherConfirms: true,
-			DelayedExchange:   config.AMQP.DelayedExchange,
-		})
-		return transport, transport.Close, nil
+		catalog := newAMQPTransport(config.AMQP, config.AMQP.Queue)
+		scrapeQueue := config.AMQP.Queue + "-scrape"
+		scrape := newAMQPTransport(config.AMQP, scrapeQueue)
+		return map[string]goqueue.Transport{
+			TransportName:       catalog,
+			ScrapeTransportName: scrape,
+		}, func() error {
+			err := catalog.Close()
+			if scrapeErr := scrape.Close(); scrapeErr != nil && err == nil {
+				err = scrapeErr
+			}
+			return err
+		}, nil
 	default:
 		return nil, nil, fmt.Errorf("job bus: unknown queue driver %q (supported: %s, %s)", config.Driver, DriverPostgres, DriverAMQP)
 	}
 }
 
-// Dispatch routes a Shopmon job explicitly to the stable async transport.
+func newAMQPTransport(config AMQPConfig, queue string) *amqp.Transport {
+	return amqp.NewTransport(amqp.Config{
+		DSN:           config.DSN,
+		Exchange:      config.Exchange,
+		Queue:         queue,
+		RoutingKey:    queue,
+		PrefetchCount: config.PrefetchCount,
+		Durable:       true,
+		// Re-declare exchange, queue, and binding after a broker restart.
+		AutoSetup:         true,
+		PublisherConfirms: true,
+		DelayedExchange:   config.DelayedExchange,
+	})
+}
+
+// transportFor returns the queue a Shopmon job type is published to.
+// StoreExtensionSync stays on the legacy async transport; every other job
+// uses the scrape transport so catalog work cannot occupy the shop-refresh path.
+func transportFor[T any]() string {
+	var zero T
+	if _, ok := any(zero).(StoreExtensionSync); ok {
+		return TransportName
+	}
+	return ScrapeTransportName
+}
+
+// Dispatch routes a Shopmon job to its dedicated transport.
 // go-queue otherwise derives the route from a registered handler, which would
 // force dispatch-only processes to construct the complete worker graph.
 func Dispatch[T any](ctx context.Context, bus *goqueue.Bus, message T, options ...goqueue.Option) error {
@@ -112,6 +158,6 @@ func Dispatch[T any](ctx context.Context, bus *goqueue.Bus, message T, options .
 	}
 	routedOptions := make([]goqueue.Option, 0, len(options)+1)
 	routedOptions = append(routedOptions, options...)
-	routedOptions = append(routedOptions, goqueue.WithQueue(TransportName))
+	routedOptions = append(routedOptions, goqueue.WithQueue(transportFor[T]()))
 	return goqueue.Dispatch(ctx, bus, message, routedOptions...)
 }

--- a/api/internal/jobs/bus_test.go
+++ b/api/internal/jobs/bus_test.go
@@ -15,17 +15,21 @@ import (
 const messageTypePrefix = "github.com/friendsofshopware/shopmon/api/internal/jobs."
 
 func TestDispatchRoutesMessagesWithoutRegisteredHandlers(t *testing.T) {
-	bus, transport := newMemoryBus()
+	bus, catalog, scrape := newMemoryBus()
 
 	tests := []struct {
 		name          string
 		expectedType  string
+		expectedQueue string
+		source        *memory.Transport
 		dispatch      func() error
 		expectedDelay time.Duration
 	}{
 		{
-			name:         "environment scrape",
-			expectedType: messageTypePrefix + "EnvironmentScrape",
+			name:          "environment scrape",
+			expectedType:  messageTypePrefix + "EnvironmentScrape",
+			expectedQueue: ScrapeTransportName,
+			source:        scrape,
 			dispatch: func() error {
 				return Dispatch(context.Background(), bus, EnvironmentScrape{EnvironmentID: 42})
 			},
@@ -33,14 +37,18 @@ func TestDispatchRoutesMessagesWithoutRegisteredHandlers(t *testing.T) {
 		{
 			name:          "delayed sitespeed scrape",
 			expectedType:  messageTypePrefix + "SitespeedScrape",
+			expectedQueue: ScrapeTransportName,
+			source:        scrape,
 			expectedDelay: 15 * time.Minute,
 			dispatch: func() error {
 				return Dispatch(context.Background(), bus, SitespeedScrape{EnvironmentID: 42}, goqueue.WithDelay(15*time.Minute))
 			},
 		},
 		{
-			name:         "catalog sync",
-			expectedType: messageTypePrefix + "StoreExtensionSync",
+			name:          "catalog sync",
+			expectedType:  messageTypePrefix + "StoreExtensionSync",
+			expectedQueue: TransportName,
+			source:        catalog,
 			dispatch: func() error {
 				return Dispatch(context.Background(), bus, StoreExtensionSync{Names: []string{"Example"}, ShopwareVersion: "6.7"})
 			},
@@ -50,8 +58,8 @@ func TestDispatchRoutesMessagesWithoutRegisteredHandlers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.NoError(t, test.dispatch())
-			envelope := <-transport.Chan()
-			assert.Equal(t, TransportName, envelope.Transport)
+			envelope := <-test.source.Chan()
+			assert.Equal(t, test.expectedQueue, envelope.Transport)
 			assert.Equal(t, test.expectedType, envelope.Type)
 			_, registered := bus.GetHandler(envelope.Type)
 			assert.False(t, registered, "dispatch-only bus must not require a worker handler")
@@ -68,30 +76,34 @@ func TestDispatchRoutesMessagesWithoutRegisteredHandlers(t *testing.T) {
 }
 
 func TestRegisterHandlersRegistersEveryStableMessageType(t *testing.T) {
-	bus, transport := newMemoryBus()
+	bus, catalog, scrape := newMemoryBus()
 	require.NoError(t, RegisterHandlers(bus, completeHandlers()))
 
-	dispatches := []func() error{
-		func() error { return Dispatch(context.Background(), bus, EnvironmentScrape{}) },
-		func() error { return Dispatch(context.Background(), bus, SitespeedScrape{}) },
-		func() error { return Dispatch(context.Background(), bus, LockCleanup{}) },
-		func() error { return Dispatch(context.Background(), bus, InvitationCleanup{}) },
-		func() error { return Dispatch(context.Background(), bus, OldDataCleanup{}) },
-		func() error { return Dispatch(context.Background(), bus, ShopwareChangelogSync{}) },
-		func() error { return Dispatch(context.Background(), bus, ComposerAdvisorySync{}) },
-		func() error { return Dispatch(context.Background(), bus, StoreExtensionSync{}) },
+	dispatches := []struct {
+		dispatch func() error
+		source   *memory.Transport
+	}{
+		{func() error { return Dispatch(context.Background(), bus, EnvironmentScrape{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, SitespeedScrape{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, LockCleanup{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, InvitationCleanup{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, OldDataCleanup{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, ShopwareChangelogSync{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, ComposerAdvisorySync{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, SecurityPluginSync{}) }, scrape},
+		{func() error { return Dispatch(context.Background(), bus, StoreExtensionSync{}) }, catalog},
 	}
 
-	for _, dispatch := range dispatches {
-		require.NoError(t, dispatch())
-		envelope := <-transport.Chan()
+	for _, test := range dispatches {
+		require.NoError(t, test.dispatch())
+		envelope := <-test.source.Chan()
 		_, registered := bus.GetHandler(envelope.Type)
 		assert.True(t, registered, "worker handler missing for %s", envelope.Type)
 	}
 }
 
 func TestRegisterHandlersRejectsIncompleteWorkerGraph(t *testing.T) {
-	bus, _ := newMemoryBus()
+	bus, _, _ := newMemoryBus()
 	require.Error(t, RegisterHandlers(bus, Handlers{}))
 	require.Error(t, RegisterHandlers(nil, completeHandlers()))
 }
@@ -132,6 +144,19 @@ func TestNewTransportSelectsDriver(t *testing.T) {
 	}
 }
 
+func TestNewTransportsRegistersCatalogAndScrape(t *testing.T) {
+	transports, closeTransport, err := newTransports(nil, BusConfig{
+		Driver: DriverAMQP,
+		AMQP:   AMQPConfig{DSN: "amqp://guest:guest@localhost:5672/", Exchange: "shopmon", Queue: "shopmon"},
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, closeTransport()) }()
+
+	require.Contains(t, transports, TransportName)
+	require.Contains(t, transports, ScrapeTransportName)
+	assert.NotSame(t, transports[TransportName], transports[ScrapeTransportName])
+}
+
 func TestNewTransportKeepsPostgresPoolOpen(t *testing.T) {
 	// postgres.Transport.Close() closes the pool it was handed, which the rest of
 	// the process still uses — NewBus must therefore hand back a no-op closer.
@@ -150,11 +175,13 @@ func TestNewTransportKeepsPostgresPoolOpen(t *testing.T) {
 	assert.NotContains(t, err.Error(), "closed pool")
 }
 
-func newMemoryBus() (*goqueue.Bus, *memory.Transport) {
+func newMemoryBus() (*goqueue.Bus, *memory.Transport, *memory.Transport) {
 	bus := goqueue.NewBus()
-	transport := memory.NewTransport()
-	bus.AddTransport(TransportName, transport)
-	return bus, transport
+	catalog := memory.NewTransport()
+	scrape := memory.NewTransport()
+	bus.AddTransport(TransportName, catalog)
+	bus.AddTransport(ScrapeTransportName, scrape)
+	return bus, catalog, scrape
 }
 
 type scraperStub struct{}

--- a/api/internal/jobs/handlers.go
+++ b/api/internal/jobs/handlers.go
@@ -75,7 +75,7 @@ func RegisterHandlers(bus *goqueue.Bus, handlers Handlers) error {
 		return errors.New("register job handlers: security plugin synchronizer is required")
 	}
 
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, message EnvironmentScrape) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, message EnvironmentScrape) error {
 		// Annotate the go-queue otel Consumer span before Scrape starts a child
 		// Internal span, so Datadog can facet EnvironmentScrape process by environment.id.
 		return runEnvironmentJob(ctx, message.EnvironmentID, func(ctx context.Context) error {
@@ -86,28 +86,28 @@ func RegisterHandlers(bus *goqueue.Bus, handlers Handlers) error {
 		// Names are high-cardinality; keep them off the Consumer entry span.
 		return handlers.StoreExtensionSynchronizer.Sync(ctx, message.Names, message.ShopwareVersion)
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, message SitespeedScrape) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, message SitespeedScrape) error {
 		return runEnvironmentJob(ctx, message.EnvironmentID, func(ctx context.Context) error {
 			return handlers.SitespeedScraper.Scrape(ctx, message.EnvironmentID)
 		})
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ LockCleanup) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ LockCleanup) error {
 		return handlers.Cleanup.CleanupLocks(ctx)
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ InvitationCleanup) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ InvitationCleanup) error {
 		return handlers.Cleanup.CleanupInvitations(ctx)
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ OldDataCleanup) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ OldDataCleanup) error {
 		return handlers.Cleanup.CleanupOldData(ctx)
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ ShopwareChangelogSync) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ ShopwareChangelogSync) error {
 		return handlers.ChangelogSynchronizer.Sync(ctx)
 	})
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ ComposerAdvisorySync) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ ComposerAdvisorySync) error {
 		return handlers.AdvisorySynchronizer.Sync(ctx)
 	})
 
-	goqueue.HandleFunc(bus, TransportName, func(ctx context.Context, _ SecurityPluginSync) error {
+	goqueue.HandleFunc(bus, ScrapeTransportName, func(ctx context.Context, _ SecurityPluginSync) error {
 		return handlers.SecurityPluginSynchronizer.Sync(ctx)
 	})
 	return nil

--- a/api/internal/jobs/messages.go
+++ b/api/internal/jobs/messages.go
@@ -1,7 +1,20 @@
 package jobs
 
-// TransportName is the stable queue transport used by every Shopmon job.
-const TransportName = "async"
+const (
+	// TransportName is the legacy async transport (`queue_messages` / AMQP
+	// `QUEUE_AMQP_QUEUE`). StoreExtensionSync stays here so a catalog backlog
+	// does not share claim-order with shop-facing jobs.
+	TransportName = "async"
+	// ScrapeTransportName is the shop-facing job transport
+	// (`queue_messages_scrape` / AMQP `<QUEUE_AMQP_QUEUE>-scrape`).
+	// Environment scrapes, sitespeed, and the other scheduled jobs publish here.
+	//
+	// go-queue's postgres consumer claims `ORDER BY created_at` and retries
+	// keep the original created_at, so StoreExtensionSync 429 retries on the
+	// shared table stay ahead of newer EnvironmentScrape rows. Production
+	// (thousands of shops) starves shop refreshes; staging (two shops) does not.
+	ScrapeTransportName = "scrape"
+)
 
 // Message types are deliberately kept in this package so their reflected type
 // names remain stable for envelopes already persisted in PostgreSQL.

--- a/api/internal/jobs/scheduler.go
+++ b/api/internal/jobs/scheduler.go
@@ -167,16 +167,29 @@ func (s *Scheduler) enqueueEnvironmentScrapes(ctx context.Context) {
 		slog.ErrorContext(ctx, "failed to list environments for scrape", "error", err)
 		return
 	}
+	dispatched := 0
+	skipped := 0
+	failed := 0
 	for _, target := range targets {
 		// Back off instead of hammering an environment that has repeatedly
 		// failed to connect.
 		if target.ConnectionIssueCount >= 3 {
+			skipped++
 			continue
 		}
 		if err := s.dispatcher.EnqueueEnvironmentScrape(ctx, target.ID); err != nil {
+			failed++
 			slog.ErrorContext(ctx, "failed to dispatch environment scrape", "environmentId", target.ID, "error", err)
+			continue
 		}
+		dispatched++
 	}
+	slog.InfoContext(ctx, "enqueued environment scrapes",
+		"targets", len(targets),
+		"dispatched", dispatched,
+		"skippedConnectionIssues", skipped,
+		"failed", failed,
+	)
 }
 
 func (s *Scheduler) enqueueSitespeedScrapes(ctx context.Context) {

--- a/api/internal/testutil/testutil.go
+++ b/api/internal/testutil/testutil.go
@@ -150,6 +150,7 @@ func Setup(t *testing.T, cfgFn ...func(*config.Config)) *TestEnv {
 	// Handlers that enqueue work only need a transport: jobs.Dispatch supplies
 	// the explicit route, so tests do not construct fake worker handlers.
 	bus.AddTransport(jobs.TransportName, &noopTransport{})
+	bus.AddTransport(jobs.ScrapeTransportName, &noopTransport{})
 	organizationRepository := organizationpostgres.NewAuthorizationRepository(q)
 	organizationAuthorizer := organization.NewAuthorizer(organizationRepository)
 	organizationStore := organizationpostgres.NewRepository(pool, q)

--- a/api/worker.go
+++ b/api/worker.go
@@ -134,7 +134,9 @@ func runWorker(cmd *cobra.Command, args []string) error {
 		slog.Error("failed to dispatch initial composer advisory sync", "error", err)
 	}
 
-	// Worker
+	// One worker consumes every registered transport. Catalog sync
+	// (TransportName) and shop-facing jobs (ScrapeTransportName) each get
+	// this concurrency, so a StoreExtensionSync backlog cannot starve scrapes.
 	worker := goqueue.NewWorker(bus, goqueue.WorkerConfig{
 		Concurrency:     10,
 		HandlerTimeout:  10 * time.Minute,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users report production shops are not updating. Datadog (2026-08-24) matches that:

- **Staging** `shopmon-worker` scrapes 2 shops every hour on the hour (`scraping environment` / `scrape completed`) and also runs changelog / advisory / cleanup cron.
- **Production** `shopmon-worker` has had **zero** of those messages for 24h+ (last scrape consumption: **2026-08-23 04:00 UTC**, last changelog: **05:00 UTC**). The same process is busy with `StoreExtensionSync` / Store API 429 aborts (~230 successful syncs/h + ~160 retries/h, steady).

This is not a missing cron, feature flag, or different consumer. The in-process scheduler (`0 * * * *` in `shopmon worker`) is the only publisher. Staging and production run the same job type on the same bus.

**Hypothesis discarded:** “prod scrape jobs never get published, or they use a different consumer/queue than StoreExtensionSync.”

They use the **same** queue. That is the bug.

## How scrapes are scheduled

1. `shopmon worker` starts `jobs.Scheduler` (robfig/cron, no leader election, no env flag).
2. Hourly tick lists every environment (`GetAllEnvironments`) and enqueues `EnvironmentScrape` unless `connection_issue_count >= 3`.
3. Create/connect and manual refresh also dispatch `EnvironmentScrape` (API → same bus).
4. The worker consumes `EnvironmentScrape` and, after a scrape, may dispatch `StoreExtensionSync` for stale catalog names.

There is no separate k8s CronJob and no `QUEUE_*` switch that disables scrapes.

## Why staging scrapes and production does not

go-queue’s postgres consumer claims `ORDER BY created_at` and **retries keep the original `created_at`**. A week of production scrapes left a large `StoreExtensionSync` backlog. Those jobs fail on Store 429, retry immediately, and stay at the front of the claim order. Newer `EnvironmentScrape` rows sit behind them.

Staging has 2 shops, so the catalog queue never builds that backlog — hourly scrapes run on the hour.

7-day prod logs are the same pattern: bursts of 2k–10k scrape consumptions, then hours of only `StoreExtensionSync`, then another burst. After 2026-08-23 04:00 the catalog backlog did not drain far enough to reach the next scrape batch (33h+).

`#814` (ack StoreExtensionSync on 429) reduces retries but does **not** restore shop freshness: thousands of unique catalog jobs still share claim-order with scrapes.

## Change

- Publish shop-facing jobs (`EnvironmentScrape`, sitespeed, changelog, cleanup, advisory sync) to a dedicated transport:
  - Postgres: `queue_messages_scrape` (created on worker/API startup; listen channel `queue_notify_scrape`)
  - AMQP: `<QUEUE_AMQP_QUEUE>-scrape` (default `shopmon-scrape`)
- Leave `StoreExtensionSync` on the existing `queue_messages` / `shopmon` queue so the catalog backlog drains separately.
- The worker already consumes every registered transport; each queue gets concurrency 10, so scrapes have reserved slots.
- Log `enqueued environment scrapes` (`targets`, `dispatched`, `skippedConnectionIssues`, `failed`) on every hourly tick so publish vs consume is visible in Datadog.

## Issue #820

A newly connected environment persists Shopware version from the connect/validate call, then dispatches the **same** `EnvironmentScrape` for scheduled tasks / extensions. If that job sits behind the catalog backlog, the overview stays blank. After this change the initial scrape uses the scrape queue and should run even while catalog sync is rate-limited.

## Ops check after deploy

1. Worker logs `consuming from transport` for both `async` and `scrape`.
2. At `:00`, production should log `enqueued environment scrapes` with `dispatched` ≈ environment count (not only staging’s 2).
3. `scraping environment` should follow on `shopmon-worker` `env:production` (not only `env:staging`).
4. Leftover `EnvironmentScrape` rows in `queue_messages` (or on the catalog AMQP queue) can be left to drain or deleted; the next hourly tick republishes to the scrape queue.
5. Confirm `QUEUE_TRANSPORT` is the same on API and worker. No new env var is required. On AMQP, allow the worker to declare `shopmon-scrape`.

Do not treat Store 429 ack/backoff (#789 / draft #814) as the shop-freshness fix.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c62fc928-05f4-4616-b5d6-571ed4007fa8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c62fc928-05f4-4616-b5d6-571ed4007fa8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

