### PR TITLE
feat(ui): filter chart runs and timespan

### DIFF
--- a/frontend/src/components/layout/DataTable.vue
+++ b/frontend/src/components/layout/DataTable.vue
@@ -23,7 +23,11 @@
       </TableHeader>
 
       <TableBody>
-        <TableRow v-for="(row, rowIndex) in sortedFilteredData" :key="rowIndex">
+        <TableRow
+          v-for="(row, rowIndex) in sortedFilteredData"
+          :key="rowIndex"
+          :class="rowClass?.(row)"
+        >
           <TableCell v-for="column in columns" :key="column.key" :class="[column.class]">
             <slot :name="`cell-${column.key}`" :row="row" :row-index="rowIndex">
               {{ row[column.key] }}
@@ -94,10 +98,12 @@ const props = withDefaults(
     };
     data: RowData[];
     searchTerm?: string;
+    rowClass?: (row: RowData) => string;
   }>(),
   {
     searchTerm: "",
     defaultSort: undefined,
+    rowClass: undefined,
   },
 );
 

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -905,7 +905,8 @@
     "allTime": "Gesamter Zeitraum",
     "hideFromChart": "Diesen Lauf in den Diagrammen ausblenden",
     "showInChart": "Diesen Lauf in den Diagrammen anzeigen",
