### PR TITLE
refactor(api): resolve Shopware compatibility from the packages.shopware.com feed

### DIFF
--- a/api/internal/catalog/securityplugin/branch.go
+++ b/api/internal/catalog/securityplugin/branch.go
@@ -3,12 +3,14 @@ package securityplugin
 import "strings"
 
 // pluginBranchToShopware maps a SwagPlatformSecurity major version to the
-// Shopware line it serves. Confirmed by probing the store's pluginsByName
-// endpoint: 6.7 resolves to 4.x, 6.6 to 3.x, 6.5 to 2.x.
+// Shopware line it serves. Confirmed by the require constraints in the
+// plugin's packages.shopware.com feed: 4.x requires ~6.7.0, 3.x ~6.6.0, 2.x
+// ~6.5.0.
 //
-// This is a constant rather than an inference. The store returns changelogs for
-// every branch regardless of the Shopware version queried, so nothing in the
-// response identifies which line a given entry belongs to.
+// This is a constant rather than an inference from the feed's constraints:
+// older branches mix constraints within one branch (1.x spans "~6.4.0",
+// ">=6.1.0 <6.5.0" and "*"), so no single line can be derived for them, and
+// the checker keeps an equivalent map that must agree with this one.
 var pluginBranchToShopware = map[string]string{
 	"4": "6.7",
 	"3": "6.6",

--- a/api/internal/catalog/securityplugin/service.go
+++ b/api/internal/catalog/securityplugin/service.go
@@ -13,17 +13,15 @@ import (
 
 	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
-	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/shopwarepackages"
 )
 
 // ExtensionName is the technical name of the Shopware Security Plugin.
 const ExtensionName = "SwagPlatformSecurity"
 
-// anchorVersions ensure every known branch is probed even when no monitored
-// shop runs that Shopware line yet. Without them a fleet that is entirely on
-// 6.7 would never learn what 3.x backports, and a shop upgrading onto 6.6 would
-// start with an empty map.
-var anchorVersions = []string{"6.7.0.0", "6.6.0.0", "6.5.0.0"}
+// PackageName is the plugin's Composer name on packages.shopware.com, whose
+// feed lists every released version with its changelog.
+const PackageName = "store.shopware.com/swagplatformsecurity"
 
 // coverageDropTolerance guards against markup drift. If a re-parse finds fewer
 // than this fraction of the identifiers a branch had before, the existing rows
@@ -33,31 +31,31 @@ const coverageDropTolerance = 0.5
 
 var tracer = otel.Tracer("shopmon/catalog/securityplugin")
 
-// StoreClient fetches plugin metadata from the Shopware account API.
-type StoreClient interface {
-	PluginsByName(ctx context.Context, locale, shopwareVersion string, technicalNames []string) ([]shopwareaccount.StorePlugin, error)
+// FeedClient fetches package feeds from the Shopware Composer repository.
+type FeedClient interface {
+	PackageFeed(ctx context.Context, name string) (*shopwarepackages.Package, error)
 }
 
 // Service refreshes the GHSA -> plugin version map.
 //
-// It calls the store directly rather than routing through the extension catalog
-// sync: that sync is driven by installed extensions, and writing catalog and
-// compatibility rows for a plugin nobody has installed would pollute the
-// extension catalog and its orphan-cleanup queries.
+// It reads the packages.shopware.com feed directly rather than routing through
+// the extension catalog sync: that sync is driven by installed extensions, and
+// writing catalog and compatibility rows for a plugin nobody has installed
+// would pollute the extension catalog and its orphan-cleanup queries.
 type Service struct {
 	// pool backs the transaction that persist() needs: the map's upserts,
 	// prune, and coverage rows must land atomically.
 	pool    *pgxpool.Pool
 	queries *queries.Queries
-	client  StoreClient
+	client  FeedClient
 	now     func() time.Time
 }
 
-func NewService(pool *pgxpool.Pool, q *queries.Queries, client StoreClient) *Service {
+func NewService(pool *pgxpool.Pool, q *queries.Queries, client FeedClient) *Service {
 	return &Service{pool: pool, queries: q, client: client, now: time.Now}
 }
 
-// Sync re-derives the whole map from the store changelog.
+// Sync re-derives the whole map from the plugin's package feed changelog.
 //
 // The changelog is small (under a hundred entries), so a full recompute is
 // cheaper than tracking deltas and is self-correcting: a fix to the parser
@@ -118,59 +116,34 @@ func (s *Service) Sync(ctx context.Context) error {
 	return nil
 }
 
-// collectChangelog probes every relevant Shopware version and merges the
-// results. One probe already returns entries for all branches, but the endpoint
-// omits the plugin entirely when no release supports the requested version, so
-// probing several versions is what makes the map robust.
+// collectChangelog fetches the plugin's packages.shopware.com feed once. The
+// feed lists every released version with its changelog regardless of any
+// Shopware version scoping, replacing the store API's pluginsByName probing:
+// one unauthenticated request instead of one request per in-use Shopware
+// version.
 func (s *Service) collectChangelog(ctx context.Context) ([]ChangelogEntry, error) {
-	versionsToProbe := map[string]bool{}
-	for _, v := range anchorVersions {
-		versionsToProbe[v] = true
-	}
-	inUse, err := s.queries.GetDistinctEnvironmentShopwareVersions(ctx)
-	if err != nil {
-		slog.WarnContext(ctx, "failed to list environment shopware versions", "error", err)
-	}
-	for _, v := range inUse {
-		if v != "" {
-			versionsToProbe[v] = true
-		}
-	}
-
 	byVersion := map[string]ChangelogEntry{}
-	var probeSucceeded bool
+	var feedSucceeded bool
 
-	for shopwareVersion := range versionsToProbe {
-		plugins, err := s.client.PluginsByName(ctx, "en_GB", shopwareVersion, []string{ExtensionName})
-		if err != nil {
-			slog.WarnContext(ctx, "failed to probe security plugin",
-				"shopwareVersion", shopwareVersion, "error", err)
-			continue
-		}
-		probeSucceeded = true
-
-		for _, plugin := range plugins {
-			if plugin.Name != ExtensionName {
+	feed, err := s.client.PackageFeed(ctx, PackageName)
+	if err != nil {
+		slog.WarnContext(ctx, "failed to fetch security plugin feed", "error", err)
+	} else {
+		feedSucceeded = true
+		for _, v := range feed.Versions {
+			if v.Version == "" {
 				continue
 			}
-			for _, entry := range plugin.Changelogs {
-				if entry.Version == "" {
-					continue
-				}
-				if _, seen := byVersion[entry.Version]; seen {
-					continue
-				}
-				byVersion[entry.Version] = ChangelogEntry{
-					Version:    entry.Version,
-					Changelog:  entry.Text,
-					ReleasedAt: parseStoreDate(entry.CreationDate.Date),
-				}
+			byVersion[v.Version] = ChangelogEntry{
+				Version:    v.Version,
+				Changelog:  v.Changelog,
+				ReleasedAt: v.ReleasedAt,
 			}
 		}
 	}
 
 	// Fall back to the catalog copy, which exists whenever a monitored shop has
-	// the plugin installed. Free, and keeps the map fresh if the store is down.
+	// the plugin installed. Free, and keeps the map fresh if the feed is down.
 	if rows, err := s.queries.GetStoreExtensionChangelogs(ctx, ExtensionName); err == nil {
 		for _, row := range rows {
 			if row.Version == "" || row.ChangelogEn == nil {
@@ -183,7 +156,7 @@ func (s *Service) collectChangelog(ctx context.Context) ([]ChangelogEntry, error
 		}
 	}
 
-	if !probeSucceeded && len(byVersion) == 0 {
+	if !feedSucceeded && len(byVersion) == 0 {
 		return nil, fmt.Errorf("no security plugin changelog could be fetched")
 	}
 
@@ -274,19 +247,6 @@ func (s *Service) persist(ctx context.Context, fixes []Fix, coverage []Coverage,
 
 	if err := tx.Commit(ctx); err != nil {
 		return fmt.Errorf("commit security plugin transaction: %w", err)
-	}
-	return nil
-}
-
-func parseStoreDate(value string) *time.Time {
-	if value == "" {
-		return nil
-	}
-	for _, layout := range []string{"2006-01-02 15:04:05.000000", "2006-01-02 15:04:05", time.RFC3339} {
-		if t, err := time.Parse(layout, value); err == nil {
-			utc := t.UTC()
-			return &utc
-		}
 	}
 	return nil
 }

--- a/api/internal/catalog/securityplugin/service_test.go
+++ b/api/internal/catalog/securityplugin/service_test.go
@@ -1,0 +1,121 @@
+package securityplugin
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/friendsofshopware/shopmon/api/internal/shopwarepackages"
+	"github.com/friendsofshopware/shopmon/api/internal/testutil"
+)
+
+type stubFeedClient struct {
+	pkg *shopwarepackages.Package
+	err error
+}
+
+func (s stubFeedClient) PackageFeed(context.Context, string) (*shopwarepackages.Package, error) {
+	return s.pkg, s.err
+}
+
+func feedVersion(version, changelog string) shopwarepackages.PackageVersion {
+	return shopwarepackages.PackageVersion{Version: version, Changelog: changelog}
+}
+
+// The feed replaces the store API probing: a single response covering every
+// branch must derive the same per-branch minimums the merged probes did.
+func TestSyncDerivesFixesFromFeed(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+
+	released := time.Date(2026, 5, 19, 13, 25, 35, 0, time.UTC)
+	feed := &shopwarepackages.Package{
+		Name: PackageName,
+		Versions: []shopwarepackages.PackageVersion{
+			{Version: "4.0.12", Changelog: "Improved the fix for GHSA-aaaa-bbbb-cccc", ReleasedAt: &released},
+			{Version: "4.0.10", Changelog: "Added fix for GHSA-aaaa-bbbb-cccc", ReleasedAt: &released},
+			{Version: "3.0.15", Changelog: "Added fix for GHSA-aaaa-bbbb-cccc"},
+			{Version: "2.0.20", Changelog: "unrelated improvements"},
+		},
+	}
+	svc := NewService(env.Pool, env.Queries, stubFeedClient{pkg: feed})
+
+	require.NoError(t, svc.Sync(ctx))
+
+	fixes, err := env.Queries.ListSecurityPluginFixes(ctx)
+	require.NoError(t, err)
+	require.Len(t, fixes, 2)
+
+	byBranch := map[string]string{}
+	for _, fix := range fixes {
+		byBranch[fix.PluginBranch] = fix.PluginVersion
+	}
+	// The 4.0.12 refinement must not raise the required version past the
+	// release that actually shipped the fix.
+	assert.Equal(t, "4.0.10", byBranch["4"])
+	assert.Equal(t, "3.0.15", byBranch["3"])
+	_, hasBranch2 := byBranch["2"]
+	assert.False(t, hasBranch2, "branch 2 never named the advisory")
+
+	coverage, err := env.Queries.ListSecurityPluginCoverage(ctx)
+	require.NoError(t, err)
+	require.Len(t, coverage, 3, "every branch in the feed is recorded as parsed")
+}
+
+func TestSyncFeedFailureWithEmptyCatalogErrors(t *testing.T) {
+	env := testutil.Setup(t)
+
+	svc := NewService(env.Pool, env.Queries, stubFeedClient{err: errors.New("feed down")})
+
+	require.Error(t, svc.Sync(context.Background()))
+}
+
+// When the feed is unreachable, the catalog copy synced from monitored shops
+// keeps the map fresh.
+func TestSyncFeedFailureFallsBackToCatalog(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+
+	_, err := env.Pool.Exec(ctx, `INSERT INTO store_extension (name) VALUES ($1)`, ExtensionName)
+	require.NoError(t, err)
+	var versionID int
+	require.NoError(t, env.Pool.QueryRow(ctx,
+		`INSERT INTO store_extension_version (extension_name, version) VALUES ($1, '4.0.10') RETURNING id`,
+		ExtensionName).Scan(&versionID))
+	_, err = env.Pool.Exec(ctx,
+		`INSERT INTO store_extension_version_translation (extension_version_id, language, changelog) VALUES ($1, 'en', 'Added fix for GHSA-aaaa-bbbb-cccc')`,
+		versionID)
+	require.NoError(t, err)
+
+	svc := NewService(env.Pool, env.Queries, stubFeedClient{err: errors.New("feed down")})
+	require.NoError(t, svc.Sync(ctx))
+
+	fixes, err := env.Queries.ListSecurityPluginFixes(ctx)
+	require.NoError(t, err)
+	require.Len(t, fixes, 1)
+	assert.Equal(t, "GHSA-AAAA-BBBB-CCCC", fixes[0].GhsaID)
+	assert.Equal(t, "4.0.10", fixes[0].PluginVersion)
+}
+
+// A feed that answers but lists no versions must not wipe the existing map.
+func TestSyncEmptyFeedKeepsExistingMap(t *testing.T) {
+	env := testutil.Setup(t)
+	ctx := context.Background()
+
+	svc := NewService(env.Pool, env.Queries, stubFeedClient{pkg: &shopwarepackages.Package{
+		Name:     PackageName,
+		Versions: []shopwarepackages.PackageVersion{feedVersion("4.0.10", "Added fix for GHSA-aaaa-bbbb-cccc")},
+	}})
+	require.NoError(t, svc.Sync(ctx))
+
+	svc = NewService(env.Pool, env.Queries, stubFeedClient{pkg: &shopwarepackages.Package{Name: PackageName}})
+	require.NoError(t, svc.Sync(ctx), "an empty feed is a warn, not a failure")
+
+	fixes, err := env.Queries.ListSecurityPluginFixes(ctx)
+	require.NoError(t, err)
+	assert.Len(t, fixes, 1, "existing fixes survive an empty feed")
+}

--- a/api/internal/catalog/sync/service.go
+++ b/api/internal/catalog/sync/service.go
@@ -2,17 +2,20 @@ package sync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
 	"slices"
 	"sort"
+	"strings"
 
 	"github.com/friendsofshopware/shopmon/api/internal/catalog/storemodel"
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
 	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/shopwarepackages"
 	"github.com/friendsofshopware/shopmon/api/internal/version"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"go.opentelemetry.io/otel"
@@ -35,6 +38,9 @@ type Service struct {
 	// account is an optional store client override (tests). When nil, SyncNames
 	// constructs one from cfg.ShopwareAPIURL.
 	account *shopwareaccount.Client
+	// packages is an optional packages.shopware.com client override (tests).
+	// When nil, SyncNames constructs one from cfg.ShopwarePackagesURL.
+	packages *shopwarepackages.Client
 }
 
 // NewService creates a new Service.
@@ -47,6 +53,13 @@ func (h *Service) accountClient() *shopwareaccount.Client {
 		return h.account
 	}
 	return shopwareaccount.NewClient(h.cfg.ShopwareAPIURL, nil)
+}
+
+func (h *Service) packagesClient() *shopwarepackages.Client {
+	if h.packages != nil {
+		return h.packages
+	}
+	return shopwarepackages.NewClient(h.cfg.ShopwarePackagesURL, nil)
 }
 
 // Sync refreshes the requested names using the normal freshness checks.
@@ -190,15 +203,43 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 
 	client := h.accountClient()
 
+	// Compatibility is resolved from the packages.shopware.com feed wherever
+	// possible: the feed lists every release with its shopware/core constraint,
+	// so the compatible latest version for every in-use Shopware version can be
+	// computed locally instead of probing the rate-limited store API once per
+	// version. The store is still probed for what the feed does not have —
+	// store membership, metadata, translations, pictures, and the changelog
+	// history the global latest version is derived from.
+	//
+	// compat[name][swv] is the compatible latest version for that Shopware
+	// version (nil for "checked, no compatible release"); feedResolved marks
+	// names whose compat map came from the feed. best[name] is the plugin data
+	// used to build the shared catalog subtree, preferring the probe with the
+	// most changelog history (which yields the correct uncapped global latest
+	// version).
+	compat := make(map[string]map[string]*string, len(needed))
+	feedResolved := make(map[string]bool, len(needed))
+	for _, name := range needed {
+		byShopwareVersion, err := h.compatibleVersionsFromFeed(ctx, name, swvs)
+		if err != nil {
+			return err
+		}
+		if byShopwareVersion != nil {
+			compat[name] = byShopwareVersion
+			feedResolved[name] = true
+		}
+	}
+
 	// The store's pluginsByName endpoint is scoped to the requested Shopware
 	// version: it omits any plugin whose releases are all incompatible with that
 	// version. So an extension must be persisted from a probe that actually
 	// returned it, not from a fixed "newest" version — otherwise an extension
 	// installed only on an older environment (whose latest release predates the
 	// newest environment's Shopware version) would be dropped from the catalog
-	// while still being marked synced. Every in-use version is therefore probed
-	// (en + de), and each extension's catalog data is taken from the richest
-	// probe that returned it.
+	// while still being marked synced. Versions are therefore walked newest
+	// first, probing only names that still need the store: not yet returned by
+	// any probe, or without feed-resolved compatibility (the feed does not
+	// cover custom plugins, so those keep the per-version probing).
 	//
 	// Versions are probed sequentially (and locales within a version serially)
 	// so a rate-limit from the store is not amplified by fan-out. On 429 after
@@ -206,18 +247,22 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 	// persisted without advancing sync bookkeeping so the next scheduled scrape
 	// can finish the work. The job returns success so the queue does not
 	// nack/retry into a still-limited Store API.
-	//
-	// compat[swv][name] is the compatible latest version the store reports for
-	// that Shopware version; best[name] is the plugin data used to build the
-	// shared catalog subtree, preferring the probe with the most changelog
-	// history (which yields the correct uncapped global latest version).
-	compat := make(map[string]map[string]string, len(swvs))
 	best := make(map[string]*storemodel.Data, len(needed))
 	anyProbeSucceeded := false
 	var rateLimitErr error
 
 	for _, swv := range swvs {
-		enPlugins, dePlugins, err := h.probeVersion(ctx, client, swv, needed)
+		var probeNames []string
+		for _, name := range needed {
+			if _, found := best[name]; !found || !feedResolved[name] {
+				probeNames = append(probeNames, name)
+			}
+		}
+		if len(probeNames) == 0 {
+			break
+		}
+
+		enPlugins, dePlugins, err := h.probeVersion(ctx, client, swv, probeNames)
 		if err != nil {
 			if shopwareaccount.IsRateLimited(err) {
 				// Stop probing further versions; continuing would only deepen the
@@ -238,17 +283,31 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 		enMap := storemodel.IndexPlugins(enPlugins)
 		deMap := storemodel.IndexPlugins(dePlugins)
 
-		versions := make(map[string]string)
-		for _, name := range needed {
+		for _, name := range probeNames {
 			sd := &storemodel.Data{English: enMap[name], German: deMap[name]}
-			if p := sd.Primary(); p != nil {
-				versions[name] = p.Version
-				if cur, ok := best[name]; !ok || len(sd.MergedChangelogs()) > len(cur.MergedChangelogs()) {
-					best[name] = sd
+			p := sd.Primary()
+
+			if !feedResolved[name] {
+				// Without a feed the compatible latest version comes from the
+				// probe itself; an absent plugin records a NULL row ("checked,
+				// no compatible release") for this Shopware version.
+				if compat[name] == nil {
+					compat[name] = make(map[string]*string, len(swvs))
 				}
+				var latest *string
+				if p != nil {
+					latest = nilIfEmpty(p.Version)
+				}
+				compat[name][swv] = latest
+			}
+
+			if p == nil {
+				continue
+			}
+			if cur, ok := best[name]; !ok || len(sd.MergedChangelogs()) > len(cur.MergedChangelogs()) {
+				best[name] = sd
 			}
 		}
-		compat[swv] = versions
 	}
 
 	if !anyProbeSucceeded {
@@ -268,7 +327,7 @@ func (h *Service) SyncNames(ctx context.Context, names []string, shopwareVersion
 		if !ok {
 			continue // not a store extension; still recorded in the bookkeeping below
 		}
-		if err := h.persistExtension(ctx, name, sd, compat); err != nil {
+		if err := h.persistExtension(ctx, name, sd, compat[name]); err != nil {
 			return err
 		}
 		synced++
@@ -320,6 +379,87 @@ func (h *Service) probeVersion(ctx context.Context, client *shopwareaccount.Clie
 		slog.Warn("failed to fetch store plugins", "locale", "de_DE", "shopwareVersion", shopwareVersion, "error", deErr)
 	}
 	return enPlugins, dePlugins, nil
+}
+
+// compatibleVersionsFromFeed resolves the latest compatible extension version
+// for each Shopware version from the packages.shopware.com feed. It returns
+// nil when the feed cannot be used — unknown package (custom plugins are not
+// on packages.shopware.com), request failure, or no version with an evaluable
+// shopware/core constraint — in which case the caller falls back to probing
+// the store API per Shopware version.
+func (h *Service) compatibleVersionsFromFeed(ctx context.Context, name string, shopwareVersions []string) (map[string]*string, error) {
+	feed, err := h.packagesClient().PackageFeed(ctx, storePackageName(name))
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if errors.Is(err, shopwarepackages.ErrNotFound) {
+			slog.DebugContext(ctx, "no packages feed for extension, falling back to store probes", "extension", name)
+		} else {
+			slog.WarnContext(ctx, "failed to fetch packages feed, falling back to store probes", "extension", name, "error", err)
+		}
+		return nil, nil
+	}
+
+	byShopwareVersion := make(map[string]*string, len(shopwareVersions))
+	evaluable := false
+	for _, swv := range shopwareVersions {
+		latest, ok := latestCompatibleVersion(feed.Versions, swv)
+		if ok {
+			evaluable = true
+		}
+		byShopwareVersion[swv] = latest
+	}
+	if !evaluable {
+		slog.WarnContext(ctx, "packages feed has no evaluable versions, falling back to store probes", "extension", name)
+		return nil, nil
+	}
+	return byShopwareVersion, nil
+}
+
+// latestCompatibleVersion returns the newest feed version whose shopware/core
+// constraint matches the given Shopware version. Versions with a pre-release
+// marker or without a constraint are skipped. The second return value reports
+// whether any version had an evaluable constraint, so the caller can tell a
+// genuinely incompatible extension apart from a feed it cannot make sense of.
+func latestCompatibleVersion(versions []shopwarepackages.PackageVersion, shopwareVersion string) (*string, bool) {
+	var latest *string
+	evaluable := false
+	for _, feedVersion := range versions {
+		constraint := shopwareCoreConstraint(feedVersion.Require)
+		if constraint == "" || strings.Contains(feedVersion.Version, "-") {
+			continue
+		}
+		ok, err := version.Satisfies(shopwareVersion, constraint)
+		if err != nil {
+			continue
+		}
+		evaluable = true
+		if !ok {
+			continue
+		}
+		if latest == nil || version.Compare(*latest, feedVersion.Version) < 0 {
+			v := feedVersion.Version
+			latest = &v
+		}
+	}
+	return latest, evaluable
+}
+
+func shopwareCoreConstraint(require map[string]string) string {
+	for packageName, constraint := range require {
+		if strings.EqualFold(packageName, "shopware/core") {
+			return constraint
+		}
+	}
+	return ""
+}
+
+// storePackageName maps a store technical name to its Composer package name on
+// packages.shopware.com, which serves every store extension under a lowercased
+// store.shopware.com/ vendor prefix.
+func storePackageName(technicalName string) string {
+	return "store.shopware.com/" + strings.ToLower(technicalName)
 }
 
 // shopwareVersionsToProbe returns every Shopware version in use by any
@@ -458,8 +598,11 @@ func persistStoreExtensionCatalog(ctx context.Context, q *queries.Queries, name 
 }
 
 // persistExtension writes one extension's catalog subtree and compatibility
-// rows in a single transaction.
-func (h *Service) persistExtension(ctx context.Context, name string, sd *storemodel.Data, compat map[string]map[string]string) error {
+// rows in a single transaction. compat maps each in-use Shopware version to
+// its compatible latest version; a nil value records "checked, no compatible
+// release", and a Shopware version absent from the map gets no row, so the
+// compatibility gap re-triggers a sync on the next scrape.
+func (h *Service) persistExtension(ctx context.Context, name string, sd *storemodel.Data, compat map[string]*string) error {
 	tx, err := h.pool.Begin(ctx)
 	if err != nil {
 		return fmt.Errorf("begin transaction: %w", err)
@@ -472,13 +615,7 @@ func (h *Service) persistExtension(ctx context.Context, name string, sd *storemo
 		return err
 	}
 
-	for swv, versions := range compat {
-		// An extension absent from a version's probe has no compatible release
-		// there; the NULL row records that the combination was checked.
-		var latest *string
-		if v, ok := versions[name]; ok && v != "" {
-			latest = &v
-		}
+	for swv, latest := range compat {
 		if err := qtx.UpsertStoreExtensionCompatibility(ctx, queries.UpsertStoreExtensionCompatibilityParams{
 			ExtensionName:   name,
 			ShopwareVersion: swv,

--- a/api/internal/catalog/sync/service_test.go
+++ b/api/internal/catalog/sync/service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/maintenance"
 	"github.com/friendsofshopware/shopmon/api/internal/metrics"
 	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/shopwarepackages"
 	"github.com/friendsofshopware/shopmon/api/internal/testutil/testdb"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/assert"
@@ -35,13 +37,25 @@ type mockExtension struct {
 	changelogVersions []string
 }
 
+// mockFeedVersion is one release in the mock packages.shopware.com feed.
+type mockFeedVersion struct {
+	version    string
+	constraint string
+}
+
 // mockStoreServer serves the pluginsByName endpoint for a configurable set of
 // extensions whose availability and reported latest version depend on the
-// requested Shopware version, and counts requests.
+// requested Shopware version, plus the packages.shopware.com package feeds,
+// and counts requests.
 type mockStoreServer struct {
 	*httptest.Server
-	requests   atomic.Int64
-	extensions map[string]*mockExtension
+	requests    atomic.Int64
+	feedRequests atomic.Int64
+	extensions  map[string]*mockExtension
+	// feeds maps a lowercased technical name to its package feed versions; a
+	// name absent from the map gets a 404 like a package unknown to
+	// packages.shopware.com.
+	feeds map[string][]mockFeedVersion
 
 	mu sync.Mutex
 	// rateLimitedVersions, when set, causes pluginsByName for those Shopware
@@ -50,6 +64,9 @@ type mockStoreServer struct {
 	// serverErrorVersions, when set, causes pluginsByName for those Shopware
 	// versions to respond with HTTP 500 (non-retryable, not a rate limit).
 	serverErrorVersions map[string]bool
+	// feedServerErrorNames, when set, causes the package feed for those
+	// lowercased names to respond with HTTP 500.
+	feedServerErrorNames map[string]bool
 	// seen records locale@shopwareVersion hits in order.
 	seen []string
 	// inFlight tracks concurrent handlers; maxInFlight is the high-water mark.
@@ -69,8 +86,16 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 				changelogVersions:       []string{"1.2.0", "1.1.0", "1.0.0"},
 			},
 		},
-		rateLimitedVersions: map[string]bool{},
-		serverErrorVersions: map[string]bool{},
+		feeds: map[string][]mockFeedVersion{
+			"froshtools": {
+				{version: "1.2.0", constraint: "~6.6.0"},
+				{version: "1.1.0", constraint: "~6.5.0"},
+				{version: "1.0.0", constraint: "~6.5.0"},
+			},
+		},
+		rateLimitedVersions:  map[string]bool{},
+		serverErrorVersions:  map[string]bool{},
+		feedServerErrorNames: map[string]bool{},
 	}
 
 	mux := http.NewServeMux()
@@ -151,6 +176,40 @@ func newMockStoreServer(t *testing.T) *mockStoreServer {
 		assert.NoError(t, json.NewEncoder(w).Encode(plugins), "encode mock response")
 	})
 
+	mux.HandleFunc("/feeds/package/store.shopware.com/", func(w http.ResponseWriter, r *http.Request) {
+		m.feedRequests.Add(1)
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/feeds/package/store.shopware.com/"), ".json")
+
+		m.mu.Lock()
+		versions, ok := m.feeds[name]
+		serverError := m.feedServerErrorNames[name]
+		m.mu.Unlock()
+
+		if serverError {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		feedVersions := make([]map[string]any, 0, len(versions))
+		for _, v := range versions {
+			feedVersions = append(feedVersions, map[string]any{
+				"version":   v.version,
+				"date":      "2023-01-01T00:00:00+00:00",
+				"changelog": "changelog " + v.version,
+				"require":   map[string]string{"shopware/core": v.constraint},
+			})
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"name":     "store.shopware.com/" + name,
+			"versions": feedVersions,
+		}), "encode mock feed response")
+	})
+
 	m.Server = httptest.NewServer(mux)
 	t.Cleanup(m.Close)
 	return m
@@ -186,7 +245,7 @@ func setupSyncTest(t *testing.T) (*Service, *pgxpool.Pool, *mockStoreServer) {
 	pool := testdb.Setup(t)
 	q := queries.New(pool)
 	store := newMockStoreServer(t)
-	h := NewService(pool, q, &config.Config{ShopwareAPIURL: store.URL})
+	h := NewService(pool, q, &config.Config{ShopwareAPIURL: store.URL, ShopwarePackagesURL: store.URL})
 
 	seedEnvironment(t, pool, "Production", "6.5.0.0")
 	seedEnvironment(t, pool, "Staging", "6.6.0.0")
@@ -291,8 +350,11 @@ func TestStoreExtensionSyncPersistsCatalog(t *testing.T) {
 
 	require.NoError(t, h.SyncNames(ctx, []string{"FroshTools", "CustomPlugin"}, "6.5.0.0", false))
 
-	// en + de for each in-use Shopware version (6.5.0.0 and 6.6.0.0).
+	// FroshTools is feed-resolved, so the store is probed at the newest version
+	// only; the feed-missing CustomPlugin keeps per-version probing:
+	// en+de at 6.6.0.0 (both names) plus en+de at 6.5.0.0 (CustomPlugin).
 	assert.Equal(t, int64(4), store.requests.Load(), "store requests")
+	assert.Equal(t, int64(2), store.feedRequests.Load(), "feed requests (FroshTools hit, CustomPlugin 404)")
 
 	for table, want := range map[string]int{
 		"store_extension":                     1,
@@ -372,6 +434,121 @@ func TestStoreExtensionSyncPersistsOlderOnlyExtension(t *testing.T) {
 	assert.Equal(t, 1, countRows(t, pool, "store_extension_sync"))
 }
 
+// TestStoreExtensionSyncCompatibilityFromFeed: compatibility for every in-use
+// Shopware version is computed from the packages feed, so the store is probed
+// only until the extension's metadata is found (newest version, en+de) instead
+// of once per in-use version.
+func TestStoreExtensionSyncCompatibilityFromFeed(t *testing.T) {
+	h, pool, store := setupSyncTest(t)
+	ctx := context.Background()
+
+	require.NoError(t, h.SyncNames(ctx, []string{"FroshTools"}, "6.5.0.0", false))
+
+	assert.Equal(t, []string{"en_GB@6.6.0.0", "de_DE@6.6.0.0"}, store.seenLocales(),
+		"feed-resolved extension is probed at the newest version only")
+	assert.Equal(t, int64(1), store.feedRequests.Load(), "one feed request")
+
+	// Both compatibility rows come from the feed — including 6.5.0.0, which was
+	// never probed against the store.
+	for swv, want := range map[string]string{"6.5.0.0": "1.1.0", "6.6.0.0": "1.2.0"} {
+		var latest *string
+		require.NoErrorf(t, pool.QueryRow(ctx, `SELECT latest_version FROM store_extension_compatibility WHERE extension_name = 'FroshTools' AND shopware_version = $1`, swv).Scan(&latest), "read compatibility %s", swv)
+		require.NotNilf(t, latest, "compatible latest for %s", swv)
+		assert.Equalf(t, want, *latest, "compatible latest for %s", swv)
+	}
+
+	// The catalog subtree is complete and nothing stays eligible for re-sync.
+	assert.Equal(t, 1, countRows(t, pool, "store_extension"))
+	assert.Equal(t, 3, countRows(t, pool, "store_extension_version"))
+	needing, err := h.namesNeedingSync(ctx, []string{"FroshTools"}, "6.5.0.0")
+	require.NoError(t, err)
+	assert.Empty(t, needing, "feed-resolved sync satisfies the compatibility check")
+}
+
+// TestStoreExtensionSyncFeedFallback: when the feed cannot be used (server
+// error, or no version with an evaluable constraint), compatibility falls back
+// to probing the store once per in-use Shopware version.
+func TestStoreExtensionSyncFeedFallback(t *testing.T) {
+	for name, mutate := range map[string]func(*mockStoreServer){
+		"feed server error": func(store *mockStoreServer) {
+			store.feedServerErrorNames["froshtools"] = true
+		},
+		"no evaluable constraint": func(store *mockStoreServer) {
+			store.feeds["froshtools"] = []mockFeedVersion{{version: "1.2.0", constraint: ""}}
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h, pool, store := setupSyncTest(t)
+			mutate(store)
+			ctx := context.Background()
+
+			require.NoError(t, h.SyncNames(ctx, []string{"FroshTools"}, "6.5.0.0", false))
+
+			assert.Equal(t, []string{
+				"en_GB@6.6.0.0", "de_DE@6.6.0.0",
+				"en_GB@6.5.0.0", "de_DE@6.5.0.0",
+			}, store.seenLocales(), "fallback probes every in-use version")
+
+			for swv, want := range map[string]string{"6.5.0.0": "1.1.0", "6.6.0.0": "1.2.0"} {
+				var latest *string
+				require.NoErrorf(t, pool.QueryRow(ctx, `SELECT latest_version FROM store_extension_compatibility WHERE extension_name = 'FroshTools' AND shopware_version = $1`, swv).Scan(&latest), "read compatibility %s", swv)
+				require.NotNilf(t, latest, "compatible latest for %s", swv)
+				assert.Equalf(t, want, *latest, "compatible latest for %s", swv)
+			}
+		})
+	}
+}
+
+func TestLatestCompatibleVersion(t *testing.T) {
+	versions := []shopwarepackages.PackageVersion{
+		{Version: "1.2.0", Require: map[string]string{"shopware/core": "~6.6.0"}},
+		{Version: "1.1.0", Require: map[string]string{"shopware/core": "~6.5.0"}},
+		{Version: "1.0.0", Require: map[string]string{"shopware/core": "~6.5.0"}},
+	}
+
+	latest, ok := latestCompatibleVersion(versions, "6.5.0.0")
+	require.True(t, ok, "evaluable")
+	require.NotNil(t, latest)
+	assert.Equal(t, "1.1.0", *latest, "newest version matching 6.5")
+
+	latest, ok = latestCompatibleVersion(versions, "6.6.0.0")
+	require.True(t, ok, "evaluable")
+	require.NotNil(t, latest)
+	assert.Equal(t, "1.2.0", *latest, "newest version matching 6.6")
+
+	// Pre-release versions and releases without a constraint are skipped.
+	withNoise := append([]shopwarepackages.PackageVersion{
+		{Version: "2.0.0-rc1", Require: map[string]string{"shopware/core": "~6.6.0"}},
+		{Version: "1.3.0"},
+	}, versions...)
+	latest, ok = latestCompatibleVersion(withNoise, "6.6.0.0")
+	require.True(t, ok, "evaluable")
+	require.NotNil(t, latest)
+	assert.Equal(t, "1.2.0", *latest, "pre-release and constraint-less versions skipped")
+
+	// The require key match is case-insensitive and range constraints work.
+	ranged := []shopwarepackages.PackageVersion{
+		{Version: "1.5.0", Require: map[string]string{"Shopware/Core": ">=6.5.0 <6.7.0"}},
+	}
+	latest, ok = latestCompatibleVersion(ranged, "6.6.0.0")
+	require.True(t, ok, "evaluable")
+	require.NotNil(t, latest)
+	assert.Equal(t, "1.5.0", *latest)
+
+	// A constrained feed that matches nothing is evaluable but yields no version.
+	latest, ok = latestCompatibleVersion(versions, "6.4.0.0")
+	require.True(t, ok, "evaluable")
+	assert.Nil(t, latest, "no compatible release")
+
+	// A feed whose constraints cannot be parsed is not evaluable at all.
+	broken := []shopwarepackages.PackageVersion{
+		{Version: "1.0.0", Require: map[string]string{"shopware/core": "not-a-constraint"}},
+	}
+	latest, ok = latestCompatibleVersion(broken, "6.6.0.0")
+	assert.False(t, ok, "not evaluable")
+	assert.Nil(t, latest)
+}
+
 // TestStoreExtensionSyncFreshIsNoop: a second sync right after the first must
 // be answered from the bookkeeping without any HTTP request or row write. This
 // is what collapses concurrent dispatches from many environments sharing the
@@ -427,10 +604,12 @@ func TestStoreExtensionSyncPicksUpNewRelease(t *testing.T) {
 	require.NoError(t, h.SyncNames(ctx, []string{"FroshTools"}, "6.5.0.0", false), "first sync")
 	before := snapshotRowVersions(t, pool)
 
-	// A new release appears and the bookkeeping ages out.
+	// A new release appears (in the store and in the packages feed) and the
+	// bookkeeping ages out.
 	frosh := store.extensions["FroshTools"]
 	frosh.latestByShopwareVersion["6.6.0.0"] = "1.3.0"
 	frosh.changelogVersions = append([]string{"1.3.0"}, frosh.changelogVersions...)
+	store.feeds["froshtools"] = append([]mockFeedVersion{{version: "1.3.0", constraint: "~6.6.0"}}, store.feeds["froshtools"]...)
 	_, err := pool.Exec(ctx, `UPDATE store_extension_sync SET last_synced_at = NOW() - INTERVAL '2 days'`)
 	require.NoError(t, err, "age sync state")
 
@@ -481,9 +660,12 @@ func TestNamesNeedingSyncCompatibilityGap(t *testing.T) {
 }
 
 // TestStoreExtensionSyncSerializesLocaleProbes: en and de for a version must
-// not run concurrently, otherwise catalog sync doubles store API pressure.
+// not run concurrently, otherwise catalog sync doubles store API pressure. The
+// feed is removed so the extension keeps per-version probing, which is what
+// exercises the multi-version walk order.
 func TestStoreExtensionSyncSerializesLocaleProbes(t *testing.T) {
 	h, _, store := setupSyncTest(t)
+	delete(store.feeds, "froshtools")
 	store.handlerDelay = 30 * time.Millisecond
 
 	require.NoError(t, h.SyncNames(context.Background(), []string{"FroshTools"}, "6.5.0.0", false))
@@ -505,8 +687,11 @@ func TestStoreExtensionSyncAbortsRemainingVersionsOn429(t *testing.T) {
 	ctx := context.Background()
 	collect := withStoreSyncMetrics(t)
 
-	// Newest version (6.6.0.0) succeeds; older 6.5.0.0 is rate-limited. Probes
-	// run newest-first, so we get partial progress then abort.
+	// Without a feed the extension keeps per-version probing, so the walk
+	// reaches the rate-limited older version. Newest version (6.6.0.0)
+	// succeeds; older 6.5.0.0 is rate-limited. Probes run newest-first, so we
+	// get partial progress then abort.
+	delete(store.feeds, "froshtools")
 	store.rateLimitedVersions["6.5.0.0"] = true
 	h.account = fastStoreClient(store.URL)
 
@@ -594,6 +779,8 @@ func TestStoreExtensionSyncNon429StillErrors(t *testing.T) {
 func TestStoreExtensionSyncRateLimitThenScheduledPass(t *testing.T) {
 	h, pool, store := setupSyncTest(t)
 	ctx := context.Background()
+	// Feed-missing, so the first pass walks into the rate-limited version.
+	delete(store.feeds, "froshtools")
 	store.rateLimitedVersions["6.5.0.0"] = true
 	h.account = fastStoreClient(store.URL)
 

--- a/api/internal/config/config.go
+++ b/api/internal/config/config.go
@@ -77,6 +77,10 @@ type Config struct {
 	// ShopwareChangelogURL is the base URL of the Shopware release changelog API
 	// (index.json + per-version JSON) crawled hourly by the worker.
 	ShopwareChangelogURL string `env:"SHOPWARE_CHANGELOG_URL" envDefault:"https://releases.shopware.com/changelog"`
+	// ShopwarePackagesURL is the base URL of the public Shopware Composer
+	// repository. Its package feeds serve extension versions and changelogs
+	// without the rate limits of the store API.
+	ShopwarePackagesURL string `env:"SHOPWARE_PACKAGES_URL" envDefault:"https://packages.shopware.com"`
 
 	// The OTLP signal endpoints fall back to the generic
 	// OTEL_EXPORTER_OTLP_ENDPOINT, and service env/version to the Datadog

--- a/api/internal/httputil/client_span_name.go
+++ b/api/internal/httputil/client_span_name.go
@@ -13,6 +13,7 @@ import (
 // (e.g. "GET api.shopware.com/pluginStore/pluginsByName").
 var sharedSpanHosts = map[string]struct{}{
 	"api.shopware.com":          {},
+	"packages.shopware.com":     {},
 	"releases.shopware.com":     {},
 	"store.shopware.com":        {},
 	"raw.githubusercontent.com": {},

--- a/api/internal/shopwarepackages/client.go
+++ b/api/internal/shopwarepackages/client.go
@@ -1,0 +1,129 @@
+// Package shopwarepackages is a client for the public packages.shopware.com
+// Composer repository. Its per-package feeds list every released version with
+// its changelog and require constraints, without the authentication and rate
+// limits of the store API (api.shopware.com).
+package shopwarepackages
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/friendsofshopware/shopmon/api/internal/httputil"
+)
+
+// DefaultBaseURL is the public Shopware Composer repository base URL.
+const DefaultBaseURL = "https://packages.shopware.com"
+
+// maxFeedResponseBytes bounds how much we read from a single feed response, so
+// a misbehaving upstream can't exhaust worker memory.
+const maxFeedResponseBytes = 10 << 20 // 10 MB
+
+// Client fetches package feeds from packages.shopware.com.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a Client for the given base URL. If httpClient is nil a
+// default instrumented client with a 30s timeout is used.
+func NewClient(baseURL string, httpClient *http.Client) *Client {
+	if baseURL == "" {
+		baseURL = DefaultBaseURL
+	}
+	if httpClient == nil {
+		httpClient = httputil.NewHTTPClient(httputil.WithTimeout(30 * time.Second))
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
+	}
+}
+
+// Package is a package feed: every released version with its changelog and
+// Composer require constraints.
+type Package struct {
+	Name     string
+	Link     string
+	Versions []PackageVersion
+}
+
+// PackageVersion is one release in a package feed.
+type PackageVersion struct {
+	Version    string
+	Changelog  string
+	ReleasedAt *time.Time
+	Require    map[string]string
+}
+
+// rawFeed mirrors the feed JSON document served at
+// {baseURL}/feeds/package/{name}.json.
+type rawFeed struct {
+	Name     string `json:"name"`
+	Link     string `json:"link"`
+	Versions []struct {
+		Version   string            `json:"version"`
+		Date      string            `json:"date"`
+		Changelog string            `json:"changelog"`
+		Require   map[string]string `json:"require"`
+	} `json:"versions"`
+}
+
+// PackageFeed fetches the feed for a Composer package name such as
+// "store.shopware.com/swagplatformsecurity".
+func (c *Client) PackageFeed(ctx context.Context, name string) (*Package, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/feeds/package/"+name+".json", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch package feed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch package feed %s: unexpected status %d", name, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxFeedResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("read package feed: %w", err)
+	}
+
+	var raw rawFeed
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parse package feed: %w", err)
+	}
+
+	pkg := &Package{
+		Name:     raw.Name,
+		Link:     raw.Link,
+		Versions: make([]PackageVersion, 0, len(raw.Versions)),
+	}
+	for _, v := range raw.Versions {
+		pkg.Versions = append(pkg.Versions, PackageVersion{
+			Version:    v.Version,
+			Changelog:  v.Changelog,
+			ReleasedAt: parseFeedDate(v.Date),
+			Require:    v.Require,
+		})
+	}
+	return pkg, nil
+}
+
+func parseFeedDate(value string) *time.Time {
+	if value == "" {
+		return nil
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		utc := t.UTC()
+		return &utc
+	}
+	return nil
+}

--- a/api/internal/shopwarepackages/client.go
+++ b/api/internal/shopwarepackages/client.go
@@ -7,6 +7,7 @@ package shopwarepackages
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -22,6 +23,11 @@ const DefaultBaseURL = "https://packages.shopware.com"
 // maxFeedResponseBytes bounds how much we read from a single feed response, so
 // a misbehaving upstream can't exhaust worker memory.
 const maxFeedResponseBytes = 10 << 20 // 10 MB
+
+// ErrNotFound marks a feed that packages.shopware.com does not serve (HTTP
+// 404) — the normal case for custom plugins that are not distributed through
+// the store's Composer repository.
+var ErrNotFound = errors.New("package feed not found")
 
 // Client fetches package feeds from packages.shopware.com.
 type Client struct {
@@ -87,6 +93,9 @@ func (c *Client) PackageFeed(ctx context.Context, name string) (*Package, error)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, name)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("fetch package feed %s: unexpected status %d", name, resp.StatusCode)
 	}

--- a/api/internal/shopwarepackages/client_test.go
+++ b/api/internal/shopwarepackages/client_test.go
@@ -1,0 +1,95 @@
+package shopwarepackages
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func feedServer(t *testing.T, status int, body string) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/feeds/package/store.shopware.com/swagplatformsecurity.json", r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestPackageFeedParsesVersions(t *testing.T) {
+	srv := feedServer(t, http.StatusOK, `{
+		"name": "store.shopware.com/swagplatformsecurity",
+		"link": "https://store.shopware.com/en/detail/67457acbc21beb4318cf782a7ec39a5c",
+		"date": "2026-08-26T08:58:12+00:00",
+		"versions": [
+			{
+				"version": "4.0.14",
+				"date": "2026-08-26T08:58:12+00:00",
+				"changelog": "<ul><li>Added fix for GHSA-6qhw-38wm-7g7h</li></ul>",
+				"require": {"shopware/core": "~6.7.0"}
+			},
+			{
+				"version": "3.0.18",
+				"date": "2026-08-25T15:53:34+00:00",
+				"changelog": "<ul><li>Added fix for GHSA-rrc3-p9vx-5373</li></ul>",
+				"require": {"shopware/core": "~6.6.0"}
+			}
+		]
+	}`)
+
+	pkg, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
+	require.NoError(t, err)
+
+	assert.Equal(t, "store.shopware.com/swagplatformsecurity", pkg.Name)
+	assert.Equal(t, "https://store.shopware.com/en/detail/67457acbc21beb4318cf782a7ec39a5c", pkg.Link)
+	require.Len(t, pkg.Versions, 2)
+
+	assert.Equal(t, "4.0.14", pkg.Versions[0].Version)
+	assert.Contains(t, pkg.Versions[0].Changelog, "GHSA-6qhw-38wm-7g7h")
+	assert.Equal(t, "~6.7.0", pkg.Versions[0].Require["shopware/core"])
+	require.NotNil(t, pkg.Versions[0].ReleasedAt)
+	assert.Equal(t, time.Date(2026, 8, 26, 8, 58, 12, 0, time.UTC), *pkg.Versions[0].ReleasedAt)
+
+	assert.Equal(t, "3.0.18", pkg.Versions[1].Version)
+	assert.Equal(t, "~6.6.0", pkg.Versions[1].Require["shopware/core"])
+}
+
+func TestPackageFeedToleratesMissingDate(t *testing.T) {
+	srv := feedServer(t, http.StatusOK, `{
+		"name": "store.shopware.com/swagplatformsecurity",
+		"versions": [{"version": "1.0.0", "changelog": "", "require": {"shopware/core": "*"}}]
+	}`)
+
+	pkg, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
+	require.NoError(t, err)
+	require.Len(t, pkg.Versions, 1)
+	assert.Nil(t, pkg.Versions[0].ReleasedAt)
+}
+
+func TestPackageFeedErrorsOnNon200(t *testing.T) {
+	srv := feedServer(t, http.StatusNotFound, `{}`)
+
+	_, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestPackageFeedErrorsOnInvalidJSON(t *testing.T) {
+	srv := feedServer(t, http.StatusOK, `not json`)
+
+	_, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
+	require.Error(t, err)
+}
+
+func TestNewClientDefaults(t *testing.T) {
+	client := NewClient("", nil)
+	assert.Equal(t, DefaultBaseURL, client.baseURL)
+	assert.NotNil(t, client.httpClient)
+}

--- a/api/internal/shopwarepackages/client_test.go
+++ b/api/internal/shopwarepackages/client_test.go
@@ -74,11 +74,19 @@ func TestPackageFeedToleratesMissingDate(t *testing.T) {
 }
 
 func TestPackageFeedErrorsOnNon200(t *testing.T) {
-	srv := feedServer(t, http.StatusNotFound, `{}`)
+	srv := feedServer(t, http.StatusTeapot, `{}`)
 
 	_, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
+	assert.NotErrorIs(t, err, ErrNotFound)
+	assert.Contains(t, err.Error(), "418")
+}
+
+func TestPackageFeedNotFound(t *testing.T) {
+	srv := feedServer(t, http.StatusNotFound, `{}`)
+
+	_, err := NewClient(srv.URL, nil).PackageFeed(context.Background(), "store.shopware.com/swagplatformsecurity")
+	require.ErrorIs(t, err, ErrNotFound)
 }
 
 func TestPackageFeedErrorsOnInvalidJSON(t *testing.T) {

--- a/api/worker.go
+++ b/api/worker.go
@@ -14,14 +14,13 @@ import (
 	"github.com/friendsofshopware/shopmon/api/internal/config"
 	"github.com/friendsofshopware/shopmon/api/internal/database"
 	"github.com/friendsofshopware/shopmon/api/internal/database/queries"
-	"github.com/friendsofshopware/shopmon/api/internal/httputil"
 	"github.com/friendsofshopware/shopmon/api/internal/jobs"
 	jobspostgres "github.com/friendsofshopware/shopmon/api/internal/jobs/postgres"
 	"github.com/friendsofshopware/shopmon/api/internal/mail"
 	"github.com/friendsofshopware/shopmon/api/internal/maintenance"
 	monitoringscrape "github.com/friendsofshopware/shopmon/api/internal/monitoring/scrape"
 	"github.com/friendsofshopware/shopmon/api/internal/monitoring/sitespeed"
-	"github.com/friendsofshopware/shopmon/api/internal/shopwareaccount"
+	"github.com/friendsofshopware/shopmon/api/internal/shopwarepackages"
 	"github.com/friendsofshopware/shopmon/api/internal/telemetry"
 	goqueue "github.com/shyim/go-queue"
 	queueotel "github.com/shyim/go-queue/middleware/otel"
@@ -94,8 +93,7 @@ func runWorker(cmd *cobra.Command, args []string) error {
 		NVDAPIKey:   cfg.NVDAPIKey,
 		Mailer:      mailSvc,
 	})
-	securityPluginSync := securityplugin.NewService(pool, q, shopwareaccount.NewClient(
-		cfg.ShopwareAPIURL, httputil.NewHTTPClient(httputil.WithTimeout(30*time.Second))))
+	securityPluginSync := securityplugin.NewService(pool, q, shopwarepackages.NewClient(cfg.ShopwarePackagesURL, nil))
 	if err := jobs.RegisterHandlers(bus, jobs.Handlers{
 		EnvironmentScraper:         environmentScrape,
 		StoreExtensionSynchronizer: storeSync,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Both hourly sync jobs leaned on the store API's `pluginsByName` endpoint, which is rate-limited (429s) and scoped to the requested Shopware version:

- `SecurityPluginSync` probed it once per anchor version (6.7/6.6/6.5) **plus once per distinct Shopware version in use** — just to collect the SwagPlatformSecurity changelog.
- `StoreExtensionSync` (dispatched from scrapes) probed it en+de for **every** distinct in-use Shopware version, because the endpoint only reports the compatible latest version for the version you ask about.

The public feeds at `packages.shopware.com/feeds/package/store.shopware.com/<name>.json` return every released version with its changelog, release date, and `require` constraints in a **single unauthenticated request per extension**, so both jobs now use the feed instead of most of those store calls.

## Changes

- **`api/internal/shopwarepackages`** (new): minimal client for the packages.shopware.com package feeds, following the existing `shopwareaccount` client pattern. 404 maps to `ErrNotFound` (the expected case for custom plugins, which are not distributed via packages.shopware.com).
- **`internal/catalog/securityplugin`**: `collectChangelog` fetches the feed once instead of probing `pluginsByName` per Shopware version. Anchor versions, the probing loop, and the `shopwareaccount` dependency are gone. The catalog changelog fallback (from shops that have the plugin installed) is kept, so the map stays fresh even if the feed is down; the sharp-drop coverage guard and per-branch pruning are unchanged.
- **`internal/catalog/sync`** (`StoreExtensionSync`): the compatible latest version for every in-use Shopware version is now computed locally from the feed's `shopware/core` constraints (verified to match the store's answers). The store is still probed for what the feed does not have — membership, metadata, translations, pictures, and the changelog history behind the global latest version — but the version walk stops once every name is resolved, so a feed-covered extension costs **one en+de probe pair at the newest version** instead of 2×N requests. Extensions without a usable feed (custom plugins, feed errors, no evaluable constraints) keep the old per-version probing, including the 429 abort/partial-persist semantics.
- **Config**: new `SHOPWARE_PACKAGES_URL` (default `https://packages.shopware.com`).
- **Worker**: wires the feed client for the security plugin sync.
- **Tracing**: `packages.shopware.com` added to the shared span hosts.

## Not changed (deliberately)

- Store membership is still decided by store probes alone — the feed never creates catalog rows, so a package that exists on packages.shopware.com but not in the store does not enter the catalog.
- The security plugin's branch → Shopware-line mapping stays a constant: the feed's `require` constraints are uniform per branch for 4.x/3.x/2.x (`~6.7.0`/`~6.6.0`/`~6.5.0`) but mixed within 1.x (`~6.4.0`, `>=6.1.0 <6.5.0`, `*`), and the checker keeps an equivalent map that must agree with it.
- The global latest version of a store extension stays changelog-derived (the feed is not localized, so de changelogs still come from the store probe).

## Verification

- `mise run lint` — green (golangci-lint, oxlint, vue-tsc, oxfmt, vitest)
- `mise run test` — green (full integration suite)
- New tests: feed client parsing/error/404 cases; security-plugin sync from feed with per-branch minimums, feed-down error, catalog fallback; catalog sync feed-derived compatibility (2 store requests instead of 4, compat row for the never-probed version), feed-error and no-evaluable-constraint fallback to per-version probing, `latestCompatibleVersion` constraint evaluation (newest match, pre-release/constraint-less skips, ranges, case-insensitive require key)
- Smoke-tested the client against the live feed: 96 versions parsed with release dates and `require` constraints; constraint-computed compatibility matched the store's `pluginsByName` answer for all probed extension/version combinations
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a5f0ae63-2f3e-4810-b6e3-2aade3e1c5c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a5f0ae63-2f3e-4810-b6e3-2aade3e1c5c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

