### PR TITLE
fix(db): space out history seeding

### DIFF
--- a/api/fixtures.go
+++ b/api/fixtures.go
@@ -540,8 +540,10 @@ func (s *seeder) seedDeployments(environmentID int32) []deploymentRef {
 	return deployments
 }
 
-// seedSitespeed creates sitespeed samples every ~6h over the last 7 days, with a
-// performance penalty applied to samples taken shortly after a deployment.
+// seedSitespeed creates one sitespeed sample per day over the last month, with a
+// performance penalty applied to samples taken shortly after a deployment. Daily
+// steps keep every sample at least a day apart from its neighbours, so the charts
+// show a real trend line instead of one stack of points.
 func (s *seeder) seedSitespeed(environmentID int32, deployments []deploymentRef) {
 	const (
 		baseTTFB         = 120.0
@@ -551,16 +553,20 @@ func (s *seeder) seedSitespeed(environmentID int32, deployments []deploymentRef)
 		baseCLS          = 0.05
 		baseTransferSize = 1200000.0
 	)
+	// One sample per day, so consecutive entries are always a day apart.
+	const sampleDays = 29
 	count := 0
 
-	for hoursAgo := 7 * 24; hoursAgo >= 0; hoursAgo -= 6 {
-		createdAt := s.now.Add(-time.Duration(hoursAgo) * time.Hour)
+	for daysAgo := sampleDays - 1; daysAgo >= 0; daysAgo-- {
+		createdAt := s.now.AddDate(0, 0, -daysAgo)
 
 		var deploymentID *int32
 		deploymentPenalty := 1.0
 		for _, d := range deployments {
+			// A sample belongs to the deployment that happened within the day
+			// before it — the sampling interval, so no deployment is missed.
 			diff := createdAt.Sub(d.createdAt)
-			if diff >= 0 && diff < 2*time.Hour {
+			if diff >= 0 && diff < 24*time.Hour {
 				id := d.id
 				deploymentID = &id
 				deploymentPenalty = 1.3
@@ -577,9 +583,10 @@ func (s *seeder) seedSitespeed(environmentID int32, deployments []deploymentRef)
 		cls := float32(math.Round(baseCLS*jitter()*deploymentPenalty*1000) / 1000)
 		transferSize := int32(math.Round(baseTransferSize * jitter()))
 
-		if err := s.q.InsertEnvironmentSitespeed(s.ctx, queries.InsertEnvironmentSitespeedParams{
+		if err := s.q.InsertEnvironmentSitespeedAt(s.ctx, queries.InsertEnvironmentSitespeedAtParams{
 			EnvironmentID:          &environmentID,
 			DeploymentID:           deploymentID,
+			CreatedAt:              pgtype.Timestamp{Time: createdAt, Valid: true},
 			Ttfb:                   &ttfb,
 			FullyLoaded:            &fullyLoaded,
 			LargestContentfulPaint: &lcp,

--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -958,6 +958,40 @@ func (q *Queries) InsertEnvironmentSitespeed(ctx context.Context, arg InsertEnvi
 	return err
 }
 
+const insertEnvironmentSitespeedAt = `-- name: InsertEnvironmentSitespeedAt :exec
+INSERT INTO environment_sitespeed (environment_id, deployment_id, created_at, ttfb, fully_loaded, largest_contentful_paint, first_contentful_paint, cumulative_layout_shift, transfer_size)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`
+
+type InsertEnvironmentSitespeedAtParams struct {
+	EnvironmentID          *int32           `json:"environment_id"`
+	DeploymentID           *int32           `json:"deployment_id"`
+	CreatedAt              pgtype.Timestamp `json:"created_at"`
+	Ttfb                   *int32           `json:"ttfb"`
+	FullyLoaded            *int32           `json:"fully_loaded"`
+	LargestContentfulPaint *int32           `json:"largest_contentful_paint"`
+	FirstContentfulPaint   *int32           `json:"first_contentful_paint"`
+	CumulativeLayoutShift  *float32         `json:"cumulative_layout_shift"`
+	TransferSize           *int32           `json:"transfer_size"`
+}
+
+// Same insert with an explicit timestamp. Fixtures use it to seed a history that
+// spans days; NOW() would collapse every seeded sample onto the seeding moment.
+func (q *Queries) InsertEnvironmentSitespeedAt(ctx context.Context, arg InsertEnvironmentSitespeedAtParams) error {
+	_, err := q.db.Exec(ctx, insertEnvironmentSitespeedAt,
+		arg.EnvironmentID,
+		arg.DeploymentID,
+		arg.CreatedAt,
+		arg.Ttfb,
+		arg.FullyLoaded,
+		arg.LargestContentfulPaint,
+		arg.FirstContentfulPaint,
+		arg.CumulativeLayoutShift,
+		arg.TransferSize,
+	)
+	return err
+}
+
 const listEnvironmentsByOrganization = `-- name: ListEnvironmentsByOrganization :many
 SELECT e.id, e.name, e.url, e.favicon, e.status, e.shopware_version,
        e.last_scraped_at, e.last_scraped_error, e.created_at, e.shop_id, e.organization_id,

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -267,6 +267,12 @@ SELECT e.id, e.url, e.sitespeed_urls, e.active_deployment_id, e.environment_toke
 INSERT INTO environment_sitespeed (environment_id, deployment_id, created_at, ttfb, fully_loaded, largest_contentful_paint, first_contentful_paint, cumulative_layout_shift, transfer_size)
 VALUES ($1, $2, NOW(), $3, $4, $5, $6, $7, $8);
 
+-- Same insert with an explicit timestamp. Fixtures use it to seed a history that
+-- spans days; NOW() would collapse every seeded sample onto the seeding moment.
+-- name: InsertEnvironmentSitespeedAt :exec
+INSERT INTO environment_sitespeed (environment_id, deployment_id, created_at, ttfb, fully_loaded, largest_contentful_paint, first_contentful_paint, cumulative_layout_shift, transfer_size)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
+
 -- name: GetEnvironmentNotificationSubscribers :many
 SELECT u.id, u.name, u.email, u.locale
 FROM "user" u


### PR DESCRIPTION
This pull request updates the sitespeed seeding logic to generate more realistic historical data and introduces a new database method for inserting sitespeed samples with explicit timestamps. The main goal is to ensure seeded sitespeed data is distributed one sample per day over the last month, rather than every 6 hours over a week, and to avoid all samples being timestamped at the seeding moment.

**Improvements to sitespeed seeding:**

* Changed `seedSitespeed` to create one sample per day for the past 29 days, instead of every 6 hours over 7 days, ensuring samples are spaced out and trend lines in charts are meaningful. [[1]](diffhunk://#diff-e0d4c1422e9dfe977e1ae0aabbebb1c823c2de7d0290a5bb0f1ac3fa749bc3e2L543-R546) [[2]](diffhunk://#diff-e0d4c1422e9dfe977e1ae0aabbebb1c823c2de7d0290a5bb0f1ac3fa749bc3e2R556-R569)
* Adjusted logic to associate a sitespeed sample with a deployment if the deployment happened within the previous 24 hours, rather than 2 hours.

**Database and query enhancements:**

* Added a new SQL query and Go method, `InsertEnvironmentSitespeedAt`, allowing insertion of sitespeed samples with an explicit `created_at` timestamp, which is used by the fixtures to create historical data. [[1]](diffhunk://#diff-bf672c23695ee58e943b53c9366f4f918cf7415123f45cef277f81c0b2ae1b73R961-R994) [[2]](diffhunk://#diff-ba5c9210be4bc647e7b59b73f9619e59bd58b4f266bc6075e47b944cf23416b7R270-R275)
* Updated the seeder to use the new `InsertEnvironmentSitespeedAt` method, passing the correct timestamp for each sample.