### PR TITLE
fix(frontend): make update wizard modal scrollable

### DIFF
--- a/frontend/src/components/modal/ShopwareUpdateWizard.vue
+++ b/frontend/src/components/modal/ShopwareUpdateWizard.vue
@@ -1,6 +1,6 @@
 <template>
   <Dialog :open="show" @update:open="(v: boolean) => !v && $emit('close')">
-    <DialogContent class="flex max-h-[calc(100vh-4rem)] max-w-2xl flex-col">
+    <DialogContent class="flex max-h-[calc(100dvh-4rem)] max-w-2xl flex-col">
       <DialogHeader>
         <DialogTitle class="flex items-center gap-2">
           <icon-fa6-solid:rotate />

--- a/frontend/src/components/modal/ShopwareUpdateWizard.vue
+++ b/frontend/src/components/modal/ShopwareUpdateWizard.vue
@@ -1,6 +1,6 @@
 <template>
   <Dialog :open="show" @update:open="(v: boolean) => !v && $emit('close')">
-    <DialogContent class="max-w-2xl">
+    <DialogContent class="flex max-h-[calc(100vh-4rem)] max-w-2xl flex-col">
       <DialogHeader>
         <DialogTitle class="flex items-center gap-2">
           <icon-fa6-solid:rotate />
@@ -8,18 +8,18 @@
         </DialogTitle>
       </DialogHeader>
 
-      <div>
-        <Select @update:model-value="(v) => v && $emit('versionSelected', String(v))">
-          <SelectTrigger class="mb-3 w-full">
-            <SelectValue :placeholder="$t('updateWizard.selectVersion')" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem v-for="version in shopwareVersions" :key="version" :value="version">
-              {{ version }}
-            </SelectItem>
-          </SelectContent>
-        </Select>
+      <Select @update:model-value="(v) => v && $emit('versionSelected', String(v))">
+        <SelectTrigger class="w-full shrink-0">
+          <SelectValue :placeholder="$t('updateWizard.selectVersion')" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem v-for="version in shopwareVersions" :key="version" :value="version">
+            {{ version }}
+          </SelectItem>
+        </SelectContent>
+      </Select>
 
+      <div class="-mx-6 min-h-0 overflow-y-auto px-6">
         <template v-if="loading">
           <div class="py-4 text-center">
             {{ $t("common.loading") }}


### PR DESCRIPTION
This pull request updates the layout and scrolling behavior of the `ShopwareUpdateWizard.vue` modal to improve its usability and appearance. The main changes focus on making the modal content more flexible and ensuring that overflowing content is scrollable within the dialog.

**UI and Layout Improvements:**

* Changed the root `DialogContent` to use a flex column layout and set a maximum height to ensure the modal fits within the viewport and its content is scrollable if needed.
* Wrapped the main content area in a scrollable `div` with appropriate padding and negative margins to ensure consistent spacing and allow for vertical scrolling when content overflows.

**Component Structure Adjustments:**

* Adjusted the `SelectTrigger` class to improve layout and prevent shrinking, supporting a more consistent appearance.