### PR TITLE
feat(environments): show last deployment date

### DIFF
--- a/api/internal/api/models.go
+++ b/api/internal/api/models.go
@@ -1075,6 +1075,7 @@ type EnvironmentDetail struct {
 	Id                 int                    `json:"id"`
 	Ignores            *[]string              `json:"ignores"`
 	LastChangelog      *AccountChangelog      `json:"lastChangelog"`
+	LastDeploymentAt   *time.Time             `json:"lastDeploymentAt"`
 	LastScrapedAt      *time.Time             `json:"lastScrapedAt"`
 	LastScrapedError   *string                `json:"lastScrapedError"`
 	Name               string                 `json:"name"`

--- a/api/internal/database/queries/environment.sql.go
+++ b/api/internal/database/queries/environment.sql.go
@@ -503,6 +503,21 @@ func (q *Queries) GetEnvironmentForScrape(ctx context.Context, id int32) (GetEnv
 	return i, err
 }
 
+const getEnvironmentLastDeploymentAt = `-- name: GetEnvironmentLastDeploymentAt :one
+SELECT created_at
+FROM deployment
+WHERE environment_id = $1
+ORDER BY created_at DESC
+LIMIT 1
+`
+
+func (q *Queries) GetEnvironmentLastDeploymentAt(ctx context.Context, environmentID int32) (pgtype.Timestamp, error) {
+	row := q.db.QueryRow(ctx, getEnvironmentLastDeploymentAt, environmentID)
+	var created_at pgtype.Timestamp
+	err := row.Scan(&created_at)
+	return created_at, err
+}
+
 const getEnvironmentNotificationSubscribers = `-- name: GetEnvironmentNotificationSubscribers :many
 SELECT u.id, u.name, u.email, u.locale
 FROM "user" u

--- a/api/internal/handler/environment_test.go
+++ b/api/internal/handler/environment_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/friendsofshopware/shopmon/api/internal/api"
 	"github.com/friendsofshopware/shopmon/api/internal/crypto"
@@ -83,6 +84,45 @@ func TestGetEnvironment(t *testing.T) {
 	assert.NotNil(t, environment.ScheduledTasks)
 	assert.NotNil(t, environment.Queues)
 	assert.NotNil(t, environment.Checks)
+	assert.Equal(t, 0, environment.DeploymentsCount)
+	assert.Nil(t, environment.LastDeploymentAt)
+}
+
+// TestGetEnvironment_LastDeployment covers the deployment summary in the detail
+// payload: the total count plus the timestamp of the most recent deployment.
+func TestGetEnvironment_LastDeployment(t *testing.T) {
+	env := testutil.Setup(t)
+	token := env.SeedUser(t, "user-1", "Test User", "test@example.com", "user")
+	env.SeedOrganization(t, "org-1", "Test Org", "test-org", "user-1")
+	shopID := env.SeedShop(t, "org-1", "Test Shop")
+	environmentID := env.SeedEnvironment(t, "org-1", shopID, "My Environment", "https://env.example.com")
+
+	// Seed the older deployment last so the query cannot pass by insertion order.
+	latest := time.Now().UTC().Truncate(time.Microsecond)
+	older := latest.Add(-24 * time.Hour)
+	for _, createdAt := range []time.Time{latest, older} {
+		_, err := env.Pool.Exec(t.Context(), `
+			INSERT INTO deployment (environment_id, name, command, return_code, start_date, end_date, execution_time, created_at)
+			VALUES ($1, 'Deploy', 'bin/console deploy', 0, $2, $2, 12.5, $2)
+		`, environmentID, createdAt)
+		require.NoError(t, err)
+	}
+
+	req := testutil.NewRequest(t, "GET", fmt.Sprintf("%s/api/environments/%d", env.Server.URL, environmentID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var environment api.EnvironmentDetail
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&environment))
+	assert.Equal(t, 2, environment.DeploymentsCount)
+	require.NotNil(t, environment.LastDeploymentAt)
+	assert.True(t, latest.Equal(*environment.LastDeploymentAt),
+		"expected last deployment %s, got %s", latest, *environment.LastDeploymentAt)
 }
 
 func TestGetEnvironment_NotMember(t *testing.T) {

--- a/api/internal/readmodel/environment/service.go
+++ b/api/internal/readmodel/environment/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/ptr"
 	"github.com/friendsofshopware/shopmon/api/internal/shopware"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -109,6 +110,7 @@ type detailAggregate struct {
 	sitespeeds     []queries.EnvironmentSitespeed
 	changelogCount int32
 	deployCount    int32
+	lastDeployAt   pgtype.Timestamp
 	subscribed     bool
 }
 
@@ -178,6 +180,17 @@ func (s *Service) loadAggregate(ctx context.Context, environmentID int32, langua
 			return fmt.Errorf("count environment deployments: %w", err)
 		}
 		aggregate.deployCount = count
+		return nil
+	})
+	group.Go(func() error {
+		createdAt, err := s.queries.GetEnvironmentLastDeploymentAt(groupCtx, environmentID)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("get environment last deployment: %w", err)
+		}
+		aggregate.lastDeployAt = createdAt
 		return nil
 	})
 
@@ -278,6 +291,7 @@ func (s *Service) buildDetail(environment *queries.GetEnvironmentByIDRow, aggreg
 		Sitespeeds:         mapEnvironmentSitespeeds(aggregate.sitespeeds),
 		ChangelogsCount:    int(aggregate.changelogCount),
 		DeploymentsCount:   int(aggregate.deployCount),
+		LastDeploymentAt:   database.TimePtr(aggregate.lastDeployAt),
 		LastChangelog:      lastChangelog,
 		Subscribed:         aggregate.subscribed,
 	}, nil

--- a/api/sql/queries/environment.sql
+++ b/api/sql/queries/environment.sql
@@ -104,6 +104,13 @@ SELECT COUNT(*)::int FROM environment_changelog WHERE environment_id = $1;
 -- name: CountEnvironmentDeployments :one
 SELECT COUNT(*)::int FROM deployment WHERE environment_id = $1;
 
+-- name: GetEnvironmentLastDeploymentAt :one
+SELECT created_at
+FROM deployment
+WHERE environment_id = $1
+ORDER BY created_at DESC
+LIMIT 1;
+
 -- name: UpdateEnvironmentSitespeedSettings :exec
 UPDATE environment SET sitespeed_enabled = $1, sitespeed_urls = $2 WHERE id = $3;
 

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -711,6 +711,7 @@ export type EnvironmentDetail = {
     id: number;
     ignores: Array<string>;
     lastChangelog: AccountChangelog;
+    lastDeploymentAt: string | null;
     lastScrapedAt: string | null;
     lastScrapedError: string | null;
     name: string;

--- a/frontend/src/locales/de.json
+++ b/frontend/src/locales/de.json
@@ -819,6 +819,7 @@
     "lastCheckedAt": "Zuletzt geprüft am",
     "shopUpdateTooltip": "Umgebung wird automatisch einmal pro Stunde aktualisiert",
     "lastShopUpdate": "Letzte Umgebungs-Aktualisierung",
+    "deploymentsCount": "Anzahl Deployments",
     "lastDeployment": "Letztes Deployment",
     "environment": "Umgebung",
     "cacheAdapter": "Cache-Adapter",

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -819,6 +819,7 @@
     "lastCheckedAt": "Last Checked At",
     "shopUpdateTooltip": "Environment is updated once an hour automatically",
     "lastShopUpdate": "Last Environment Update",
+    "deploymentsCount": "Deployment Count",
     "lastDeployment": "Last Deployment",
     "environment": "Environment",
     "cacheAdapter": "Cache Adapter",

--- a/frontend/src/views/environment/detail/DetailEnvironment.vue
+++ b/frontend/src/views/environment/detail/DetailEnvironment.vue
@@ -418,11 +418,17 @@ const infoItems = computed(() => {
         : t("common.never"),
     },
     {
-      label: t("shopDetail.lastDeployment"),
+      label: t("shopDetail.deploymentsCount"),
       value:
         environment.value.deploymentsCount > 0
           ? t("deployments.count", { count: environment.value.deploymentsCount })
           : t("common.never"),
+    },
+    {
+      label: t("shopDetail.lastDeployment"),
+      value: environment.value.lastDeploymentAt
+        ? formatDateTime(environment.value.lastDeploymentAt)
+        : t("common.never"),
     },
     { label: t("shopDetail.environment"), value: environment.value.cache?.environment ?? "-" },
     { label: t("shopDetail.cacheAdapter"), value: environment.value.cache?.cacheAdapter ?? "-" },


### PR DESCRIPTION
This pull request adds support for displaying deployment statistics in the environment detail view, including the total number of deployments and the timestamp of the most recent deployment. The changes span backend database queries, API models, service aggregation logic, localization, and the frontend display to ensure this information is accurately fetched and presented to users.

**Backend: Deployment statistics aggregation**
- Added a new SQL query and corresponding Go method to fetch the timestamp of the latest deployment for a given environment (`GetEnvironmentLastDeploymentAt`). [[1]](diffhunk://#diff-ba5c9210be4bc647e7b59b73f9619e59bd58b4f266bc6075e47b944cf23416b7R107-R113) [[2]](diffhunk://#diff-bf672c23695ee58e943b53c9366f4f918cf7415123f45cef277f81c0b2ae1b73R506-R520)
- Updated the environment detail aggregation logic and model to include the last deployment timestamp, ensuring this data is available in API responses. [[1]](diffhunk://#diff-d35101c0a7333f4a54d760720c429e2ccc5a5a50ca1ebe89ca3ac69e6a27b3b5R113) [[2]](diffhunk://#diff-d35101c0a7333f4a54d760720c429e2ccc5a5a50ca1ebe89ca3ac69e6a27b3b5R185-R195) [[3]](diffhunk://#diff-d35101c0a7333f4a54d760720c429e2ccc5a5a50ca1ebe89ca3ac69e6a27b3b5R294) [[4]](diffhunk://#diff-0395e7099a75a4a48a2d986e2e9d4a15eace7a27685bb63faaf7a6af42eb5bb6R1078)

**Testing**
- Added a new test to verify that the environment detail API returns both the correct deployment count and the timestamp of the latest deployment. [[1]](diffhunk://#diff-702a98568caba555e2b450d30679355cf50c785efa8b09120e9d365512099d75R87-R125) [[2]](diffhunk://#diff-702a98568caba555e2b450d30679355cf50c785efa8b09120e9d365512099d75R11)

**Frontend: Display and localization**
- Updated the environment detail view to display both the deployment count and the last deployment timestamp, using localized labels and formatting.
- Added localization strings for "Deployment Count" in both English and German. [[1]](diffhunk://#diff-7be928071fbd8d4af08070ded91749699b7de85a5af18b91d41aeef26b98f31cR822) [[2]](diffhunk://#diff-c7dac166523f65b3b341b97acb20491b5b38e9b5cb20084e8db308b148f89944R822)