-    "showAllInChart": "Alle Läufe anzeigen"
+    "showAllInChart": "Alle Läufe anzeigen",
+    "noRunsInTimespan": "Keine Läufe im gewählten Zeitraum. Wählen Sie einen längeren Zeitraum oder blenden Sie Läufe wieder ein, um die Diagramme zu sehen."
   },
   "deployments": {
     "setupTitle": "Deployments nachverfolgen",

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -896,7 +896,16 @@
     "clsOverTime": "Cumulative Layout Shift über Zeit",
     "clsScore": "CLS-Wert",
     "date": "Datum",
-    "sitespeedDetails": "{name} Details"
+    "sitespeedDetails": "{name} Details",
+    "timespan": "Zeitraum",
+    "last7Days": "Letzte 7 Tage",
+    "last30Days": "Letzte 30 Tage",
+    "last90Days": "Letzte 90 Tage",
+    "lastYear": "Letztes Jahr",
+    "allTime": "Gesamter Zeitraum",
+    "hideFromChart": "Diesen Lauf in den Diagrammen ausblenden",
+    "showInChart": "Diesen Lauf in den Diagrammen anzeigen",
+    "showAllInChart": "Alle Läufe anzeigen"
   },
   "deployments": {
     "setupTitle": "Deployments nachverfolgen",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -896,7 +896,16 @@
     "clsOverTime": "Cumulative Layout Shift Over Time",
     "clsScore": "CLS Score",
     "date": "Date",
-    "sitespeedDetails": "{name} details"
+    "sitespeedDetails": "{name} details",
+    "timespan": "Timespan",
+    "last7Days": "Last 7 days",
+    "last30Days": "Last 30 days",
+    "last90Days": "Last 90 days",
+    "lastYear": "Last year",
+    "allTime": "All time",
+    "hideFromChart": "Hide this run from the charts",
+    "showInChart": "Show this run in the charts",
+    "showAllInChart": "Show all runs"
   },
   "deployments": {
     "setupTitle": "How to Track Deployments",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -905,7 +905,8 @@
     "allTime": "All time",
     "hideFromChart": "Hide this run from the charts",
     "showInChart": "Show this run in the charts",
-    "showAllInChart": "Show all runs"
+    "showAllInChart": "Show all runs",
+    "noRunsInTimespan": "No runs in the selected timespan. Pick a longer timespan or unhide runs to see the charts."
   },
   "deployments": {
     "setupTitle": "How to Track Deployments",

--- a/frontend/src/views/environment/detail/DetailSitespeed.spec.ts
+++ b/frontend/src/views/environment/detail/DetailSitespeed.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mount, flushPromises } from "@vue/test-utils";
+import { ref } from "vue";
+import type { ChartConfiguration } from "chart.js";
+
+// Chart.js needs a real canvas, so record the configs it would render instead.
+const chartConfigs: ChartConfiguration[] = [];
+
+vi.mock("chart.js", () => {
+  class ChartStub {
+    static register = vi.fn();
+    config: ChartConfiguration;
+    constructor(_ctx: unknown, config: ChartConfiguration) {
+      this.config = config;
+      chartConfigs.push(config);
+    }
+    destroy() {}
+  }
+  return { Chart: ChartStub, registerables: [] };
+});
+vi.mock("chartjs-plugin-annotation", () => ({ default: {} }));
+vi.mock("chartjs-adapter-date-fns", () => ({}));
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function daysAgo(days: number): string {
+  return new Date(Date.now() - days * DAY).toISOString();
+}
+
+// Two runs inside the default 30 day window, one far outside it.
+const recentRun = {
+  createdAt: daysAgo(1),
+  ttfb: 100,
+  fullyLoaded: 1000,
+  largestContentfulPaint: 900,
+  firstContentfulPaint: 800,
+  cumulativeLayoutShift: 0.01,
+  transferSize: 1024,
+};
+const secondRecentRun = {
+  createdAt: daysAgo(5),
+  ttfb: 200,
+  fullyLoaded: 2000,
+  largestContentfulPaint: 1900,
+  firstContentfulPaint: 1800,
+  cumulativeLayoutShift: 0.02,
+  transferSize: 2048,
+};
+const oldRun = {
+  createdAt: daysAgo(120),
+  ttfb: 300,
+  fullyLoaded: 3000,
+  largestContentfulPaint: 2900,
+  firstContentfulPaint: 2800,
+  cumulativeLayoutShift: 0.03,
+  transferSize: 3072,
+};
+
+const environment = ref<Record<string, unknown> | null>(null);
+
+vi.mock("@/composables/useEnvironmentDetail", () => ({
+  useEnvironmentDetail: () => ({ environment }),
+}));
+
+import DetailSitespeed from "./DetailSitespeed.vue";
+
+// The component only builds its charts once the canvas reports a real size,
+// which jsdom never does on its own.
+function stubCanvasLayout() {
+  for (const prop of ["clientWidth", "clientHeight"]) {
+    Object.defineProperty(HTMLCanvasElement.prototype, prop, {
+      configurable: true,
+      get: () => 600,
+    });
+  }
+  HTMLCanvasElement.prototype.getContext = vi.fn(
+    () => ({}) as unknown as CanvasRenderingContext2D,
+  ) as unknown as HTMLCanvasElement["getContext"];
+}
+
+/** x values (timestamps) of the first dataset of the most recent chart render. */
+function lastChartTimestamps(): number[] {
+  const config = chartConfigs[chartConfigs.length - 1];
+  const points = config.data.datasets[0].data as Array<{ x: number }>;
+  return points.map((point) => point.x);
+}
+
+async function settleCharts() {
+  await flushPromises();
+  // Two nested requestAnimationFrame hops before the charts are created.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+function mountComponent() {
+  return mount(DetailSitespeed);
+}
+
+describe("DetailSitespeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chartConfigs.length = 0;
+    stubCanvasLayout();
+    environment.value = {
+      id: 1,
+      sitespeedEnabled: true,
+      sitespeedDetailUrl: "https://sitespeed.example/result/index.html",
+      sitespeeds: [recentRun, secondRecentRun, oldRun],
+    };
+  });
+
+  it("renders a visibility toggle for every history row", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    const toggles = wrapper.findAll('button[aria-label="Hide this run from the charts"]');
+    expect(toggles).toHaveLength(3);
+  });
+
+  it("defaults the timespan to the last 30 days", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    expect(wrapper.text()).toContain("Last 30 days");
+    // The 120 day old run is outside the default window.
+    expect(lastChartTimestamps()).toEqual([
+      new Date(secondRecentRun.createdAt).getTime(),
+      new Date(recentRun.createdAt).getTime(),
+    ]);
+  });
+
+  it("drops a hidden run from the charts and keeps it in the table", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    await wrapper.findAll('button[aria-label="Hide this run from the charts"]')[0].trigger("click");
+    await settleCharts();
+
+    expect(lastChartTimestamps()).toEqual([new Date(secondRecentRun.createdAt).getTime()]);
+    expect(wrapper.findAll("tbody tr")).toHaveLength(3);
+    expect(wrapper.findAll("tbody tr")[0].classes()).toContain("opacity-50");
+  });
+
+  it("flips the toggle to a show action once a run is hidden", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    await wrapper.findAll('button[aria-label="Hide this run from the charts"]')[0].trigger("click");
+    await settleCharts();
+
+    const toggle = wrapper.findAll("tbody tr")[0].find("button");
+    expect(toggle.attributes("aria-label")).toBe("Show this run in the charts");
+    expect(toggle.attributes("aria-pressed")).toBe("true");
+  });
+
+  it("restores every hidden run via 'Show all runs'", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    await wrapper.findAll('button[aria-label="Hide this run from the charts"]')[0].trigger("click");
+    await settleCharts();
+
+    const showAll = wrapper.findAll("button").find((button) => button.text() === "Show all runs");
+    expect(showAll).toBeTruthy();
+
+    await showAll!.trigger("click");
+    await settleCharts();
+
+    expect(lastChartTimestamps()).toEqual([
+      new Date(secondRecentRun.createdAt).getTime(),
+      new Date(recentRun.createdAt).getTime(),
+    ]);
+    expect(wrapper.findAll("button").find((button) => button.text() === "Show all runs")).toBe(
+      undefined,
+    );
+  });
+
+  it("includes older runs when the timespan is widened", async () => {
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    // The Select renders a listbox only when opened, so drive the model directly.
+    (wrapper.vm as unknown as { timespan: string }).timespan = "all";
+    await settleCharts();
+
+    expect(lastChartTimestamps()).toEqual([
+      new Date(oldRun.createdAt).getTime(),
+      new Date(secondRecentRun.createdAt).getTime(),
+      new Date(recentRun.createdAt).getTime(),
+    ]);
+  });
+});

