### PR TITLE
fix(telemetry): append /v1/traces to OTLP HTTP endpoint

### DIFF
--- a/api/internal/telemetry/telemetry.go
+++ b/api/internal/telemetry/telemetry.go
@@ -79,7 +79,7 @@ func Setup(ctx context.Context, cfg Config) (shutdown func(context.Context) erro
 	// Tracing
 	if traceEndpoint != "" {
 		traceExporter, err := otlptracehttp.New(setupCtx,
-			otlptracehttp.WithEndpointURL(traceEndpoint),
+			otlptracehttp.WithEndpointURL(ensurePath(traceEndpoint, "/v1/traces")),
 		)
 		if err != nil {
 			slog.Error("failed to create OTLP trace exporter", "error", err)

--- a/api/internal/telemetry/telemetry_test.go
+++ b/api/internal/telemetry/telemetry_test.go
@@ -35,6 +35,12 @@ func TestEnsurePath(t *testing.T) {
 			want:        "http://localhost:4318/custom",
 		},
 		{
+			name:        "traces path appended",
+			endpoint:    "http://localhost:4318",
+			defaultPath: "/v1/traces",
+			want:        "http://localhost:4318/v1/traces",
+		},
+		{
 			name:        "invalid url unchanged",
 			endpoint:    "://not a url",
 			defaultPath: "/v1/logs",


### PR DESCRIPTION
## Summary

OTLP HTTP traces were POSTed to the collector root (`http://host:4318/`) and production logged `404 page not found` on every export.

`WithEndpointURL` uses the URL as-is. Logs and metrics already go through `ensurePath` (`/v1/logs`, `/v1/metrics`); traces did not. A base `OTEL_EXPORTER_OTLP_ENDPOINT` like `http://$(HOST_IP):4318` now becomes `/v1/traces`. An explicit path (local compose: `http://jaeger:4318/v1/traces`) is left unchanged.

## Test plan

- [x] `go test ./internal/telemetry/`
- [x] `mise run lint`
- [x] `mise run test`
- [ ] After deploy, worker/api logs no longer show `traces export: failed to send to http://…:4318/: 404`