### PR TITLE
Fix passkey login and registration

### DIFF
--- a/api/internal/auth/passkey.go
+++ b/api/internal/auth/passkey.go
@@ -43,13 +43,13 @@ func (h *AuthHandler) PasskeyRegister(ctx context.Context, input *passkeyRegiste
 		return nil, err
 	}
 	var metadata passkeyRegisterMetadata
-	if err := json.Unmarshal(input.RawBody, &metadata); err != nil {
+	if err := json.Unmarshal(input.Body, &metadata); err != nil {
 		return nil, huma.Error400BadRequest("invalid request body")
 	}
 	if metadata.ChallengeKey == "" {
 		return nil, huma.Error400BadRequest("challengeKey is required")
 	}
-	registered, err := h.passkeys.FinishRegistration(ctx, requestWithRawBody(ctx, input.RawBody), identitypasskey.User{
+	registered, err := h.passkeys.FinishRegistration(ctx, requestWithRawBody(ctx, input.Body), identitypasskey.User{
 		ID: principal.User.ID, Name: principal.User.Name, Email: principal.User.Email,
 	}, metadata.ChallengeKey, metadata.Name)
 	if err != nil {
@@ -70,13 +70,13 @@ func (h *AuthHandler) PasskeyLoginOptions(ctx context.Context, _ *struct{}) (*pa
 
 func (h *AuthHandler) PasskeyLogin(ctx context.Context, input *passkeyLoginInput) (*tokenUserOutput, error) {
 	var metadata passkeyLoginMetadata
-	if err := json.Unmarshal(input.RawBody, &metadata); err != nil {
+	if err := json.Unmarshal(input.Body, &metadata); err != nil {
 		return nil, huma.Error400BadRequest("invalid request body")
 	}
 	if metadata.ChallengeKey == "" {
 		return nil, huma.Error400BadRequest("challengeKey is required")
 	}
-	r := requestWithRawBody(ctx, input.RawBody)
+	r := requestWithRawBody(ctx, input.Body)
 	authentication, err := h.passkeys.FinishLogin(r, metadata.ChallengeKey, sessionMetadata(r))
 	if err != nil {
 		if errors.Is(err, identitypasskey.ErrChallenge) {

--- a/api/internal/auth/passkey_test.go
+++ b/api/internal/auth/passkey_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/descope/virtualwebauthn"
+	"github.com/friendsofshopware/shopmon/api/internal/apirouter"
+	"github.com/friendsofshopware/shopmon/api/internal/auth"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil"
+	"github.com/go-chi/chi/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -433,4 +436,23 @@ func TestPasskeyRegisterMultiple(t *testing.T) {
 	var count int
 	require.NoError(t, env.Pool.QueryRow(t.Context(), `SELECT COUNT(*) FROM passkey WHERE user_id = 'user-1'`).Scan(&count))
 	assert.Equal(t, 2, count)
+}
+
+func TestPasskeyFinishOpenAPIUsesJSON(t *testing.T) {
+	t.Parallel()
+
+	router := chi.NewRouter()
+	api := apirouter.NewAPI(router)
+	auth.Register(api, &auth.AuthHandler{})
+
+	for _, path := range []string{"/auth/passkey/login", "/auth/passkey/register"} {
+		item := api.OpenAPI().Paths[path]
+		require.NotNil(t, item, path)
+		require.NotNil(t, item.Post, path)
+		require.NotNil(t, item.Post.RequestBody, path)
+		_, hasJSON := item.Post.RequestBody.Content["application/json"]
+		_, hasOctet := item.Post.RequestBody.Content["application/octet-stream"]
+		assert.True(t, hasJSON, "%s should accept application/json", path)
+		assert.False(t, hasOctet, "%s must not be advertised as a binary upload", path)
+	}
 }

--- a/api/internal/auth/request_dto.go
+++ b/api/internal/auth/request_dto.go
@@ -1,5 +1,7 @@
 package auth
 
+import "encoding/json"
+
 type signUpEmailInput struct {
 	Body signUpEmailRequest
 }
@@ -44,11 +46,14 @@ type exchangeCodeInput struct {
 }
 
 type passkeyRegisterInput struct {
-	RawBody []byte
+	// Body must be JSON (not RawBody). RawBody is advertised as
+	// application/octet-stream, and the generated client then skips JSON
+	// serialization of the WebAuthn payload.
+	Body json.RawMessage
 }
 
 type passkeyLoginInput struct {
-	RawBody []byte
+	Body json.RawMessage
 }
 
 type tokenUserOutput struct {

--- a/api/internal/identity/passkey/decode_test.go
+++ b/api/internal/identity/passkey/decode_test.go
@@ -1,0 +1,46 @@
+package passkey
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Sample ES256 COSE key from go-webauthn's assertion tests.
+const cosePublicKeyRawURL = "pQMmIAEhWCAoCF-x0dwEhzQo-ABxHIAgr_5WL6cJceREc81oIwFn7iJYIHEHx8ZhBIE42L26-rSC_3l0ZaWEmsHAKyP9rgslApUdAQI"
+
+func TestDecodeCOSEPublicKey(t *testing.T) {
+	t.Parallel()
+
+	raw, err := base64.RawURLEncoding.DecodeString(cosePublicKeyRawURL)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{name: "raw-url", value: cosePublicKeyRawURL},
+		{name: "standard padded", value: base64.StdEncoding.EncodeToString(raw)},
+		{name: "standard raw", value: base64.RawStdEncoding.EncodeToString(raw)},
+		{name: "url padded", value: base64.URLEncoding.EncodeToString(raw)},
+		{name: "hex", value: hex.EncodeToString(raw)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			decoded, err := decodeCOSEPublicKey(tc.value)
+			require.NoError(t, err)
+			require.Equal(t, raw, decoded)
+		})
+	}
+}
+
+func TestDecodeCOSEPublicKeyRejectsGarbage(t *testing.T) {
+	t.Parallel()
+
+	_, err := decodeCOSEPublicKey("not-a-cose-key")
+	require.Error(t, err)
+}

--- a/api/internal/identity/passkey/service.go
+++ b/api/internal/identity/passkey/service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/identity"
 	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 	"github.com/go-webauthn/webauthn/webauthn"
 	"github.com/google/uuid"
 )
@@ -283,7 +284,7 @@ func storedToCredential(stored StoredPasskey) (webauthn.Credential, error) {
 	if err != nil {
 		return webauthn.Credential{}, fmt.Errorf("decode credential ID for passkey %s: %w", stored.ID, err)
 	}
-	publicKey, err := decodeBase64Any(stored.PublicKey)
+	publicKey, err := decodeCOSEPublicKey(stored.PublicKey)
 	if err != nil {
 		return webauthn.Credential{}, fmt.Errorf("decode public key for passkey %s: %w", stored.ID, err)
 	}
@@ -336,14 +337,47 @@ func credentialToStored(userID string, credential *webauthn.Credential) (StoredP
 }
 
 func decodeBase64Any(value string) ([]byte, error) {
-	for _, encoding := range []*base64.Encoding{
-		base64.RawURLEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.StdEncoding,
-	} {
+	for _, encoding := range base64Encodings {
 		if decoded, err := encoding.DecodeString(value); err == nil {
 			return decoded, nil
 		}
 	}
 	return nil, fmt.Errorf("no supported base64 encoding matched")
+}
+
+// decodeCOSEPublicKey decodes a stored WebAuthn public key and returns the
+// first candidate that parses as a COSE key. Trying encodings blindly can
+// succeed with the wrong variant and yield "Unsupported Public Key Type" at
+// assertion time — the production symptom for some better-auth rows.
+func decodeCOSEPublicKey(value string) ([]byte, error) {
+	var candidates [][]byte
+	var lastErr error
+	for _, encoding := range base64Encodings {
+		decoded, err := encoding.DecodeString(value)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		candidates = append(candidates, decoded)
+	}
+	if decoded, err := hex.DecodeString(value); err == nil {
+		candidates = append(candidates, decoded)
+	}
+	for _, decoded := range candidates {
+		if _, err := webauthncose.ParsePublicKey(decoded); err != nil {
+			lastErr = err
+			continue
+		}
+		return decoded, nil
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("no supported COSE public key encoding matched: %w", lastErr)
+	}
+	return nil, fmt.Errorf("no supported COSE public key encoding matched")
+}
+
+var base64Encodings = []*base64.Encoding{
+	base64.RawURLEncoding, base64.RawStdEncoding, base64.URLEncoding, base64.StdEncoding,
 }
 
 func generateToken() (string, error) {

--- a/frontend/src/api/generated/sdk.gen.ts
+++ b/frontend/src/api/generated/sdk.gen.ts
@@ -664,11 +664,10 @@ export const listUserPasskeys = <ThrowOnError extends boolean = false>(options?:
  * Complete passkey login
  */
 export const passkeyLogin = <ThrowOnError extends boolean = false>(options: Options<PasskeyLoginData, ThrowOnError>): RequestResult<PasskeyLoginResponses, PasskeyLoginErrors, ThrowOnError> => (options.client ?? client).post<PasskeyLoginResponses, PasskeyLoginErrors, ThrowOnError>({
-    bodySerializer: null,
     url: '/auth/passkey/login',
     ...options,
     headers: {
-        'Content-Type': 'application/octet-stream',
+        'Content-Type': 'application/json',
         ...options.headers
     }
 });
@@ -682,12 +681,11 @@ export const passkeyLoginOptions = <ThrowOnError extends boolean = false>(option
  * Complete passkey registration
  */
 export const passkeyRegister = <ThrowOnError extends boolean = false>(options: Options<PasskeyRegisterData, ThrowOnError>): RequestResult<PasskeyRegisterResponses, PasskeyRegisterErrors, ThrowOnError> => (options.client ?? client).post<PasskeyRegisterResponses, PasskeyRegisterErrors, ThrowOnError>({
-    bodySerializer: null,
     security: [{ scheme: 'bearer', type: 'http' }],
     url: '/auth/passkey/register',
     ...options,
     headers: {
-        'Content-Type': 'application/octet-stream',
+        'Content-Type': 'application/json',
         ...options.headers
     }
 });

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -3251,7 +3251,7 @@ export type ListUserPasskeysResponses = {
 export type ListUserPasskeysResponse = ListUserPasskeysResponses[keyof ListUserPasskeysResponses];
 
 export type PasskeyLoginData = {
-    body: Blob | File;
+    body: unknown;
     path?: never;
     query?: never;
     url: '/auth/passkey/login';
@@ -3301,7 +3301,7 @@ export type PasskeyLoginOptionsResponses = {
 export type PasskeyLoginOptionsResponse = PasskeyLoginOptionsResponses[keyof PasskeyLoginOptionsResponses];
 
 export type PasskeyRegisterData = {
-    body: Blob | File;
+    body: unknown;
     path?: never;
     query?: never;
     url: '/auth/passkey/register';

--- a/frontend/src/api/passkey-client.spec.ts
+++ b/frontend/src/api/passkey-client.spec.ts
@@ -35,7 +35,13 @@ describe("passkey client serialization", () => {
     );
     client.setConfig({ fetch: fetchMock, baseUrl: "http://example.test/api" });
 
-    const body = { challengeKey: "abc", name: "Laptop", id: "cred", rawId: "cred", type: "public-key" };
+    const body = {
+      challengeKey: "abc",
+      name: "Laptop",
+      id: "cred",
+      rawId: "cred",
+      type: "public-key",
+    };
     await passkeyRegister({ body });
 
     expect(fetchMock).toHaveBeenCalled();

--- a/frontend/src/api/passkey-client.spec.ts
+++ b/frontend/src/api/passkey-client.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { client } from "./generated/client.gen";
+import { passkeyLogin, passkeyRegister } from "./generated";
+
+describe("passkey client serialization", () => {
+  afterEach(() => {
+    client.setConfig({ fetch: undefined, baseUrl: "/api" });
+  });
+
+  it("sends passkey login as JSON, not a binary upload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ token: "t", user: { id: "1", name: "n", email: "e" } }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    client.setConfig({ fetch: fetchMock, baseUrl: "http://example.test/api" });
+
+    const body = { challengeKey: "abc", id: "cred", rawId: "cred", type: "public-key" };
+    await passkeyLogin({ body });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const request = fetchMock.mock.calls[0][0] as Request;
+    expect(request.headers.get("Content-Type")).toContain("application/json");
+    expect(JSON.parse(await request.clone().text())).toEqual(body);
+  });
+
+  it("sends passkey registration as JSON, not a binary upload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ id: "pk-1", name: "Laptop" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    client.setConfig({ fetch: fetchMock, baseUrl: "http://example.test/api" });
+
+    const body = { challengeKey: "abc", name: "Laptop", id: "cred", rawId: "cred", type: "public-key" };
+    await passkeyRegister({ body });
+
+    expect(fetchMock).toHaveBeenCalled();
+    const request = fetchMock.mock.calls[0][0] as Request;
+    expect(request.headers.get("Content-Type")).toContain("application/json");
+    expect(JSON.parse(await request.clone().text())).toEqual(body);
+  });
+});

--- a/frontend/src/views/account/Settings.vue
+++ b/frontend/src/views/account/Settings.vue
@@ -587,7 +587,7 @@ async function createPasskey() {
     };
     const attestation = await startRegistration({ optionsJSON: options.publicKey });
     const { error: registerError } = await passkeyRegister({
-      body: { challengeKey, name: passKeyName.value, ...attestation } as never,
+      body: { challengeKey, name: passKeyName.value, ...attestation },
     });
     if (registerError) {
       alert.error(t("settings.passkeyRegisterFailed"));

--- a/frontend/src/views/auth/Login.vue
+++ b/frontend/src/views/auth/Login.vue
@@ -220,7 +220,7 @@ async function webauthnLogin() {
 
     // Send assertion to server
     const { data: loginData, error } = await passkeyLogin({
-      body: { challengeKey, ...assertion } as never,
+      body: { challengeKey, ...assertion },
     });
 
     if (error) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Passkey creation and login both fail in the browser. The finish endpoints (`POST /auth/passkey/register` and `POST /auth/passkey/login`) used Huma `RawBody []byte`, which OpenAPI advertises as `application/octet-stream`. The generated frontend client then:

- set `bodySerializer: null` (so the WebAuthn payload was never JSON-serialized)
- sent `Content-Type: application/octet-stream`

`new Request()` rejects a plain object body, so both flows died after the authenticator prompt.

Production also logged `finish WebAuthn login: Error parsing the assertion public key: Unsupported Public Key Type` for at least one stored credential. Blind base64 decoding can succeed with the wrong encoding and yield bytes that are not a COSE key.

## Fix

- Use a JSON `Body` (`json.RawMessage`) for the finish endpoints so OpenAPI and the generated client use `application/json`
- Decode stored public keys by trying encodings until `webauthncose.ParsePublicKey` succeeds (covers better-auth standard/hex variants)
- Add OpenAPI + client serialization regression tests

## Testing

- API lint (`golangci-lint`) + frontend oxlint, `vue-tsc`, oxfmt, and 265 Vitest tests
- `mise run test` (`go test ./internal/...`)
- Targeted passkey unit, integration, and client serialization tests (see walkthrough log)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-160e481c-bf20-4be1-b6e3-128fe462a52d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-160e481c-bf20-4be1-b6e3-128fe462a52d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