--- a/frontend/src/views/environment/detail/DetailSitespeed.spec.ts
+++ b/frontend/src/views/environment/detail/DetailSitespeed.spec.ts
@@ -174,6 +174,22 @@ describe("DetailSitespeed", () => {
     );
   });
 
+  it("explains an empty result instead of rendering blank charts", async () => {
+    environment.value = { ...environment.value, sitespeeds: [oldRun] };
+    const wrapper = mountComponent();
+    await settleCharts();
+
+    // The single run is 120 days old, so the default 30 day window is empty.
+    expect(wrapper.find("canvas").exists()).toBe(false);
+    expect(wrapper.text()).toContain("No runs in the selected timespan");
+
+    (wrapper.vm as unknown as { timespan: string }).timespan = "all";
+    await settleCharts();
+
+    expect(wrapper.find("canvas").exists()).toBe(true);
+    expect(wrapper.text()).not.toContain("No runs in the selected timespan");
+  });
+
   it("includes older runs when the timespan is widened", async () => {
     const wrapper = mountComponent();
     await settleCharts();

--- a/frontend/src/views/environment/detail/DetailSitespeed.vue
+++ b/frontend/src/views/environment/detail/DetailSitespeed.vue
@@ -45,7 +45,7 @@
     </div>
 
     <!-- Charts -->
-    <template v-if="showSitespeedData">
+    <template v-if="showSitespeedData && visibleSitespeeds.length">
       <Card>
         <CardHeader class="pb-2">
           <CardTitle class="text-base">{{ $t("sitespeed.performanceOverTime") }}</CardTitle>
@@ -81,6 +81,15 @@
         </Card>
       </div>
     </template>
+
+    <!-- Every run is outside the selected timespan or hidden: say so, otherwise
+         the three empty charts read as a rendering failure. -->
+    <Card v-else-if="showSitespeedData">
+      <CardContent class="p-6 text-center text-muted-foreground">
+        <icon-fa6-solid:chart-line class="mx-auto mb-2 size-6 opacity-50" />
+        <p>{{ $t("sitespeed.noRunsInTimespan") }}</p>
+      </CardContent>
+    </Card>
 
     <!-- History table -->
     <Card v-if="environment.sitespeeds?.length" class="overflow-hidden p-0">

--- a/frontend/src/views/environment/detail/DetailSitespeed.vue
+++ b/frontend/src/views/environment/detail/DetailSitespeed.vue
@@ -20,16 +20,28 @@
       </Card>
     </div>
 
-    <!-- External link -->
-    <div v-if="environment.sitespeedDetailUrl" class="flex items-center justify-between">
+    <!-- Timespan filter + external link -->
+    <div class="flex flex-wrap items-center justify-between gap-3">
       <h2 class="text-lg font-semibold">{{ $t("shopDetail.performanceOverTime") }}</h2>
-      <Button variant="outline" size="sm" as-child>
-        <a :href="environment.sitespeedDetailUrl" target="_blank">
-          <icon-fa6-solid:chart-line class="mr-1.5 size-3" />
-          {{ $t("sitespeed.sitespeedDetails", { name: $t("nav.sitespeed") }) }}
-          <icon-fa6-solid:arrow-up-right-from-square class="ml-1.5 size-2.5" />
-        </a>
-      </Button>
+      <div class="flex items-center gap-2">
+        <Select v-model="timespan">
+          <SelectTrigger class="w-44" :aria-label="$t('sitespeed.timespan')">
+            <SelectValue :placeholder="$t('sitespeed.timespan')" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem v-for="option in timespanOptions" :key="option.value" :value="option.value">
+              {{ option.label }}
+            </SelectItem>
+          </SelectContent>
+        </Select>
+        <Button v-if="environment.sitespeedDetailUrl" variant="outline" size="sm" as-child>
+          <a :href="environment.sitespeedDetailUrl" target="_blank">
+            <icon-fa6-solid:chart-line class="mr-1.5 size-3" />
+            {{ $t("sitespeed.sitespeedDetails", { name: $t("nav.sitespeed") }) }}
+            <icon-fa6-solid:arrow-up-right-from-square class="ml-1.5 size-2.5" />
+          </a>
+        </Button>
+      </div>
     </div>
 
     <!-- Charts -->
@@ -88,6 +100,7 @@
             { key: 'transferSize', name: t('shopDetail.size'), sortable: true },
           ]"
           :data="environment.sitespeeds"
+          :row-class="(row) => (isRunHidden(row) ? 'opacity-50' : '')"
         >
           <template #cell-createdAt="{ row }">
             <span class="tabular-nums text-muted-foreground">{{
@@ -140,6 +153,35 @@
               row.transferSize ? formatBytes(row.transferSize) : "—"
             }}</span>
           </template>
+          <template #cell-actions-header>
+            <Button
+              v-if="hiddenRuns.size"
+              variant="ghost"
+              size="sm"
+              class="h-7 text-xs font-normal"
+              @click="showAllRuns"
+            >
+              {{ $t("sitespeed.showAllInChart") }}
+            </Button>
+          </template>
+          <template #cell-actions="{ row }">
+            <Button
+              variant="ghost"
+              size="icon"
+              class="size-8 text-muted-foreground hover:text-foreground"
+              :title="
+                isRunHidden(row) ? $t('sitespeed.showInChart') : $t('sitespeed.hideFromChart')
+              "
+              :aria-label="
+                isRunHidden(row) ? $t('sitespeed.showInChart') : $t('sitespeed.hideFromChart')
+              "
+              :aria-pressed="isRunHidden(row)"
+              @click="toggleRunVisibility(row)"
+            >
+              <icon-fa6-solid:eye-slash v-if="isRunHidden(row)" class="size-3.5" />
+              <icon-fa6-solid:eye v-else class="size-3.5" />
+            </Button>
+          </template>
         </DataTable>
       </CardContent>
     </Card>
@@ -157,6 +199,13 @@ import { useEnvironmentDetail } from "@/composables/useEnvironmentDetail";
 import { useI18n } from "vue-i18n";
 
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import DataTable from "@/components/layout/DataTable.vue";
@@ -169,6 +218,57 @@ Chart.register(...registerables, annotationPlugin);
 const showSitespeedData = computed(
   () => environment.value?.sitespeedEnabled && (environment.value?.sitespeeds?.length ?? 0) > 0,
 );
+
+// ── Chart visibility ──
+// Runs the user hid via the eye button in the history table. They stay in the
+// table (dimmed) and in the summary cards, and only drop out of the charts, so
+// a single outlier run cannot flatten the rest of the curve.
+const hiddenRuns = ref(new Set<string>());
+
+function isRunHidden(run: { createdAt: string }): boolean {
+  return hiddenRuns.value.has(run.createdAt);
+}
+
+function toggleRunVisibility(run: { createdAt: string }) {
+  // Replace the Set so the computed chart data and the icons react to the change.
+  const next = new Set(hiddenRuns.value);
+  if (!next.delete(run.createdAt)) next.add(run.createdAt);
+  hiddenRuns.value = next;
+}
+
+function showAllRuns() {
+  hiddenRuns.value = new Set();
+}
+
+// ── Chart timespan ──
+// Days of history the charts cover; null keeps every run.
+const timespanDays: Record<string, number | null> = {
+  "7d": 7,
+  "30d": 30,
+  "90d": 90,
+  "1y": 365,
+  all: null,
+};
+
+const timespan = ref("30d");
+
+const timespanOptions = computed(() => [
+  { value: "7d", label: t("sitespeed.last7Days") },
+  { value: "30d", label: t("sitespeed.last30Days") },
+  { value: "90d", label: t("sitespeed.last90Days") },
+  { value: "1y", label: t("sitespeed.lastYear") },
+  { value: "all", label: t("sitespeed.allTime") },
+]);
+
+const visibleSitespeeds = computed(() => {
+  const entries = environment.value?.sitespeeds ?? [];
+  const days = timespanDays[timespan.value] ?? null;
+  const cutoff = days === null ? null : Date.now() - days * 24 * 60 * 60 * 1000;
+  return entries.filter(
+    (entry) =>
+      !isRunHidden(entry) && (cutoff === null || new Date(entry.createdAt).getTime() >= cutoff),
+  );
+});
 
 // Latest entry
 const latest = computed(() => {
@@ -295,9 +395,8 @@ const clsChartCanvas = ref<HTMLCanvasElement | null>(null);
 const clsChartInstance = ref<Chart | null>(null);
 
 const deploymentMarkers = computed(() => {
-  if (!environment.value?.sitespeeds) return [];
   const map = new Map<number, { id: number; name: string; timestamp: number }>();
-  environment.value.sitespeeds.forEach((item) => {
+  visibleSitespeeds.value.forEach((item) => {
     if (item.deployment?.id && !map.has(item.deployment.id)) {
       map.set(item.deployment.id, {
         id: item.deployment.id,
@@ -390,13 +489,13 @@ const chartConfigs: ChartConfig[] = [
 ];
 
 function createChart(config: ChartConfig) {
-  if (!config.canvasRef.value || !environment.value?.sitespeeds) return;
+  if (!config.canvasRef.value) return;
   config.chartInstance.value?.destroy();
 
   const ctx = config.canvasRef.value.getContext("2d");
   if (!ctx) return;
 
-  const sorted = [...environment.value.sitespeeds].sort(
+  const sorted = [...visibleSitespeeds.value].sort(
     (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
   );
 
@@ -459,7 +558,15 @@ function createChart(config: ChartConfig) {
       scales: {
         x: {
           type: "time",
-          time: { unit: "day", displayFormats: { day: "MMM dd" } },
+          // No fixed unit: a short timespan can hold several runs of the same day,
+          // which a day unit collapses into a single unlabelled tick. minUnit keeps
+          // it from going down to seconds, and the tick cap keeps the axis readable
+          // whether it spans an hour or a year.
+          time: {
+            minUnit: "minute",
+            displayFormats: { minute: "MMM dd HH:mm", hour: "MMM dd HH:mm", day: "MMM dd" },
+          },
+          ticks: { autoSkip: true, maxTicksLimit: 8, maxRotation: 0 },
           title: { display: false },
         },
         y: { beginAtZero: true, title: { display: true, text: config.yAxisLabel } },
@@ -505,4 +612,6 @@ watch(
   () => void renderCharts(),
   { deep: true },
 );
+
+watch([hiddenRuns, timespan], () => void renderCharts());
 </script>


### PR DESCRIPTION
This pull request adds significant new functionality to the sitespeed history charts and table, focusing on improved data filtering and user control. It introduces the ability to filter chart data by timespan (e.g., last 7/30/90 days, year, or all time) and to hide or show individual data runs from the charts without removing them from the table. The UI is updated to support these features, and comprehensive tests are included to verify the new behaviors. Localization strings are also added for the new controls.

**Sitespeed chart and table enhancements:**

* Added a timespan filter (`Select` dropdown) above the sitespeed charts, allowing users to choose which period of runs to display (last 7/30/90 days, last year, or all time). The chart data now reacts to this filter. [[1]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aL23-R45) [[2]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aR222-R272)
* Implemented per-run visibility toggles in the sitespeed history table, enabling users to hide or show specific runs from the charts (hidden runs are dimmed in the table and can be restored with a "Show all runs" button). [[1]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aR103) [[2]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aR156-R184) [[3]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aR222-R272)
* The chart rendering logic now only includes runs that are both within the selected timespan and not hidden, and deployment markers are updated accordingly. [[1]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aL298-R399) [[2]](diffhunk://#diff-4d25e70dfcbafe57961054b319be31aa8bf0030ecf1241c6af4dbc679ba80c7aL393-R498)
* Improved the chart X axis to better handle variable timespans and avoid label overlap, especially when multiple runs occur on the same day.

**Component and test updates:**

* Updated `DataTable.vue` to support a `rowClass` prop for dynamic row styling, used to dim hidden runs. [[1]](diffhunk://#diff-ab615a1789a5d15282beb166ee2f4279ffc99afeda34aad0352349e621184be5L26-R30) [[2]](diffhunk://#diff-ab615a1789a5d15282beb166ee2f4279ffc99afeda34aad0352349e621184be5R101-R106)
* Added a comprehensive test suite (`DetailSitespeed.spec.ts`) to verify timespan filtering, run visibility toggling, and UI behaviors.

**Localization:**

* Added new translation strings for timespan options and run visibility controls in both English and German locales. [[1]](diffhunk://#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31cL899-R908) [[2]](diffhunk://#diff-c7dac166523f65b3b341b97acb20491b5b38e9b5cb20084e8db308b148f89944L899-R908)