### PR TITLE
fix(ui): add missing snippets

### DIFF
--- a/frontend/src/components/shop/AddApiKeyModal.vue
+++ b/frontend/src/components/shop/AddApiKeyModal.vue
@@ -12,7 +12,7 @@
             <FormControl>
               <Input
                 v-bind="componentField"
-                :placeholder="$t('shop.apiKeyNamePlaceholder')"
+                :placeholder="$t('shop.apiKeyPlaceholder')"
                 autocomplete="off"
               />
             </FormControl>

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -321,7 +321,11 @@
     "title": "Ökosystem",
     "description": "Aggregierte Wachstums- und Shopware-Versionsstatistiken über ganz Shopmon hinweg.",
     "loading": "Ökosystem-Statistiken werden geladen...",
-    "groupByMinor": "Nach Minor-Version gruppieren"
+    "environmentsGrowth": "Umgebungswachstum",
+    "userGrowth": "Benutzerwachstum",
+    "shopwareDistribution": "Shopware-Versionsverteilung",
+    "groupByMinor": "Nach Minor-Version gruppieren",
+    "noVersionData": "Noch keine Versionsdaten verfügbar."
   },
   "notFound": {
     "title": "Seite nicht gefunden",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -321,7 +321,11 @@
     "title": "Ecosystem",
     "description": "Aggregate growth and Shopware version statistics across all of Shopmon.",
     "loading": "Loading ecosystem statistics...",
-    "groupByMinor": "Group by minor version"
+    "environmentsGrowth": "Environment Growth",
+    "userGrowth": "User Growth",
+    "shopwareDistribution": "Shopware Version Distribution",
+    "groupByMinor": "Group by minor version",
+    "noVersionData": "No version data available yet."
   },
   "notFound": {
     "title": "Page not found",


### PR DESCRIPTION
This pull request introduces minor UI and localization improvements, mainly updating placeholder text and adding new translation keys to support additional labels and messages in the ecosystem statistics section.

Localization updates:

* Added new translation keys for ecosystem statistics, including `environmentsGrowth`, `userGrowth`, `shopwareDistribution`, and `noVersionData` in both the English and German locale files (`frontend/src/locales/en.json`, `frontend/src/locales/de.json`). [[1]](diffhunk://#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31cL324-R328) [[2]](diffhunk://#diff-c7dac166523f65b3b341b97acb20491b5b38e9b5cb20084e8db308b148f89944L324-R328)

UI improvements:

* Updated the placeholder text in the `AddApiKeyModal` component to use the correct translation key (`shop.apiKeyPlaceholder`) instead of `shop.apiKeyNamePlaceholder` (`frontend/src/components/shop/AddApiKeyModal.vue`).